### PR TITLE
Remove user triggered early miss window

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Scoring/SentakkiHitWindows.cs
+++ b/osu.Game.Rulesets.Sentakki/Scoring/SentakkiHitWindows.cs
@@ -15,8 +15,6 @@ namespace osu.Game.Rulesets.Sentakki.Scoring
                 case HitResult.Great:
                 case HitResult.Good:
                 case HitResult.Meh:
-                case HitResult.Miss:
-                    return true;
                 default:
                     return false;
             }

--- a/osu.Game.Rulesets.Sentakki/Scoring/SentakkiHitWindows.cs
+++ b/osu.Game.Rulesets.Sentakki/Scoring/SentakkiHitWindows.cs
@@ -15,6 +15,7 @@ namespace osu.Game.Rulesets.Sentakki.Scoring
                 case HitResult.Great:
                 case HitResult.Good:
                 case HitResult.Meh:
+                    return true;
                 default:
                     return false;
             }


### PR DESCRIPTION
This wouldn't really affect too much in terms of gameplay. 

Forgiving misses due to ahead of time hit attempts seems fair, it also makes gameplay more lenient especially after #26 is merged.

Late misses remain unchanged. (no shit xd)