### PR TITLE
Compensate note speed using audio tempo and frequency instead of clock rate

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -132,25 +131,20 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         }
 
         private Bindable<double> animationDuration = new Bindable<double>(1000);
-        private Bindable<Track> speedAdjustmentTrack = new Bindable<Track>(new TrackVirtual(0));
-        private double speed => speedAdjustmentTrack.Value.AggregateTempo.Value * speedAdjustmentTrack.Value.AggregateFrequency.Value;
 
         [BackgroundDependencyLoader(true)]
-        private void load(SentakkiRulesetConfigManager settings, DrawableSentakkiRuleset drawableRuleset)
+        private void load(SentakkiRulesetConfigManager settings)
         {
             settings?.BindWith(SentakkiRulesetSettings.AnimationDuration, animationDuration);
             HitObjectLine.Child.Colour = HitObject.NoteColor;
-
-            if (drawableRuleset != null)
-                speedAdjustmentTrack.BindTo(drawableRuleset?.SpeedAdjustmentTrack);
         }
 
         protected override void Update()
         {
             base.Update();
             if (Result.HasResult) return;
-            double fadeIn = 500 * speed;
-            double moveTo = animationDuration.Value * speed;
+            double fadeIn = 500 * GameplaySpeed;
+            double moveTo = animationDuration.Value * GameplaySpeed;
             double animStart = HitObject.StartTime - moveTo - fadeIn;
             double currentProg = Clock.CurrentTime - animStart;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -34,7 +35,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public readonly HitReceptor HitArea;
         private readonly HoldBody note;
         public readonly CircularContainer HitObjectLine;
-        protected override double InitialLifetimeOffset => 12000;
+        protected override double InitialLifetimeOffset => 6000;
 
         /// <summary>
         /// Time at which the user started holding this hold note. Null if the user is not holding this hold note.
@@ -131,20 +132,24 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         }
 
         private Bindable<double> animationDuration = new Bindable<double>(1000);
+        private Bindable<Track> speedAdjustmentTrack = new Bindable<Track>(new TrackVirtual(0));
+        private double speed => speedAdjustmentTrack.Value.AggregateTempo.Value * speedAdjustmentTrack.Value.AggregateFrequency.Value;
 
         [BackgroundDependencyLoader(true)]
-        private void load(SentakkiRulesetConfigManager settings)
+        private void load(SentakkiRulesetConfigManager settings, DrawableSentakkiRuleset drawableRuleset)
         {
             settings?.BindWith(SentakkiRulesetSettings.AnimationDuration, animationDuration);
             HitObjectLine.Child.Colour = HitObject.NoteColor;
+
+            speedAdjustmentTrack.BindTo(drawableRuleset.SpeedAdjustmentTrack);
         }
 
         protected override void Update()
         {
             base.Update();
             if (Result.HasResult) return;
-            double fadeIn = 500 * (Clock.Rate < 0 ? 1 : Clock.Rate);
-            double moveTo = animationDuration.Value * (Clock.Rate < 0 ? 1 : Clock.Rate);
+            double fadeIn = 500 * speed;
+            double moveTo = animationDuration.Value * speed;
             double animStart = HitObject.StartTime - moveTo - fadeIn;
             double currentProg = Clock.CurrentTime - animStart;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -141,7 +141,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             settings?.BindWith(SentakkiRulesetSettings.AnimationDuration, animationDuration);
             HitObjectLine.Child.Colour = HitObject.NoteColor;
 
-            speedAdjustmentTrack.BindTo(drawableRuleset.SpeedAdjustmentTrack);
+            if (drawableRuleset != null)
+                speedAdjustmentTrack.BindTo(drawableRuleset?.SpeedAdjustmentTrack);
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Game.Rulesets.Sentakki.UI;
 using osu.Game.Rulesets.Objects.Drawables;
 
@@ -21,6 +22,16 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public DrawableSentakkiHitObject(SentakkiHitObject hitObject)
             : base(hitObject)
         {
+        }
+
+        private DrawableSentakkiRuleset drawableSentakkiRuleset;
+
+        public double GameplaySpeed => drawableSentakkiRuleset?.GameplaySpeed ?? 1;
+
+        [BackgroundDependencyLoader(true)]
+        private void load(DrawableSentakkiRuleset drawableRuleset)
+        {
+            drawableSentakkiRuleset = drawableRuleset;
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
@@ -64,25 +63,19 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         }
 
         private Bindable<double> animationDuration = new Bindable<double>(1000);
-        private Bindable<Track> speedAdjustmentTrack = new Bindable<Track>(new TrackVirtual(0));
-        private double speed => speedAdjustmentTrack.Value.AggregateTempo.Value * speedAdjustmentTrack.Value.AggregateFrequency.Value;
-
         [BackgroundDependencyLoader(true)]
-        private void load(SentakkiRulesetConfigManager settings, DrawableSentakkiRuleset drawableRuleset)
+        private void load(SentakkiRulesetConfigManager settings)
         {
             settings?.BindWith(SentakkiRulesetSettings.AnimationDuration, animationDuration);
             HitObjectLine.Child.Colour = HitObject.NoteColor;
-
-            if (drawableRuleset != null)
-                speedAdjustmentTrack.BindTo(drawableRuleset.SpeedAdjustmentTrack);
         }
 
         protected override void Update()
         {
             base.Update();
             if (Result.HasResult) return;
-            double fadeIn = 500 * speed;
-            double moveTo = animationDuration.Value * speed;
+            double fadeIn = 500 * GameplaySpeed;
+            double moveTo = animationDuration.Value * GameplaySpeed;
             double animStart = HitObject.StartTime - moveTo - fadeIn;
             double currentProg = Clock.CurrentTime - animStart;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -15,6 +15,7 @@ using osuTK.Graphics;
 using System;
 using System.Diagnostics;
 using osu.Game.Rulesets.Sentakki.UI;
+
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
     public class DrawableTap : DrawableSentakkiHitObject
@@ -72,7 +73,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             settings?.BindWith(SentakkiRulesetSettings.AnimationDuration, animationDuration);
             HitObjectLine.Child.Colour = HitObject.NoteColor;
 
-            speedAdjustmentTrack.BindTo(drawableRuleset.SpeedAdjustmentTrack);
+            if (drawableRuleset != null)
+                speedAdjustmentTrack.BindTo(drawableRuleset.SpeedAdjustmentTrack);
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
@@ -14,7 +15,6 @@ using osuTK.Graphics;
 using System;
 using System.Diagnostics;
 using osu.Game.Rulesets.Sentakki.UI;
-
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
     public class DrawableTap : DrawableSentakkiHitObject
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public readonly HitReceptor HitArea;
         public readonly TapCircle CirclePiece;
         public readonly CircularContainer HitObjectLine;
-        protected override double InitialLifetimeOffset => 12000;
+        protected override double InitialLifetimeOffset => 6000;
 
         public DrawableTap(SentakkiHitObject hitObject)
             : base(hitObject)
@@ -63,20 +63,24 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         }
 
         private Bindable<double> animationDuration = new Bindable<double>(1000);
+        private Bindable<Track> speedAdjustmentTrack = new Bindable<Track>(new TrackVirtual(0));
+        private double speed => speedAdjustmentTrack.Value.AggregateTempo.Value * speedAdjustmentTrack.Value.AggregateFrequency.Value;
 
         [BackgroundDependencyLoader(true)]
-        private void load(SentakkiRulesetConfigManager settings)
+        private void load(SentakkiRulesetConfigManager settings, DrawableSentakkiRuleset drawableRuleset)
         {
             settings?.BindWith(SentakkiRulesetSettings.AnimationDuration, animationDuration);
             HitObjectLine.Child.Colour = HitObject.NoteColor;
+
+            speedAdjustmentTrack.BindTo(drawableRuleset.SpeedAdjustmentTrack);
         }
 
         protected override void Update()
         {
             base.Update();
             if (Result.HasResult) return;
-            double fadeIn = 500 * (Clock.Rate < 0 ? 1 : Clock.Rate);
-            double moveTo = animationDuration.Value * (Clock.Rate < 0 ? 1 : Clock.Rate);
+            double fadeIn = 500 * speed;
+            double moveTo = animationDuration.Value * speed;
             double animStart = HitObject.StartTime - moveTo - fadeIn;
             double currentProg = Clock.CurrentTime - animStart;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -1,8 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Audio.Track;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
+using osu.Game.Rulesets.Sentakki.UI;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
@@ -21,7 +25,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         private SentakkiInputManager sentakkiActionInputManager;
         internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= GetContainingInputManager() as SentakkiInputManager;
 
-        protected override double InitialLifetimeOffset => 500;
+        protected override double InitialLifetimeOffset => 2000;
 
         public DrawableTouchHold(TouchHold hitObject)
             : base(hitObject)
@@ -69,11 +73,20 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         public bool Auto = false;
 
+        private Bindable<Track> speedAdjustmentTrack = new Bindable<Track>(new TrackVirtual(0));
+        private double speed => speedAdjustmentTrack.Value.AggregateTempo.Value * speedAdjustmentTrack.Value.AggregateFrequency.Value;
+
+        [BackgroundDependencyLoader(true)]
+        private void load(DrawableSentakkiRuleset drawableRuleset)
+        {
+            speedAdjustmentTrack.BindTo(drawableRuleset.SpeedAdjustmentTrack);
+        }
+
         protected override void Update()
         {
             base.Update();
             if (Result.HasResult) return;
-            double fadeIn = 500 * (Clock.Rate < 0 ? 1 : Clock.Rate);
+            double fadeIn = 500 * speed;
             double animStart = HitObject.StartTime - fadeIn;
             double currentProg = Clock.CurrentTime - animStart;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-using osu.Framework.Bindables;
-using osu.Framework.Audio.Track;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
-using osu.Game.Rulesets.Sentakki.UI;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
@@ -73,21 +69,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         public bool Auto = false;
 
-        private Bindable<Track> speedAdjustmentTrack = new Bindable<Track>(new TrackVirtual(0));
-        private double speed => speedAdjustmentTrack.Value.AggregateTempo.Value * speedAdjustmentTrack.Value.AggregateFrequency.Value;
-
-        [BackgroundDependencyLoader(true)]
-        private void load(DrawableSentakkiRuleset drawableRuleset)
-        {
-            if (drawableRuleset != null)
-                speedAdjustmentTrack.BindTo(drawableRuleset?.SpeedAdjustmentTrack);
-        }
-
         protected override void Update()
         {
             base.Update();
             if (Result.HasResult) return;
-            double fadeIn = 500 * speed;
+            double fadeIn = 500 * GameplaySpeed;
             double animStart = HitObject.StartTime - fadeIn;
             double currentProg = Clock.CurrentTime - animStart;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -79,7 +79,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         [BackgroundDependencyLoader(true)]
         private void load(DrawableSentakkiRuleset drawableRuleset)
         {
-            speedAdjustmentTrack.BindTo(drawableRuleset.SpeedAdjustmentTrack);
+            if (drawableRuleset != null)
+                speedAdjustmentTrack.BindTo(drawableRuleset?.SpeedAdjustmentTrack);
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
+using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
 using osu.Framework.Allocation;
 using osu.Framework.Input;
 using osu.Game.Beatmaps;
 using osu.Game.Input.Handlers;
 using osu.Game.Replays;
+using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.Replays;
@@ -22,6 +26,15 @@ namespace osu.Game.Rulesets.Sentakki.UI
         public DrawableSentakkiRuleset(SentakkiRuleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(ruleset, beatmap, mods)
         {
+        }
+
+        public readonly Bindable<Track> SpeedAdjustmentTrack = new Bindable<Track>(new TrackVirtual(0));
+
+        [BackgroundDependencyLoader(true)]
+        private void load()
+        {
+            foreach (var mod in Mods.OfType<IApplicableToTrack>())
+                mod.ApplyToTrack(SpeedAdjustmentTrack.Value);
         }
 
         protected override Playfield CreatePlayfield() => new SentakkiPlayfield();

--- a/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
@@ -3,13 +3,11 @@
 
 using System.Linq;
 using osu.Framework.Audio.Track;
-using osu.Framework.Bindables;
 using osu.Framework.Allocation;
 using osu.Framework.Input;
 using osu.Game.Beatmaps;
 using osu.Game.Input.Handlers;
 using osu.Game.Replays;
-using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.Replays;
@@ -28,13 +26,15 @@ namespace osu.Game.Rulesets.Sentakki.UI
         {
         }
 
-        public readonly Bindable<Track> SpeedAdjustmentTrack = new Bindable<Track>(new TrackVirtual(0));
+        private readonly Track speedAdjustmentTrack = new TrackVirtual(0);
+
+        public double GameplaySpeed => speedAdjustmentTrack.AggregateFrequency.Value * speedAdjustmentTrack.AggregateTempo.Value;
 
         [BackgroundDependencyLoader(true)]
         private void load()
         {
             foreach (var mod in Mods.OfType<IApplicableToTrack>())
-                mod.ApplyToTrack(SpeedAdjustmentTrack.Value);
+                mod.ApplyToTrack(speedAdjustmentTrack);
         }
 
         protected override Playfield CreatePlayfield() => new SentakkiPlayfield();

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -73,20 +73,18 @@ namespace osu.Game.Rulesets.Sentakki.UI
             });
         }
 
-        private Bindable<Track> speedAdjustmentTrack = new Bindable<Track>(new TrackVirtual(0));
-        private double speed => speedAdjustmentTrack.Value.AggregateTempo.Value * speedAdjustmentTrack.Value.AggregateFrequency.Value;
+        private DrawableSentakkiRuleset drawableSentakkiRuleset;
 
         [BackgroundDependencyLoader(true)]
         private void load(DrawableSentakkiRuleset drawableRuleset)
         {
-            if (drawableRuleset != null)
-                speedAdjustmentTrack.BindTo(drawableRuleset?.SpeedAdjustmentTrack);
+            drawableSentakkiRuleset = drawableRuleset;
         }
 
         protected override void Update()
         {
             // Using deltaTime instead of what I did with the hitObjects to avoid noticible jitter during rate changed.
-            double rotationAmount = Clock.ElapsedFrameTime / (RevolutionDuration.Value * 1000 * speed) * 360;
+            double rotationAmount = Clock.ElapsedFrameTime / (RevolutionDuration.Value * 1000 * (drawableSentakkiRuleset?.GameplaySpeed ?? 1)) * 360;
             Rotation += (float)rotationAmount;
             base.Update();
         }

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
         private readonly JudgementContainer<DrawableSentakkiJudgement> judgementLayer;
 
         private readonly SentakkiRing ring;
-        public BindableNumber<int> RevolutionDuration = new BindableNumber<int>(0);
+        public BindableNumber<int> RevolutionDuration = new BindableNumber<int>(5);
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
@@ -59,6 +59,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             RelativeSizeAxes = Axes.None;
+            Rotation = 0;
             Size = new Vector2(600);
             AddRangeInternal(new Drawable[]
             {
@@ -78,7 +79,8 @@ namespace osu.Game.Rulesets.Sentakki.UI
         [BackgroundDependencyLoader(true)]
         private void load(DrawableSentakkiRuleset drawableRuleset)
         {
-            speedAdjustmentTrack.BindTo(drawableRuleset.SpeedAdjustmentTrack);
+            if (drawableRuleset != null)
+                speedAdjustmentTrack.BindTo(drawableRuleset?.SpeedAdjustmentTrack);
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -56,11 +56,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
         public SentakkiPlayfield()
         {
-            RevolutionDuration.BindValueChanged(b =>
-            {
-                if (b.NewValue != 0) this.Spin(b.NewValue * 1000, RotationDirection.Clockwise).Then().Loop();
-            });
-
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             RelativeSizeAxes = Axes.None;
@@ -75,6 +70,23 @@ namespace osu.Game.Rulesets.Sentakki.UI
                     RelativeSizeAxes = Axes.Both,
                 },
             });
+        }
+
+        private Bindable<Track> speedAdjustmentTrack = new Bindable<Track>(new TrackVirtual(0));
+        private double speed => speedAdjustmentTrack.Value.AggregateTempo.Value * speedAdjustmentTrack.Value.AggregateFrequency.Value;
+
+        [BackgroundDependencyLoader(true)]
+        private void load(DrawableSentakkiRuleset drawableRuleset)
+        {
+            speedAdjustmentTrack.BindTo(drawableRuleset.SpeedAdjustmentTrack);
+        }
+
+        protected override void Update()
+        {
+            // Using deltaTime instead of what I did with the hitObjects to avoid noticible jitter during rate changed.
+            double rotationAmount = Clock.ElapsedFrameTime / (RevolutionDuration.Value * 1000 * speed) * 360;
+            Rotation += (float)rotationAmount;
+            base.Update();
         }
 
         protected override GameplayCursorContainer CreateCursor() => new SentakkiCursorContainer();
@@ -122,12 +134,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
             if (result.IsHit && judgedObject.HitObject.Kiai)
                 ring.KiaiBeat();
-        }
-
-        protected override void LoadComplete()
-        {
-            RevolutionDuration.TriggerChange();
-            base.LoadComplete();
         }
 
         private class VisualisationContainer : BeatSyncedContainer


### PR DESCRIPTION
Note speed will compensate for speed adjustment mods, but will not compensate for playback speeds(replays/autoplay). 

While I was at it, I plugged the playfield spin mod to the same delta-based system. Which avoids some transform related issues during replay rewinding.