### PR TITLE
Add circular stream input

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -5,8 +5,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Input.Bindings;
-using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Sentakki.UI;
@@ -17,9 +15,6 @@ using osu.Game.Rulesets.Scoring;
 using osuTK;
 using osuTK.Graphics;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
     public class DrawableHold : DrawableSentakkiHitObject
@@ -243,89 +238,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             HoldStartTime = Time.Current;
             isHitting.Value = true;
-        }
-
-        public class HitReceptor : CircularContainer, IKeyBindingHandler<SentakkiAction>
-        {
-            // IsHovered is used
-            public override bool HandlePositionalInput => true;
-
-            private SentakkiInputManager sentakkiActionInputManager;
-            internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= GetContainingInputManager() as SentakkiInputManager;
-
-            private List<SentakkiAction> actions = new List<SentakkiAction>();
-            public Func<bool> Hit;
-            public Action Release;
-
-            public float NoteAngle = -1;
-            public bool HoverAction()
-            {
-                if (!SentakkiActionInputManager.CurrentAngles.Contains(NoteAngle))
-                {
-                    SentakkiActionInputManager.CurrentAngles.Add(NoteAngle);
-                    if (SentakkiActionInputManager.PressedActions.Any(action => OnPressed(action)))
-                        actions.AddRange(SentakkiActionInputManager.PressedActions);
-                }
-                return false;
-            }
-            public HitReceptor()
-            {
-                RelativeSizeAxes = Axes.None;
-                Size = new Vector2(240);
-                Anchor = Anchor.Centre;
-                Origin = Anchor.Centre;
-                Add(new HoverReceptor(this));
-            }
-
-            public virtual bool OnPressed(SentakkiAction action)
-            {
-                switch (action)
-                {
-                    case SentakkiAction.Button1:
-                    case SentakkiAction.Button2:
-                        if (IsHovered && (Hit?.Invoke() ?? false))
-                        {
-                            actions.Add(action);
-                            return true;
-                        }
-                        break;
-                }
-                return false;
-            }
-
-            public void OnReleased(SentakkiAction action)
-            {
-                switch (action)
-                {
-                    case SentakkiAction.Button1:
-                    case SentakkiAction.Button2:
-                        if (actions.Contains(action))
-                            actions.Remove(action);
-                        if (!actions.Any())
-                            Release?.Invoke();
-                        break;
-                }
-            }
-            protected override void OnHoverLost(HoverLostEvent e)
-            {
-                SentakkiActionInputManager.CurrentAngles.Remove(NoteAngle);
-                actions.Clear();
-                Release?.Invoke();
-            }
-
-            public class HoverReceptor : CircularContainer
-            {
-                private readonly HitReceptor parent;
-                public HoverReceptor(HitReceptor parent)
-                {
-                    Size = new Vector2(150);
-                    Anchor = Anchor.Centre;
-                    Origin = Anchor.Centre;
-                    this.parent = parent;
-                }
-
-                protected override bool OnHover(HoverEvent e) => parent.HoverAction();
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Sentakki.UI;
@@ -293,6 +294,21 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         break;
                 }
             }
+            protected override bool OnHover(HoverEvent e)
+            {
+                foreach (var buttonheld in SentakkiActionInputManager.PressedActions)
+                    if (OnPressed(buttonheld))
+                    {
+                        actions.AddRange(SentakkiActionInputManager.PressedActions);
+                        return true;
+                    }
+                return false;
+            }
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                actions.Clear();
+            }
+
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -82,7 +82,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         Tail.UpdateResult();
                         HoldStartTime = null;
                         isHitting.Value = false;
-                    }
+                    },
+                    NoteAngle = HitObject.Angle
                 }
             });
         }
@@ -259,13 +260,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             public float NoteAngle = -1;
             public bool HoverAction()
             {
-                if (SentakkiActionInputManager.CurrentAngles.Contains(NoteAngle))
-                    return false;
-                SentakkiActionInputManager.CurrentAngles.Add(NoteAngle);
-                if (SentakkiActionInputManager.PressedActions.Any(action => OnPressed(action)))
+                if (!SentakkiActionInputManager.CurrentAngles.Contains(NoteAngle))
                 {
-                    actions.AddRange(SentakkiActionInputManager.PressedActions);
-                    return true;
+                    SentakkiActionInputManager.CurrentAngles.Add(NoteAngle);
+                    if (SentakkiActionInputManager.PressedActions.Any(action => OnPressed(action)))
+                        actions.AddRange(SentakkiActionInputManager.PressedActions);
                 }
                 return false;
             }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -256,6 +256,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             public Func<bool> Hit;
             public Action Release;
 
+            public float NoteAngle = -1;
             public HitReceptor()
             {
                 RelativeSizeAxes = Axes.None;
@@ -296,6 +297,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             }
             protected override bool OnHover(HoverEvent e)
             {
+                if (SentakkiActionInputManager.CurrentAngles.Contains(NoteAngle))
+                    return false;
+                SentakkiActionInputManager.CurrentAngles.Add(NoteAngle);
                 if (SentakkiActionInputManager.PressedActions.Any(action => OnPressed(action)))
                 {
                     actions.AddRange(SentakkiActionInputManager.PressedActions);
@@ -305,6 +309,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             }
             protected override void OnHoverLost(HoverLostEvent e)
             {
+                SentakkiActionInputManager.CurrentAngles.Remove(NoteAngle);
                 actions.Clear();
                 Release?.Invoke();
             }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -257,15 +257,28 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             public Action Release;
 
             public float NoteAngle = -1;
+            public bool HoverAction()
+            {
+                if (SentakkiActionInputManager.CurrentAngles.Contains(NoteAngle))
+                    return false;
+                SentakkiActionInputManager.CurrentAngles.Add(NoteAngle);
+                if (SentakkiActionInputManager.PressedActions.Any(action => OnPressed(action)))
+                {
+                    actions.AddRange(SentakkiActionInputManager.PressedActions);
+                    return true;
+                }
+                return false;
+            }
             public HitReceptor()
             {
                 RelativeSizeAxes = Axes.None;
                 Size = new Vector2(240);
                 Anchor = Anchor.Centre;
                 Origin = Anchor.Centre;
+                Add(new HoverReceptor(this));
             }
 
-            public bool OnPressed(SentakkiAction action)
+            public virtual bool OnPressed(SentakkiAction action)
             {
                 switch (action)
                 {
@@ -278,7 +291,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         }
                         break;
                 }
-
                 return false;
             }
 
@@ -295,23 +307,25 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         break;
                 }
             }
-            protected override bool OnHover(HoverEvent e)
-            {
-                if (SentakkiActionInputManager.CurrentAngles.Contains(NoteAngle))
-                    return false;
-                SentakkiActionInputManager.CurrentAngles.Add(NoteAngle);
-                if (SentakkiActionInputManager.PressedActions.Any(action => OnPressed(action)))
-                {
-                    actions.AddRange(SentakkiActionInputManager.PressedActions);
-                    return true;
-                }
-                return false;
-            }
             protected override void OnHoverLost(HoverLostEvent e)
             {
                 SentakkiActionInputManager.CurrentAngles.Remove(NoteAngle);
                 actions.Clear();
                 Release?.Invoke();
+            }
+
+            public class HoverReceptor : CircularContainer
+            {
+                private readonly HitReceptor parent;
+                public HoverReceptor(HitReceptor parent)
+                {
+                    Size = new Vector2(150);
+                    Anchor = Anchor.Centre;
+                    Origin = Anchor.Centre;
+                    this.parent = parent;
+                }
+
+                protected override bool OnHover(HoverEvent e) => parent.HoverAction();
             }
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -296,12 +296,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             }
             protected override bool OnHover(HoverEvent e)
             {
-                foreach (var buttonheld in SentakkiActionInputManager.PressedActions)
-                    if (OnPressed(buttonheld))
-                    {
-                        actions.AddRange(SentakkiActionInputManager.PressedActions);
-                        return true;
-                    }
+                if (SentakkiActionInputManager.PressedActions.Any(action => OnPressed(action)))
+                {
+                    actions.AddRange(SentakkiActionInputManager.PressedActions);
+                    return true;
+                }
                 return false;
             }
             protected override void OnHoverLost(HoverLostEvent e)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -306,8 +306,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             protected override void OnHoverLost(HoverLostEvent e)
             {
                 actions.Clear();
+                Release?.Invoke();
             }
-
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -5,8 +5,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Input.Bindings;
-using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -15,8 +13,6 @@ using osuTK;
 using osuTK.Graphics;
 using System;
 using System.Diagnostics;
-using System.Linq;
-
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
     public class DrawableTap : DrawableSentakkiHitObject
@@ -61,7 +57,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         UpdateResult(true);
                         return true;
                     },
-                    RelativeSizeAxes = Axes.None,
                     Position = hitObject.EndPosition,
                     NoteAngle = HitObject.Angle
                 },
@@ -144,77 +139,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
                     break;
             }
-        }
-
-        public class HitReceptor : CircularContainer, IKeyBindingHandler<SentakkiAction>
-        {
-            // IsHovered is used
-            public override bool HandlePositionalInput => true;
-
-            public Func<bool> Hit;
-
-            public SentakkiAction? HitAction;
-
-            private SentakkiInputManager sentakkiActionInputManager;
-            internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= GetContainingInputManager() as SentakkiInputManager;
-
-            public float NoteAngle = -1;
-            public HitReceptor()
-            {
-                RelativeSizeAxes = Axes.None;
-                Size = new Vector2(240);
-                Anchor = Anchor.Centre;
-                Origin = Anchor.Centre;
-                Add(new HoverReceptor(this));
-            }
-
-            public bool HoverAction()
-            {
-                if (!SentakkiActionInputManager.CurrentAngles.Contains(NoteAngle))
-                {
-                    SentakkiActionInputManager.CurrentAngles.Add(NoteAngle);
-                    SentakkiActionInputManager?.PressedActions.Any(action => OnPressed(action));
-                }
-                return false;
-            }
-            public virtual bool OnPressed(SentakkiAction action)
-            {
-                switch (action)
-                {
-                    case SentakkiAction.Button1:
-                    case SentakkiAction.Button2:
-                        if (IsHovered && (Hit?.Invoke() ?? false))
-                        {
-                            HitAction = action;
-                            return true;
-                        }
-                        break;
-                }
-
-                return false;
-            }
-
-            public virtual void OnReleased(SentakkiAction action)
-            {
-            }
-            protected override void OnHoverLost(HoverLostEvent e)
-            {
-                SentakkiActionInputManager.CurrentAngles.Remove(NoteAngle);
-            }
-        }
-        public class HoverReceptor : CircularContainer
-        {
-            public override bool HandlePositionalInput => true;
-            private readonly HitReceptor parent;
-            public HoverReceptor(HitReceptor parent)
-            {
-                RelativeSizeAxes = Axes.None;
-                Size = new Vector2(150);
-                Anchor = Anchor.Centre;
-                Origin = Anchor.Centre;
-                this.parent = parent;
-            }
-            protected override bool OnHover(HoverEvent e) => parent.HoverAction();
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -62,7 +62,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         return true;
                     },
                     RelativeSizeAxes = Axes.None,
-                    Position = hitObject.EndPosition
+                    Position = hitObject.EndPosition,
+                    NoteAngle = HitObject.Angle
                 },
             });
         }
@@ -157,6 +158,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             private SentakkiInputManager sentakkiActionInputManager;
             internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= GetContainingInputManager() as SentakkiInputManager;
 
+            public float NoteAngle = -1;
             public HitReceptor()
             {
                 RelativeSizeAxes = Axes.None;
@@ -187,7 +189,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             }
             protected override bool OnHover(HoverEvent e)
             {
+                if (SentakkiActionInputManager.CurrentAngles.Contains(NoteAngle))
+                    return false;
+                SentakkiActionInputManager.CurrentAngles.Add(NoteAngle);
                 return SentakkiActionInputManager?.PressedActions.Any(action => OnPressed(action)) ?? false;
+            }
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                sentakkiActionInputManager.CurrentAngles.Remove(NoteAngle);
             }
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -170,10 +170,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             public bool HoverAction()
             {
-                if (SentakkiActionInputManager.CurrentAngles.Contains(NoteAngle))
-                    return false;
-                SentakkiActionInputManager.CurrentAngles.Add(NoteAngle);
-                return SentakkiActionInputManager?.PressedActions.Any(action => OnPressed(action)) ?? false;
+                if (!SentakkiActionInputManager.CurrentAngles.Contains(NoteAngle))
+                {
+                    SentakkiActionInputManager.CurrentAngles.Add(NoteAngle);
+                    SentakkiActionInputManager?.PressedActions.Any(action => OnPressed(action));
+                }
+                return false;
             }
             public virtual bool OnPressed(SentakkiAction action)
             {
@@ -203,7 +205,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public class HoverReceptor : CircularContainer
         {
             public override bool HandlePositionalInput => true;
-            private HitReceptor parent;
+            private readonly HitReceptor parent;
             public HoverReceptor(HitReceptor parent)
             {
                 RelativeSizeAxes = Axes.None;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -165,9 +165,17 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 Size = new Vector2(240);
                 Anchor = Anchor.Centre;
                 Origin = Anchor.Centre;
+                Add(new HoverReceptor(this));
             }
 
-            public bool OnPressed(SentakkiAction action)
+            public bool HoverAction()
+            {
+                if (SentakkiActionInputManager.CurrentAngles.Contains(NoteAngle))
+                    return false;
+                SentakkiActionInputManager.CurrentAngles.Add(NoteAngle);
+                return SentakkiActionInputManager?.PressedActions.Any(action => OnPressed(action)) ?? false;
+            }
+            public virtual bool OnPressed(SentakkiAction action)
             {
                 switch (action)
                 {
@@ -184,20 +192,27 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 return false;
             }
 
-            public void OnReleased(SentakkiAction action)
+            public virtual void OnReleased(SentakkiAction action)
             {
-            }
-            protected override bool OnHover(HoverEvent e)
-            {
-                if (SentakkiActionInputManager.CurrentAngles.Contains(NoteAngle))
-                    return false;
-                SentakkiActionInputManager.CurrentAngles.Add(NoteAngle);
-                return SentakkiActionInputManager?.PressedActions.Any(action => OnPressed(action)) ?? false;
             }
             protected override void OnHoverLost(HoverLostEvent e)
             {
-                sentakkiActionInputManager.CurrentAngles.Remove(NoteAngle);
+                SentakkiActionInputManager.CurrentAngles.Remove(NoteAngle);
             }
+        }
+        public class HoverReceptor : CircularContainer
+        {
+            public override bool HandlePositionalInput => true;
+            private HitReceptor parent;
+            public HoverReceptor(HitReceptor parent)
+            {
+                RelativeSizeAxes = Axes.None;
+                Size = new Vector2(150);
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+                this.parent = parent;
+            }
+            protected override bool OnHover(HoverEvent e) => parent.HoverAction();
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -14,6 +15,7 @@ using osuTK;
 using osuTK.Graphics;
 using System;
 using System.Diagnostics;
+using System.Linq;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
@@ -183,6 +185,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             public void OnReleased(SentakkiAction action)
             {
             }
+            protected override bool OnHover(HoverEvent e)
+            {
+                foreach (var buttonheld in SentakkiActionInputManager.PressedActions)
+                    if (OnPressed(buttonheld))
+                        return true;
+                return false;
+            }
+
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -187,12 +187,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             }
             protected override bool OnHover(HoverEvent e)
             {
-                foreach (var buttonheld in SentakkiActionInputManager.PressedActions)
-                    if (OnPressed(buttonheld))
-                        return true;
-                return false;
+                return SentakkiActionInputManager?.PressedActions.Any(action => OnPressed(action)) ?? false;
             }
-
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HitReceptor.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HitReceptor.cs
@@ -1,0 +1,98 @@
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Sentakki.Configuration;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
+using osuTK;
+using osuTK.Graphics;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
+{
+    public class HitReceptor : CircularContainer, IKeyBindingHandler<SentakkiAction>
+    {
+        // IsHovered is used
+        public override bool HandlePositionalInput => true;
+
+        private SentakkiInputManager sentakkiActionInputManager;
+        internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= GetContainingInputManager() as SentakkiInputManager;
+
+        private List<SentakkiAction> actions = new List<SentakkiAction>();
+        public Func<bool> Hit;
+        public Action Release;
+
+        public float NoteAngle = -1;
+        public bool HoverAction()
+        {
+            if (!SentakkiActionInputManager.CurrentAngles.Contains(NoteAngle))
+            {
+                SentakkiActionInputManager.CurrentAngles.Add(NoteAngle);
+                if (SentakkiActionInputManager.PressedActions.Any(action => OnPressed(action)))
+                    actions.AddRange(SentakkiActionInputManager.PressedActions);
+            }
+            return false;
+        }
+        public HitReceptor()
+        {
+            RelativeSizeAxes = Axes.None;
+            Size = new Vector2(240);
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            Add(new HoverReceptor());
+        }
+
+        public virtual bool OnPressed(SentakkiAction action)
+        {
+            switch (action)
+            {
+                default:
+                    if (IsHovered && (Hit?.Invoke() ?? false))
+                    {
+                        actions.Add(action);
+                        return true;
+                    }
+                    break;
+            }
+            return false;
+        }
+
+        public void OnReleased(SentakkiAction action)
+        {
+            switch (action)
+            {
+                default:
+                    if (actions.Contains(action))
+                        actions.Remove(action);
+                    if (!actions.Any())
+                        Release?.Invoke();
+                    break;
+            }
+        }
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            SentakkiActionInputManager.CurrentAngles.Remove(NoteAngle);
+            actions.Clear();
+            Release?.Invoke();
+        }
+
+        internal class HoverReceptor : CircularContainer
+        {
+            public HoverReceptor()
+            {
+                Size = new Vector2(150);
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+            }
+
+            protected override bool OnHover(HoverEvent e) => (Parent as HitReceptor).HoverAction();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
@@ -42,6 +42,8 @@ namespace osu.Game.Rulesets.Sentakki
             : base(ruleset, 0, SimultaneousBindingMode.Unique)
         {
         }
+
+        public List<float> CurrentAngles = new List<float>();
     }
 
     public enum SentakkiAction


### PR DESCRIPTION
This adds in the ability for hovers to trigger a hitobject judgement. 
This allows the "circular stream" move from original maimai to be executed.