### PR TITLE
Fix speed adjustment mods affecting sentakki animation speed

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -201,6 +201,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             float sizeDiff = 600 - (SentakkiPlayfield.NOTESTARTDISTANCE * 2);
             HitObjectLine.Size = new Vector2((SentakkiPlayfield.NOTESTARTDISTANCE * 2) + (sizeDiff * TotalMoveAmount));
 
+            if (Result.HasResult)
+                HitObjectLine.Alpha = 0;
+
             // Hit feedback
             if (Time.Current >= HitObject.StartTime)
             {
@@ -232,7 +235,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             switch (state)
             {
                 case ArmedState.Hit:
-                    HitObjectLine.FadeOut();
                     using (BeginDelayedSequence((HitObject as IHasEndTime).Duration, true))
                     {
                         this.ScaleTo(1f, time_fade_hit);
@@ -252,7 +254,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                             Expire();
                         }
                     }
-                    HitObjectLine.FadeOut();
                     break;
             }
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
@@ -223,7 +223,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             if (Tail.AllJudged)
-                ApplyResult(r => r.Type = HitResult.Perfect);
+                ApplyResult(r => r.Type = (Head.IsHit || Tail.IsHit) ? HitResult.Perfect : HitResult.Miss);
         }
 
         public bool Auto = false;
@@ -244,7 +244,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     break;
 
                 case ArmedState.Miss:
-                    using (BeginDelayedSequence((HitObject as IHasEndTime).Duration, true))
+                    double longestSurvivalTime = Tail.HitObject.HitWindows.WindowFor(HitResult.Miss);
+                    using (BeginDelayedSequence((HitObject as IHasEndTime).Duration + longestSurvivalTime, true))
                     {
                         note.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
                             .FadeColour(Color4.Red, time_fade_miss, Easing.OutQuint)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
@@ -144,6 +144,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void Update()
         {
             base.Update();
+            if (Result.HasResult) return;
             fadeIn = 500 * (Clock.Rate < 0 ? 1 : Clock.Rate);
             moveTo = animationDuration.Value * (Clock.Rate < 0 ? 1 : Clock.Rate);
             double animStart = HitObject.StartTime - moveTo - fadeIn;
@@ -201,8 +202,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             float sizeDiff = 600 - (SentakkiPlayfield.NOTESTARTDISTANCE * 2);
             HitObjectLine.Size = new Vector2((SentakkiPlayfield.NOTESTARTDISTANCE * 2) + (sizeDiff * TotalMoveAmount));
 
-            if (Result.HasResult)
-                HitObjectLine.Alpha = 0;
+
 
             // Hit feedback
             if (Time.Current >= HitObject.StartTime)
@@ -232,6 +232,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.UpdateStateTransforms(state);
             const double time_fade_hit = 400, time_fade_miss = 400;
+            HitObjectLine.FadeOut();
+
             switch (state)
             {
                 case ArmedState.Hit:

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -172,7 +172,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             if (extendAmount < 0) extendAmount = 0;
             else if (extendAmount > 1) extendAmount = 1;
 
-            note.Height = (float)(80 + length * extendAmount);
+            note.Height = (float)(80 + (length * extendAmount));
 
             // Calculate duration where no movement is happening (when notes are very long)
             float idleTime = (float)((HitObject as IHasEndTime).Duration - extendTime);
@@ -196,27 +196,18 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             else if (TotalMoveAmount > 1) TotalMoveAmount = 1;
 
             if (IsHidden && TotalMoveAmount > 0)
-                Alpha = 1 - (1 * TotalMoveAmount);
-
+                Alpha = 1 - (1 * TotalMoveAmount / ((Time.Current >= HitObject.StartTime && isHitting.Value) ? 2 : 1));
             // Make sure HitObjectLine is adjusted with the moving note
             float sizeDiff = 600 - (SentakkiPlayfield.NOTESTARTDISTANCE * 2);
             HitObjectLine.Size = new Vector2((SentakkiPlayfield.NOTESTARTDISTANCE * 2) + (sizeDiff * TotalMoveAmount));
 
-
-
-            // Hit feedback
+            // Hit feedback glow
             if (Time.Current >= HitObject.StartTime)
             {
                 if (isHitting.Value)
-                {
                     note.Glow.FadeIn(50);
-                    this.FadeTo(IsHidden ? .2f : 1f, 50);
-                }
                 else
-                {
                     note.Glow.FadeOut(100);
-                    this.FadeTo(IsHidden ? 0f : .5f, 200);
-                }
             }
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -194,7 +194,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             if (TotalMoveAmount < 0) TotalMoveAmount = 0;
             else if (TotalMoveAmount > 1) TotalMoveAmount = 1;
 
-            if (IsHidden)
+            if (IsHidden && TotalMoveAmount > 0)
                 Alpha = 1 - (1 * TotalMoveAmount);
 
             // Make sure HitObjectLine is adjusted with the moving note

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public readonly HitReceptor HitArea;
         private readonly HoldBody note;
         public readonly CircularContainer HitObjectLine;
-        protected override double InitialLifetimeOffset => 3500;
+        protected override double InitialLifetimeOffset => 12000;
 
         /// <summary>
         /// Time at which the user started holding this hold note. Null if the user is not holding this hold note.
@@ -83,22 +83,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             });
         }
 
-        protected override void Update()
-        {
-            if (Time.Current >= HitObject.StartTime)
-            {
-                if (isHitting.Value)
-                {
-                    note.Glow.FadeIn(50);
-                    this.FadeTo(IsHidden ? .2f : 1f, 50);
-                }
-                else
-                {
-                    note.Glow.FadeOut(100);
-                    this.FadeTo(IsHidden ? 0f : .5f, 200);
-                }
-            }
-        }
         protected override void AddNestedHitObject(DrawableHitObject hitObject)
         {
             base.AddNestedHitObject(hitObject);
@@ -155,40 +139,82 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             HitObjectLine.Child.Colour = HitObject.NoteColor;
         }
 
-        private double fadeIn = 500, moveTo, idle;
+        private double fadeIn = 500, moveTo;
 
-        protected override void UpdateInitialTransforms()
+        protected override void Update()
         {
-            animationDuration.TriggerChange();
-            fadeIn = 500;
-            moveTo = animationDuration.Value;
-            idle = 3500 - fadeIn - moveTo;
+            base.Update();
+            fadeIn = 500 * (Clock.Rate < 0 ? 1 : Clock.Rate);
+            moveTo = animationDuration.Value * (Clock.Rate < 0 ? 1 : Clock.Rate);
+            double animStart = HitObject.StartTime - moveTo - fadeIn;
+            double currentProg = Clock.CurrentTime - animStart;
 
-            float length = Convert.ToSingle((SentakkiPlayfield.INTERSECTDISTANCE - 66) / animationDuration.Value * ((HitObject as IHasEndTime).Duration));
-            double extendTime = (length / (SentakkiPlayfield.INTERSECTDISTANCE - 66)) * animationDuration.Value;
+            // Calculate initial entry animation
+            float fadeAmount = (float)(currentProg / fadeIn);
+            if (fadeAmount < 0) fadeAmount = 0;
+            else if (fadeAmount > 1) fadeAmount = 1;
 
-            var seq = note.Delay(idle)
-                    .FadeInFromZero(500)
-                    .ScaleTo(1f, fadeIn)
-                    .Then();
+            HitObjectLine.Alpha = (float)(.75 * fadeAmount);
+            note.Alpha = (float)(1 * fadeAmount);
+            note.Scale = new Vector2((float)(1 * fadeAmount));
 
-            if (length >= (SentakkiPlayfield.INTERSECTDISTANCE - 66))
-                seq.ResizeHeightTo(SentakkiPlayfield.INTERSECTDISTANCE - 66 + 80, moveTo)
-                .Delay((HitObject as IHasEndTime).Duration)
-                .ResizeHeightTo(80, moveTo)
-                .MoveToY(-(SentakkiPlayfield.INTERSECTDISTANCE - 40), moveTo);
-            else
-                seq.ResizeHeightTo(length + 80, extendTime)
-                .Then()
-                .MoveToY(-(SentakkiPlayfield.INTERSECTDISTANCE - length - 80 + 40), animationDuration.Value - extendTime)
-                .Then()
-                .ResizeHeightTo(80, extendTime)
-                .MoveToY(-(SentakkiPlayfield.INTERSECTDISTANCE - 40), extendTime);
+            // Calculate total length of hold note
+            double length = Convert.ToSingle((SentakkiPlayfield.INTERSECTDISTANCE - 66) / moveTo * ((HitObject as IHasEndTime).Duration));
+            if (length > SentakkiPlayfield.INTERSECTDISTANCE - 66) // Clip max length
+                length = SentakkiPlayfield.INTERSECTDISTANCE - 66;
 
-            HitObjectLine.Delay(idle).FadeTo(.75f, fadeIn).Then().ResizeTo(600, moveTo);
+            // Calculate time taken to extend to desired length
+            double extendTime = length / (SentakkiPlayfield.INTERSECTDISTANCE - 66) * moveTo;
+
+            // Start strecthing
+            float extendAmount = (float)((currentProg - fadeIn) / extendTime);
+            if (extendAmount < 0) extendAmount = 0;
+            else if (extendAmount > 1) extendAmount = 1;
+
+            note.Height = (float)(80 + length * extendAmount);
+
+            // Calculate duration where no movement is happening (when notes are very long)
+            float idleTime = (float)((HitObject as IHasEndTime).Duration - extendTime);
+
+            // Move the note once idle time is over
+            float moveAmount = (float)((currentProg - fadeIn - extendTime - idleTime) / moveTo);
+            if (moveAmount < 0) moveAmount = 0;
+            else if (moveAmount > 1) moveAmount = 1;
+
+            float yDiff = SentakkiPlayfield.INTERSECTDISTANCE - 66;
+            note.Y = -26 - (yDiff * moveAmount);
+
+            // Start shrinking when the time comes
+            float shrinkAmount = Math.Abs(note.Y) + note.Height - SentakkiPlayfield.INTERSECTDISTANCE - 40;
+            if (shrinkAmount > 0)
+                note.Height -= shrinkAmount;
+
+            // Hidden fade calculation
+            float TotalMoveAmount = (float)((currentProg - fadeIn) / moveTo);
+            if (TotalMoveAmount < 0) TotalMoveAmount = 0;
+            else if (TotalMoveAmount > 1) TotalMoveAmount = 1;
 
             if (IsHidden)
-                this.Delay(idle + fadeIn).FadeOut(moveTo / 2);
+                Alpha = 1 - (1 * TotalMoveAmount);
+
+            // Make sure HitObjectLine is adjusted with the moving note
+            float sizeDiff = 600 - (SentakkiPlayfield.NOTESTARTDISTANCE * 2);
+            HitObjectLine.Size = new Vector2((SentakkiPlayfield.NOTESTARTDISTANCE * 2) + (sizeDiff * TotalMoveAmount));
+
+            // Hit feedback
+            if (Time.Current >= HitObject.StartTime)
+            {
+                if (isHitting.Value)
+                {
+                    note.Glow.FadeIn(50);
+                    this.FadeTo(IsHidden ? .2f : 1f, 50);
+                }
+                else
+                {
+                    note.Glow.FadeOut(100);
+                    this.FadeTo(IsHidden ? 0f : .5f, 200);
+                }
+            }
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -82,26 +82,28 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             double animStart = HitObject.StartTime - moveTo - fadeIn;
             double currentProg = Clock.CurrentTime - animStart;
 
+            // Calculate initial entry animation
             float fadeAmount = (float)(currentProg / fadeIn);
             if (fadeAmount < 0) fadeAmount = 0;
             else if (fadeAmount > 1) fadeAmount = 1;
-
 
             CirclePiece.Alpha = (float)(1 * fadeAmount);
             CirclePiece.Scale = new Vector2((float)(1 * fadeAmount));
             HitObjectLine.Alpha = (float)(.75 * fadeAmount);
 
+            // Calculate position
             Vector2 positionDifference = HitObject.EndPosition - HitObject.Position;
-
             float moveAmount = (float)((currentProg - fadeIn) / moveTo);
             if (moveAmount < 0) moveAmount = 0;
             else if (moveAmount > 1) moveAmount = 1;
 
             CirclePiece.Position = HitObject.Position + (positionDifference * moveAmount);
+
             if (IsHidden)
                 Alpha = 1 - (1 * moveAmount);
-            float sizeDiff = 600 - (SentakkiPlayfield.NOTESTARTDISTANCE * 2);
 
+            // Make sure HitObjectLine is adjusted
+            float sizeDiff = 600 - (SentakkiPlayfield.NOTESTARTDISTANCE * 2);
             HitObjectLine.Size = new Vector2((SentakkiPlayfield.NOTESTARTDISTANCE * 2) + (sizeDiff * moveAmount));
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             CirclePiece.Position = HitObject.Position + (positionDifference * moveAmount);
 
-            if (IsHidden)
+            if (IsHidden && moveAmount > 0)
                 Alpha = 1 - (1 * moveAmount);
 
             // Make sure HitObjectLine is adjusted

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
@@ -77,9 +77,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void Update()
         {
             base.Update();
-            animationDuration.TriggerChange();
-            fadeIn = 500 * Clock.Rate;
-            moveTo = animationDuration.Value * Clock.Rate;
+            fadeIn = 500 * (Clock.Rate < 0 ? 1 : Clock.Rate);
+            moveTo = animationDuration.Value * (Clock.Rate < 0 ? 1 : Clock.Rate);
             double animStart = HitObject.StartTime - moveTo - fadeIn;
             double currentProg = Clock.CurrentTime - animStart;
 
@@ -145,7 +144,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             {
                 case ArmedState.Hit:
                     HitObjectLine.FadeOut();
-                    this.ScaleTo(1f, time_fade_hit).Expire();
+                    this.Delay(400).FadeOut().Expire();
 
                     break;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -77,6 +77,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void Update()
         {
             base.Update();
+            if (Result.HasResult) return;
             fadeIn = 500 * (Clock.Rate < 0 ? 1 : Clock.Rate);
             moveTo = animationDuration.Value * (Clock.Rate < 0 ? 1 : Clock.Rate);
             double animStart = HitObject.StartTime - moveTo - fadeIn;
@@ -106,8 +107,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             float sizeDiff = 600 - (SentakkiPlayfield.NOTESTARTDISTANCE * 2);
             HitObjectLine.Size = new Vector2((SentakkiPlayfield.NOTESTARTDISTANCE * 2) + (sizeDiff * moveAmount));
 
-            if (Result.HasResult)
-                HitObjectLine.Alpha = 0;
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
@@ -136,6 +135,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             base.UpdateStateTransforms(state);
 
             const double time_fade_hit = 400, time_fade_miss = 400;
+            HitObjectLine.FadeOut();
 
             switch (state)
             {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -105,6 +105,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             // Make sure HitObjectLine is adjusted
             float sizeDiff = 600 - (SentakkiPlayfield.NOTESTARTDISTANCE * 2);
             HitObjectLine.Size = new Vector2((SentakkiPlayfield.NOTESTARTDISTANCE * 2) + (sizeDiff * moveAmount));
+
+            if (Result.HasResult)
+                HitObjectLine.Alpha = 0;
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
@@ -137,7 +140,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             switch (state)
             {
                 case ArmedState.Hit:
-                    HitObjectLine.FadeOut();
                     this.Delay(400).FadeOut().Expire();
 
                     break;
@@ -151,7 +153,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                        .MoveToOffset(new Vector2(-(100 * (float)Math.Cos(d)), -(100 * (float)Math.Sin(d))), time_fade_hit, Easing.OutCubic)
                        .FadeOut(time_fade_miss);
 
-                    HitObjectLine.FadeOut();
                     this.ScaleTo(1f, time_fade_miss).Expire();
 
                     break;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -106,7 +106,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             // Make sure HitObjectLine is adjusted
             float sizeDiff = 600 - (SentakkiPlayfield.NOTESTARTDISTANCE * 2);
             HitObjectLine.Size = new Vector2((SentakkiPlayfield.NOTESTARTDISTANCE * 2) + (sizeDiff * moveAmount));
-
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public readonly TapCircle CirclePiece;
         public readonly CircularContainer HitObjectLine;
 
-        private double fadeIn = 500, moveTo, idle;
+        private double fadeIn = 500, moveTo;
 
         protected override double InitialLifetimeOffset => 12000;
 
@@ -98,19 +98,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             else if (moveAmount > 1) moveAmount = 1;
 
             CirclePiece.Position = HitObject.Position + (positionDifference * moveAmount);
+            if (IsHidden)
+                Alpha = 1 - (1 * moveAmount);
             float sizeDiff = 600 - (SentakkiPlayfield.NOTESTARTDISTANCE * 2);
 
             HitObjectLine.Size = new Vector2((SentakkiPlayfield.NOTESTARTDISTANCE * 2) + (sizeDiff * moveAmount));
-        }
-
-        protected override void UpdateInitialTransforms()
-        {
-
-            fadeIn = 500;
-            moveTo = animationDuration.Value;
-            idle = 3500 - fadeIn - moveTo;
-            if (IsHidden)
-                this.Delay(idle + fadeIn).FadeOut(moveTo / 2);
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
@@ -71,6 +71,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         protected override void Update()
         {
+            base.Update();
+            if (Result.HasResult) return;
             double fadeIn = 500 * (Clock.Rate < 0 ? 1 : Clock.Rate);
             double animStart = HitObject.StartTime - fadeIn;
             double currentProg = Clock.CurrentTime - animStart;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
@@ -80,8 +80,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             if (fadeAmount < 0) fadeAmount = 0;
             else if (fadeAmount > 1) fadeAmount = 1;
 
-            Alpha = .5f * fadeAmount;
-            Scale = new Vector2(.8f * fadeAmount);
+            Alpha = fadeAmount;
+            Scale = new Vector2(1f * fadeAmount);
 
             // Calculate progressbar fill
             float fillAmount = (float)((currentProg - fadeIn) / (HitObject as TouchHold).Duration);
@@ -106,14 +106,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 if ((buttonHeld && IsHovered) || Auto)
                 {
                     held++;
-                    this.FadeTo((IsHidden) ? .2f : 1f, 100);
-                    this.ScaleTo(1f, 100);
+                    circle.FadeTo((IsHidden) ? .2f : 1f, 100);
+                    circle.ScaleTo(1f, 100);
                     circle.Glow.FadeTo(1f, 100);
                 }
                 else
                 {
-                    this.FadeTo((IsHidden) ? 0 : .5f, 100);
-                    this.ScaleTo(.9f, 200);
+                    circle.FadeTo((IsHidden) ? 0 : .5f, 100);
+                    circle.ScaleTo(.8f, 200);
                     circle.Glow.FadeTo(0f, 200);
                 }
                 base.Update();

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -39,17 +39,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             });
         }
 
-        protected override void UpdateInitialTransforms()
-        {
-            this.FadeTo(.5f, 500).ScaleTo(.8f, 500);
-            circle.StartProgressBar();
-            if (IsHidden)
-                using (BeginDelayedSequence(500))
-                {
-                    this.FadeOut(250);
-                }
-        }
-
         private double potential = 0;
         private double held = 0;
         private bool buttonHeld = false;
@@ -82,6 +71,34 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         protected override void Update()
         {
+            double fadeIn = 500 * (Clock.Rate < 0 ? 1 : Clock.Rate);
+            double animStart = HitObject.StartTime - fadeIn;
+            double currentProg = Clock.CurrentTime - animStart;
+
+            // Calculate initial entry animation
+            float fadeAmount = (float)(currentProg / fadeIn);
+            if (fadeAmount < 0) fadeAmount = 0;
+            else if (fadeAmount > 1) fadeAmount = 1;
+
+            Alpha = .5f * fadeAmount;
+            Scale = new Vector2(.8f * fadeAmount);
+
+            // Calculate progressbar fill
+            float fillAmount = (float)((currentProg - fadeIn) / (HitObject as TouchHold).Duration);
+            if (fillAmount < 0) fillAmount = 0;
+            else if (fillAmount > 1) fillAmount = 1;
+
+            circle.Progress.Current.Value = fillAmount;
+
+            // Hidden fade calculation
+            float hiddenAmount = (float)((currentProg - fadeIn) / 250);
+            if (hiddenAmount < 0) hiddenAmount = 0;
+            else if (hiddenAmount > 1) hiddenAmount = 1;
+
+            if (IsHidden && hiddenAmount > 0)
+                Alpha = 1 - (1 * hiddenAmount);
+
+            // Input and feedback
             buttonHeld = SentakkiActionInputManager?.PressedActions.Any(x => x == SentakkiAction.Button1 || x == SentakkiAction.Button2) ?? false;
             if (Time.Current >= HitObject.StartTime && Time.Current <= (HitObject as IHasEndTime)?.EndTime)
             {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
@@ -35,7 +35,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         {
             RelativeSizeAxes = Axes.Both;
             Size = Vector2.One;
-
+            Scale = new Vector2(.8f);
+            Alpha = .5f;
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         public readonly GlowPiece Glow;
         private readonly ExplodePiece explode;
         private readonly FlashPiece flash;
-        private readonly CircularProgress progress;
+        public readonly CircularProgress Progress;
         private readonly Sprite disc;
         private readonly CircularContainer fillCircle;
         private readonly CircularContainer ring;
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Masking = true,
-                            Child = progress = new CircularProgress
+                            Child = Progress = new CircularProgress
                             {
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.Centre,
@@ -125,11 +125,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             };
         }
 
-        public void StartProgressBar()
-        {
-            progress.Delay(500).FillTo(1f, Duration);
-        }
-
         private readonly IBindable<ArmedState> state = new Bindable<ArmedState>();
         private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
 
@@ -146,7 +141,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             {
                 explode.Colour = colour.NewValue;
                 Glow.Colour = colour.NewValue;
-                progress.Colour = colour.NewValue;
+                Progress.Colour = colour.NewValue;
                 fillCircle.Colour = colour.NewValue;
             }, true);
         }
@@ -171,7 +166,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                     using (BeginDelayedSequence(Duration + flash_in, true))
                     {
                         //after the flash, we can hide some elements that were behind it
-                        progress.FadeOut();
+                        Progress.FadeOut();
                         fillCircle.FadeOut();
                         outline.FadeOut();
                         ring.FadeOut();


### PR DESCRIPTION
Not really the best solution, but it kills two birds with one stone. 

Upsides:
* Allows the note speed to be adjusted on the fly, no more waiting 3.5s delay before it takes effect.
* Keeps the animation speed the same regardless of clock rate. Tested with `Clock.Rate` at 8 (Double time(2x) + Wind up (2x) + 2x Replay playback speed)

Downsides:
* Code looks way too complicated compared to using regular transforms.

Resolves #5 