### PR TITLE
Enable positional hitsounds on hit objects

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
@@ -55,6 +55,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                         Position = Vector2.Zero,
                         StartTime = original.StartTime,
                         EndTime = endTimeData.EndTime,
+                        Samples = original.Samples,
                     }.Yield();
 
                 default:

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableBreak.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableBreak.cs
@@ -41,6 +41,5 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 breakSound?.Play();
             }
         }
-
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableBreak.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableBreak.cs
@@ -1,47 +1,46 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Scoring;
-using System.Diagnostics;
 using osu.Game.Skinning;
 using osu.Game.Audio;
+using osu.Game.Configuration;
+using osu.Framework.Audio;
+using osu.Framework.Bindables;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
     public class DrawableBreak : DrawableTap
     {
+        private readonly Bindable<bool> userPositionalHitSounds = new Bindable<bool>(false);
+        private readonly BindableDouble balanceAdjust = new BindableDouble();
         private readonly SkinnableSound breakSound;
         public DrawableBreak(SentakkiHitObject hitObject) : base(hitObject)
         {
             AddRangeInternal(new Drawable[]{
                 breakSound = new SkinnableSound(new SampleInfo("Break"))
             });
+            breakSound.AddAdjustment(AdjustableProperty.Balance, balanceAdjust);
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager osuConfig)
         {
-            Debug.Assert(HitObject.HitWindows != null);
-
-            if (!userTriggered)
-            {
-                if (!HitObject.HitWindows.CanBeHit(timeOffset))
-                {
-                    ApplyResult(r => r.Type = HitResult.Miss);
-                }
-                return;
-            }
-
-            if (HitObject.HitWindows.ResultFor(timeOffset) == HitResult.Miss && Time.Current < HitObject.StartTime) return;
-
-            var result = HitObject.HitWindows.ResultFor(timeOffset);
-            if (result == HitResult.None)
-            {
-                return;
-            }
-            ApplyResult(r => r.Type = result);
-            if (result == HitResult.Perfect)
-                breakSound?.Play();
+            osuConfig.BindWith(OsuSetting.PositionalHitSounds, userPositionalHitSounds);
         }
+
+        public override void PlaySamples()
+        {
+            base.PlaySamples();
+            if (Result.Type == HitResult.Perfect)
+            {
+                const float balance_adjust_amount = 0.4f;
+                balanceAdjust.Value = balance_adjust_amount * (userPositionalHitSounds.Value ? SamplePlaybackPosition - 0.5f : 0);
+                breakSound?.Play();
+            }
+        }
+
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Sentakki.UI;
 using osu.Game.Rulesets.Objects.Drawables;
 using System;
 
@@ -9,8 +10,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
     public class DrawableSentakkiHitObject : DrawableHitObject<SentakkiHitObject>
     {
         public bool IsHidden = false;
-        public Func<DrawableSentakkiHitObject, bool> CheckValidation;
 
+        protected override float SamplePlaybackPosition => (HitObject.EndPosition.X + SentakkiPlayfield.INTERSECTDISTANCE) / (SentakkiPlayfield.INTERSECTDISTANCE * 2);
         public SentakkiAction[] HitActions { get; set; } = new[]
         {
             SentakkiAction.Button1,

--- a/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
@@ -4,7 +4,7 @@ using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
 using System.Collections.Generic;
 using System.Linq;
-
+using osuTK;
 namespace osu.Game.Rulesets.Sentakki.Objects
 {
     public class Hold : SentakkiHitObject, IHasEndTime
@@ -58,6 +58,17 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                 base.Angle = value;
                 Head.Angle = value;
                 Tail.Angle = value;
+            }
+        }
+
+        public override Vector2 EndPosition
+        {
+            get => base.EndPosition;
+            set
+            {
+                base.EndPosition = value;
+                Head.EndPosition = value;
+                Tail.EndPosition = value;
             }
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         public override Judgement CreateJudgement() => new SentakkiJudgement();
 
         public Color4 NoteColor { get; set; }
-        public Vector2 EndPosition { get; set; }
+        public virtual Vector2 EndPosition { get; set; }
         public virtual float Angle { get; set; }
 
         public Vector2 Position { get; set; }


### PR DESCRIPTION
osu has an option to make use of positional hitsounds, and the existing objects didn't make any effort to use that at all. This PR aims to resolve that.

While I was doing this, I noticed that spinners didn't play a sample, so I fixed that too.