### PR TITLE
Let autoplay cheat to complete any map

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneBreakNote.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneBreakNote.cs
@@ -8,7 +8,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Tests.Visual;
 using osuTK;
 using osuTK.Graphics;
@@ -44,40 +43,13 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
 
             circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });
 
-            var drawable = CreateDrawableBreakNote(circle, auto);
-
-            Add(drawable);
-        }
-
-        protected virtual TestDrawableBreakNote CreateDrawableBreakNote(Break circle, bool auto) => new TestDrawableBreakNote(circle, auto)
-        {
-            Anchor = Anchor.Centre,
-            Origin = Anchor.Centre,
-            Depth = depthIndex++,
-        };
-
-        protected class TestDrawableBreakNote : DrawableBreak
-        {
-            private readonly bool auto;
-
-            public TestDrawableBreakNote(Break h, bool auto)
-                : base(h)
+            Add(new DrawableBreak(circle)
             {
-                this.auto = auto;
-            }
-
-            public void TriggerJudgement() => UpdateResult(true);
-
-            protected override void CheckForResult(bool userTriggered, double timeOffset)
-            {
-                if (auto && !userTriggered && timeOffset > 0)
-                {
-                    // force success
-                    ApplyResult(r => r.Type = HitResult.Perfect);
-                }
-                else
-                    base.CheckForResult(userTriggered, timeOffset);
-            }
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Depth = depthIndex++,
+                Auto = auto
+            });
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneHoldNote.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneHoldNote.cs
@@ -8,7 +8,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Tests.Visual;
 using osuTK;
 using osuTK.Graphics;
@@ -55,38 +54,13 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
 
             circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });
 
-            var drawable = new TestDrawableHoldNote(circle, auto);
-
-            Add(drawable);
-        }
-
-        protected virtual TestDrawableHoldNote CreateDrawableHoldNote(Hold circle, bool auto) => new TestDrawableHoldNote(circle, auto)
-        {
-            Anchor = Anchor.Centre,
-            Origin = Anchor.Centre,
-            Depth = depthIndex++,
-        };
-
-        protected class TestDrawableHoldNote : DrawableHold
-        {
-            public TestDrawableHoldNote(Hold h, bool auto)
-                : base(h)
+            Add(new DrawableHold(circle)
             {
-                Auto = auto;
-            }
-
-            public void TriggerJudgement() => UpdateResult(true);
-
-            protected override void CheckForResult(bool userTriggered, double timeOffset)
-            {
-                if (Auto && !userTriggered && timeOffset > 0)
-                {
-                    // force success
-                    ApplyResult(r => r.Type = HitResult.Perfect);
-                }
-                else
-                    base.CheckForResult(userTriggered, timeOffset);
-            }
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Depth = depthIndex++,
+                Auto = auto
+            });
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneTapNote.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneTapNote.cs
@@ -8,7 +8,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Tests.Visual;
 using osuTK;
 using osuTK.Graphics;
@@ -44,40 +43,13 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
 
             circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });
 
-            var drawable = CreateDrawableTapNote(circle, auto);
-
-            Add(drawable);
-        }
-
-        protected virtual TestDrawableTapNote CreateDrawableTapNote(Tap circle, bool auto) => new TestDrawableTapNote(circle, auto)
-        {
-            Anchor = Anchor.Centre,
-            Origin = Anchor.Centre,
-            Depth = depthIndex++,
-        };
-
-        protected class TestDrawableTapNote : DrawableTap
-        {
-            private readonly bool auto;
-
-            public TestDrawableTapNote(Tap h, bool auto)
-                : base(h)
+            Add(new DrawableTap(circle)
             {
-                this.auto = auto;
-            }
-
-            public void TriggerJudgement() => UpdateResult(true);
-
-            protected override void CheckForResult(bool userTriggered, double timeOffset)
-            {
-                if (auto && !userTriggered && timeOffset > 0)
-                {
-                    // force success
-                    ApplyResult(r => r.Type = HitResult.Perfect);
-                }
-                else
-                    base.CheckForResult(userTriggered, timeOffset);
-            }
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Depth = depthIndex++,
+                Auto = auto
+            });
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneTouchHold.cs
@@ -8,7 +8,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Tests.Visual;
 using osuTK;
 
@@ -41,38 +40,13 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
 
             circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });
 
-            var drawable = CreateDrawableTouchHoldNote(circle, auto);
-
-            Add(drawable);
-        }
-
-        protected virtual TestDrawableTouchHoldNote CreateDrawableTouchHoldNote(TouchHold circle, bool auto) => new TestDrawableTouchHoldNote(circle, auto)
-        {
-            Anchor = Anchor.Centre,
-            Origin = Anchor.Centre,
-            Depth = depthIndex++,
-        };
-
-        protected class TestDrawableTouchHoldNote : DrawableTouchHold
-        {
-            public TestDrawableTouchHoldNote(TouchHold h, bool auto)
-                : base(h)
+            Add(new DrawableTouchHold(circle)
             {
-                Auto = auto;
-            }
-
-            public void TriggerJudgement() => UpdateResult(true);
-
-            protected override void CheckForResult(bool userTriggered, double timeOffset)
-            {
-                if (Auto && !userTriggered && timeOffset > 0)
-                {
-                    // force success
-                    ApplyResult(r => r.Type = HitResult.Perfect);
-                }
-                else
-                    base.CheckForResult(userTriggered, timeOffset);
-            }
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Depth = depthIndex++,
+                Auto = auto
+            });
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModAutoplay.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModAutoplay.cs
@@ -7,10 +7,14 @@ using osu.Game.Rulesets.Sentakki.Replays;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Users;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables;
+using osu.Game.Rulesets.Objects.Drawables;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace osu.Game.Rulesets.Sentakki.Mods
 {
-    public class SentakkiModAutoplay : ModAutoplay<SentakkiHitObject>
+    public class SentakkiModAutoplay : ModAutoplay<SentakkiHitObject>, IApplicableToDrawableHitObjects
     {
         public override Score CreateReplayScore(IBeatmap beatmap) => new Score
         {
@@ -20,5 +24,13 @@ namespace osu.Game.Rulesets.Sentakki.Mods
             },
             Replay = new SentakkiAutoGenerator(beatmap).Generate(),
         };
+
+        public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
+        {
+            foreach (var d in drawables.OfType<DrawableSentakkiHitObject>())
+            {
+                d.Auto = true;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -195,7 +195,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 if (hideAmount < 0) hideAmount = 0;
                 else if (hideAmount > 1) hideAmount = 1;
 
-                Alpha = 1 - (1 * hideAmount / ((Time.Current >= HitObject.StartTime && isHitting.Value) ? 2 : 1));
+                Alpha = 1 - (1 * hideAmount / ((Time.Current >= HitObject.StartTime && (isHitting.Value || Auto)) ? 2 : 1));
             }
             else if (IsFadeIn)
             {
@@ -217,7 +217,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             // Hit feedback glow
             if (Time.Current >= HitObject.StartTime)
             {
-                if (isHitting.Value)
+                if (isHitting.Value || Auto)
                     note.Glow.FadeIn(50);
                 else
                     note.Glow.FadeOut(100);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -230,8 +230,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 ApplyResult(r => r.Type = (Head.IsHit || Tail.IsHit) ? HitResult.Perfect : HitResult.Miss);
         }
 
-        public bool Auto = false;
-
         protected override void UpdateStateTransforms(ArmedState state)
         {
             base.UpdateStateTransforms(state);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHoldHead.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHoldHead.cs
@@ -5,9 +5,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
     public class DrawableHoldHead : DrawableSentakkiHitObject
     {
+        private DrawableHold hold;
         public DrawableHoldHead(DrawableHold holdNote)
             : base((holdNote.HitObject as Hold).Head)
         {
+            hold = holdNote;
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
@@ -16,6 +18,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             if (!userTriggered)
             {
+                if (hold.Auto && timeOffset > 0)
+                    ApplyResult(r => r.Type = HitResult.Perfect);
+
                 if (!HitObject.HitWindows.CanBeHit(timeOffset))
                     ApplyResult(r => r.Type = HitResult.Miss);
                 return;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHoldTail.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHoldTail.cs
@@ -31,6 +31,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             if (!userTriggered)
             {
+                if (holdNote.Auto && timeOffset > 0)
+                    ApplyResult(r => r.Type = HitResult.Perfect);
+
                 if (!HitObject.HitWindows.CanBeHit(timeOffset))
                     if (holdNote.IsHitting.Value)
                         ApplyResult(r => r.Type = HitResult.Ok);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -11,6 +11,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public bool IsHidden = false;
         public bool IsFadeIn = false;
 
+        public bool Auto = false;
+
         protected override float SamplePlaybackPosition => (HitObject.EndPosition.X + SentakkiPlayfield.INTERSECTDISTANCE) / (SentakkiPlayfield.INTERSECTDISTANCE * 2);
         public SentakkiAction[] HitActions { get; set; } = new[]
         {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -123,6 +123,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             if (!userTriggered)
             {
+                if (Auto && timeOffset > 0)
+                    ApplyResult(r => r.Type = HitResult.Perfect);
+
                 if (!HitObject.HitWindows.CanBeHit(timeOffset))
                 {
                     ApplyResult(r => r.Type = HitResult.Miss);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -67,8 +67,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             });
         }
 
-        public bool Auto = false;
-
         protected override void Update()
         {
             base.Update();

--- a/osu.Game.Rulesets.Sentakki/Replays/SentakkiAutoGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Replays/SentakkiAutoGenerator.cs
@@ -25,8 +25,6 @@ namespace osu.Game.Rulesets.Sentakki.Replays
             Frames.Add(new SentakkiReplayFrame { Position = new Vector2(-1000), Time = -500 });
         }
 
-        private Tuple<SentakkiAction, double> inUse = new Tuple<SentakkiAction, double>(SentakkiAction.Button1, -1);
-
         public override Replay Generate()
         {
             return Replay;

--- a/osu.Game.Rulesets.Sentakki/Replays/SentakkiAutoGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Replays/SentakkiAutoGenerator.cs
@@ -22,128 +22,13 @@ namespace osu.Game.Rulesets.Sentakki.Replays
             : base(beatmap)
         {
             Replay = new Replay();
+            Frames.Add(new SentakkiReplayFrame { Position = new Vector2(-1000), Time = -500 });
         }
 
         private Tuple<SentakkiAction, double> inUse = new Tuple<SentakkiAction, double>(SentakkiAction.Button1, -1);
 
         public override Replay Generate()
         {
-            Frames.Add(new SentakkiReplayFrame { Position = new Vector2(300) });
-            foreach (SentakkiHitObject hitObject in Beatmap.HitObjects)
-            {
-                SentakkiReplayFrame currentFrame = new SentakkiReplayFrame();
-                SentakkiReplayFrame nextFrame = new SentakkiReplayFrame();
-                SentakkiAction nextButton = SentakkiAction.Button1;
-
-                if (inUse.Item1 == SentakkiAction.Button1 && inUse.Item2 > hitObject.StartTime) nextButton = SentakkiAction.Button2;
-                else if (inUse.Item1 == SentakkiAction.Button2 && inUse.Item2 > hitObject.StartTime) nextButton = SentakkiAction.Button1;
-
-                bool KeepPrevious = inUse.Item2 > hitObject.StartTime;
-
-                switch (hitObject)
-                {
-                    case TouchHold th:
-                        currentFrame = new SentakkiReplayFrame
-                        {
-                            Time = hitObject.StartTime,
-                            Position = new Vector2(300),
-                            NoteEvent = ReplayEvent.TouchHoldDown,
-                            Actions = { nextButton }
-                        };
-                        Frames.Add(currentFrame);
-                        inUse = new Tuple<SentakkiAction, double>(nextButton, th.EndTime);
-                        nextFrame = new SentakkiReplayFrame
-                        {
-                            Time = th.EndTime,
-                            NoteEvent = ReplayEvent.TouchHoldUp,
-                            Position = new Vector2(300),
-                        };
-                        break;
-
-                    case Hold h:
-                        currentFrame = new SentakkiReplayFrame
-                        {
-                            Time = hitObject.StartTime,
-                            Position = h.EndPosition + new Vector2(300),
-                            NoteEvent = ReplayEvent.HoldDown,
-                            Actions = { nextButton }
-                        };
-                        Frames.Add(currentFrame);
-                        inUse = new Tuple<SentakkiAction, double>(nextButton, h.EndTime);
-                        nextFrame = new SentakkiReplayFrame
-                        {
-                            Time = h.EndTime,
-                            NoteEvent = ReplayEvent.HoldUp,
-                            Position = h.EndPosition + new Vector2(300)
-                        };
-                        break;
-
-                    case SentakkiHitObject tn:
-                        List<SentakkiAction> startList;
-                        List<SentakkiAction> endList;
-
-                        if (KeepPrevious)
-                        {
-                            startList = new List<SentakkiAction>
-                            {
-                                nextButton,
-                                inUse.Item1
-                            };
-                            endList = new List<SentakkiAction>
-                            {
-                                inUse.Item1
-                            };
-                        }
-                        else
-                        {
-                            startList = new List<SentakkiAction>
-                            {
-                                nextButton,
-                            };
-                            endList = new List<SentakkiAction>();
-                        }
-
-                        currentFrame = new SentakkiReplayFrame
-                        {
-                            Time = tn.StartTime,
-                            Position = tn.EndPosition + new Vector2(300),
-                            NoteEvent = ReplayEvent.TapDown,
-                            Actions = startList
-                        };
-                        Frames.Add(currentFrame);
-                        nextFrame = new SentakkiReplayFrame
-                        {
-                            Time = tn.StartTime + 1,
-                            Position = tn.EndPosition + new Vector2(300),
-                            NoteEvent = ReplayEvent.TapUp,
-                            Actions = endList
-                        };
-                        break;
-                }
-                Frames.Add(nextFrame);
-            }
-            bool holdActive = false;
-            List<ReplayFrame> newFrames = new List<ReplayFrame>();
-            Frames.Sort((lhs, rhs) => lhs.Time.CompareTo(rhs.Time));
-            for (int i = 0; i < Frames.Count; ++i)
-            {
-                var frame = Frames[i] as SentakkiReplayFrame;
-                if (frame.NoteEvent == ReplayEvent.TouchHoldDown) holdActive = true;
-                else if (frame.NoteEvent == ReplayEvent.TouchHoldUp) holdActive = false;
-
-                if (holdActive && frame.NoteEvent == ReplayEvent.TapUp)
-                {
-                    newFrames.Add(new SentakkiReplayFrame
-                    {
-                        Time = frame.Time - 2,
-                        Position = new Vector2(300)
-                    });
-                    frame.Position = new Vector2(300);
-                }
-            }
-            Frames.AddRange(newFrames);
-            Frames.Sort((lhs, rhs) => lhs.Time.CompareTo(rhs.Time));
-
             return Replay;
         }
     }


### PR DESCRIPTION
Autoplay can't rely on the current available input method, especially when more than one note is present at the same time. So I'll make autoplay cheat.

This also makes autoplay work 100% on weird maps.

Will likely need a revisit once newer input methods are implemented in lazer and replay frames support them.

Known issue: Key Counters obviously do not work as autoplay ain't pressing any buttons