### PR TITLE
Fix visualizer visual bug when rewinding

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
@@ -70,12 +70,19 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
 
         public PlayfieldVisualisation()
         {
+            FillAspectRatio = 1;
+            FillMode = FillMode.Fit;
+            RelativeSizeAxes = Axes.Both;
+            Size = new Vector2(.99f);
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
             texture = Texture.WhitePixel;
             Blending = BlendingParameters.Additive;
         }
 
         private readonly Bindable<ColorOption> colorOption = new Bindable<ColorOption>(ColorOption.Default);
 
+        private readonly Bindable<bool> kiaiEffect = new Bindable<bool>(true);
         [BackgroundDependencyLoader(true)]
         private void load(ShaderManager shaders, IBindable<WorkingBeatmap> beatmap, SkinManager skinManager, SentakkiRulesetConfigManager settings, OsuColour colours, DrawableSentakkiRuleset ruleset)
         {
@@ -84,6 +91,16 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
 
             skin = skinManager.CurrentSkin.GetBoundCopy();
             skin.BindValueChanged(_ => colorOption.TriggerChange());
+
+            settings.BindWith(SentakkiRulesetSettings.KiaiEffects, kiaiEffect);
+            kiaiEffect.BindValueChanged(k =>
+            {
+                if (k.NewValue)
+                    this.FadeIn(200);
+                else
+                    this.FadeOut(500);
+
+            });
 
             settings?.BindWith(SentakkiRulesetSettings.RingColor, colorOption);
             colorOption.BindValueChanged(c =>
@@ -103,6 +120,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
         protected override void LoadComplete()
         {
             colorOption.TriggerChange();
+            kiaiEffect.TriggerChange();
         }
 
         private void updateAmplitudes()
@@ -116,7 +134,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             {
                 if (track?.IsRunning ?? false)
                 {
-                    float targetAmplitude = (temporalAmplitudes?[(i + indexOffset) % bars_per_visualiser] ?? 0) * (effect?.KiaiMode == true ? 1 : 0.5f);
+                    float targetAmplitude = (temporalAmplitudes?[(i + indexOffset) % bars_per_visualiser] ?? 0) * (effect?.KiaiMode == true ? 1 : 0f);
                     if (targetAmplitude > frequencyAmplitudes[i])
                         frequencyAmplitudes[i] = targetAmplitude;
                 }

--- a/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
@@ -92,14 +92,13 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             skin = skinManager.CurrentSkin.GetBoundCopy();
             skin.BindValueChanged(_ => colorOption.TriggerChange());
 
-            settings.BindWith(SentakkiRulesetSettings.KiaiEffects, kiaiEffect);
+            settings?.BindWith(SentakkiRulesetSettings.KiaiEffects, kiaiEffect);
             kiaiEffect.BindValueChanged(k =>
             {
                 if (k.NewValue)
                     this.FadeIn(200);
                 else
                     this.FadeOut(500);
-
             });
 
             settings?.BindWith(SentakkiRulesetSettings.RingColor, colorOption);
@@ -113,7 +112,6 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                     this.FadeColour(colours.ForDifficultyRating(ruleset?.Beatmap.BeatmapInfo.DifficultyRating ?? DifficultyRating.Normal, true), 200);
                 else if (c.NewValue == ColorOption.Skin)
                     this.FadeColour(skin.Value.GetConfig<GlobalSkinColours, Color4>(GlobalSkinColours.MenuGlow)?.Value ?? Color4.White, 200);
-
             });
         }
 
@@ -227,11 +225,11 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                             if (audioData[i] < amplitude_dead_zone)
                                 continue;
 
-                            float rotation = MathUtils.DegreesToRadians(i / (float)bars_per_visualiser * 360 + j * 360 / visualiser_rounds);
+                            float rotation = MathUtils.DegreesToRadians((i / (float)bars_per_visualiser * 360) + (j * 360 / visualiser_rounds));
                             float rotationCos = MathF.Cos(rotation);
                             float rotationSin = MathF.Sin(rotation);
                             // taking the cos and sin to the 0..1 range
-                            var barPosition = new Vector2(rotationCos / 2 + 0.5f, rotationSin / 2 + 0.5f) * size;
+                            var barPosition = new Vector2((rotationCos / 2) + 0.5f, (rotationSin / 2) + 0.5f) * size;
 
                             var barSize = new Vector2(size * MathF.Sqrt(2 * (1 - MathF.Cos(MathUtils.DegreesToRadians(360f / bars_per_visualiser)))) / 2f, bar_length * audioData[i]);
                             // The distance between the position and the sides of the bar.

--- a/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
@@ -1,0 +1,249 @@
+using osuTK;
+using osuTK.Graphics;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Batches;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.OpenGL.Vertices;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+using osu.Game.Skinning;
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Sentakki.Configuration;
+
+namespace osu.Game.Rulesets.Sentakki.UI.Components
+{
+    public class PlayfieldVisualisation : Drawable, IHasAccentColour
+    {
+        private readonly IBindable<WorkingBeatmap> beatmap = new Bindable<WorkingBeatmap>();
+
+        /// <summary>
+        /// The number of bars to jump each update iteration.
+        /// </summary>
+        private const int index_change = 5;
+
+        /// <summary>
+        /// The maximum length of each bar in the visualiser. Will be reduced when kiai is not activated.
+        /// </summary>
+        private const float bar_length = 600;
+
+        /// <summary>
+        /// The number of bars in one rotation of the visualiser.
+        /// </summary>
+        private const int bars_per_visualiser = 200;
+
+        /// <summary>
+        /// How many times we should stretch around the circumference (overlapping overselves).
+        /// </summary>
+        private const float visualiser_rounds = 5;
+
+        /// <summary>
+        /// How much should each bar go down each millisecond (based on a full bar).
+        /// </summary>
+        private const float decay_per_milisecond = 0.0024f;
+
+        /// <summary>
+        /// Number of milliseconds between each amplitude update.
+        /// </summary>
+        private const float time_between_updates = 50;
+
+        /// <summary>
+        /// The minimum amplitude to show a bar.
+        /// </summary>
+        private const float amplitude_dead_zone = 1f / bar_length;
+
+        private int indexOffset;
+
+        public Color4 AccentColour { get; set; }
+
+        private readonly float[] frequencyAmplitudes = new float[256];
+
+        private IShader shader;
+        private readonly Texture texture;
+        private Bindable<Skin> skin;
+
+        public PlayfieldVisualisation()
+        {
+            texture = Texture.WhitePixel;
+            Blending = BlendingParameters.Additive;
+        }
+
+        private readonly Bindable<ColorOption> colorOption = new Bindable<ColorOption>(ColorOption.Default);
+
+        [BackgroundDependencyLoader]
+        private void load(ShaderManager shaders, IBindable<WorkingBeatmap> beatmap, SkinManager skinManager, SentakkiRulesetConfigManager settings, OsuColour colours, DrawableSentakkiRuleset ruleset)
+        {
+            this.beatmap.BindTo(beatmap);
+            shader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
+
+            skin = skinManager.CurrentSkin.GetBoundCopy();
+            skin.BindValueChanged(_ => colorOption.TriggerChange());
+
+            settings.BindWith(SentakkiRulesetSettings.RingColor, colorOption);
+            colorOption.BindValueChanged(c =>
+            {
+                AccentColour = Color4.White.Opacity(0.2f);
+
+                if (c.NewValue == ColorOption.Default)
+                    this.FadeColour(Color4.White, 200);
+                else if (c.NewValue == ColorOption.Difficulty)
+                    this.FadeColour(colours.ForDifficultyRating(ruleset?.Beatmap.BeatmapInfo.DifficultyRating ?? DifficultyRating.Normal, true), 200);
+                else if (c.NewValue == ColorOption.Skin)
+                    this.FadeColour(skin.Value.GetConfig<GlobalSkinColours, Color4>(GlobalSkinColours.MenuGlow)?.Value ?? Color4.White, 200);
+
+            }, true);
+        }
+
+        private void updateAmplitudes()
+        {
+            var track = beatmap.Value.TrackLoaded ? beatmap.Value.Track : null;
+            var effect = beatmap.Value.BeatmapLoaded ? beatmap.Value.Beatmap?.ControlPointInfo.EffectPointAt(track?.CurrentTime ?? Time.Current) : null;
+
+            float[] temporalAmplitudes = track?.CurrentAmplitudes.FrequencyAmplitudes;
+
+            for (int i = 0; i < bars_per_visualiser; i++)
+            {
+                if (track?.IsRunning ?? false)
+                {
+                    float targetAmplitude = (temporalAmplitudes?[(i + indexOffset) % bars_per_visualiser] ?? 0) * (effect?.KiaiMode == true ? 1 : 0.5f);
+                    if (targetAmplitude > frequencyAmplitudes[i])
+                        frequencyAmplitudes[i] = targetAmplitude;
+                }
+                else
+                {
+                    int index = (i + index_change) % bars_per_visualiser;
+                    if (frequencyAmplitudes[index] > frequencyAmplitudes[i])
+                        frequencyAmplitudes[i] = frequencyAmplitudes[index];
+                }
+            }
+
+            indexOffset = (indexOffset + index_change) % bars_per_visualiser;
+        }
+
+        private double delta = 0;
+        protected override void Update()
+        {
+            base.Update();
+
+            delta += Math.Abs(Time.Elapsed);
+            if (delta >= time_between_updates)
+            {
+                updateAmplitudes();
+                delta %= time_between_updates;
+            }
+
+            float decayFactor = Math.Abs((float)Time.Elapsed) * decay_per_milisecond;
+
+            for (int i = 0; i < bars_per_visualiser; i++)
+            {
+                //3% of extra bar length to make it a little faster when bar is almost at it's minimum
+                frequencyAmplitudes[i] -= decayFactor * (frequencyAmplitudes[i] + 0.03f);
+                if (frequencyAmplitudes[i] < 0)
+                    frequencyAmplitudes[i] = 0;
+            }
+
+            Invalidate(Invalidation.DrawNode);
+        }
+
+        protected override DrawNode CreateDrawNode() => new VisualisationDrawNode(this);
+
+        private class VisualisationDrawNode : DrawNode
+        {
+            protected new PlayfieldVisualisation Source => (PlayfieldVisualisation)base.Source;
+
+            private IShader shader;
+            private Texture texture;
+
+            // Assuming the logo is a circle, we don't need a second dimension.
+            private float size;
+
+            private Color4 colour;
+            private float[] audioData;
+
+            private readonly QuadBatch<TexturedVertex2D> vertexBatch = new QuadBatch<TexturedVertex2D>(100, 10);
+
+            public VisualisationDrawNode(PlayfieldVisualisation source)
+                : base(source)
+            {
+            }
+
+            public override void ApplyState()
+            {
+                base.ApplyState();
+
+                shader = Source.shader;
+                texture = Source.texture;
+                size = Source.DrawSize.X;
+                colour = Source.AccentColour;
+                audioData = Source.frequencyAmplitudes;
+            }
+
+            public override void Draw(Action<TexturedVertex2D> vertexAction)
+            {
+                base.Draw(vertexAction);
+
+                shader.Bind();
+
+                Vector2 inflation = DrawInfo.MatrixInverse.ExtractScale().Xy;
+
+                ColourInfo colourInfo = DrawColourInfo.Colour;
+                colourInfo.ApplyChild(colour);
+
+                if (audioData != null)
+                {
+                    for (int j = 0; j < visualiser_rounds; j++)
+                    {
+                        for (int i = 0; i < bars_per_visualiser; i++)
+                        {
+                            if (audioData[i] < amplitude_dead_zone)
+                                continue;
+
+                            float rotation = MathUtils.DegreesToRadians(i / (float)bars_per_visualiser * 360 + j * 360 / visualiser_rounds);
+                            float rotationCos = MathF.Cos(rotation);
+                            float rotationSin = MathF.Sin(rotation);
+                            // taking the cos and sin to the 0..1 range
+                            var barPosition = new Vector2(rotationCos / 2 + 0.5f, rotationSin / 2 + 0.5f) * size;
+
+                            var barSize = new Vector2(size * MathF.Sqrt(2 * (1 - MathF.Cos(MathUtils.DegreesToRadians(360f / bars_per_visualiser)))) / 2f, bar_length * audioData[i]);
+                            // The distance between the position and the sides of the bar.
+                            var bottomOffset = new Vector2(-rotationSin * barSize.X / 2, rotationCos * barSize.X / 2);
+                            // The distance between the bottom side of the bar and the top side.
+                            var amplitudeOffset = new Vector2(rotationCos * barSize.Y, rotationSin * barSize.Y);
+
+                            var rectangle = new Quad(
+                                Vector2Extensions.Transform(barPosition - bottomOffset, DrawInfo.Matrix),
+                                Vector2Extensions.Transform(barPosition - bottomOffset + amplitudeOffset, DrawInfo.Matrix),
+                                Vector2Extensions.Transform(barPosition + bottomOffset, DrawInfo.Matrix),
+                                Vector2Extensions.Transform(barPosition + bottomOffset + amplitudeOffset, DrawInfo.Matrix)
+                            );
+
+                            DrawQuad(
+                                texture,
+                                rectangle,
+                                colourInfo,
+                                null,
+                                vertexBatch.AddAction,
+                                // barSize by itself will make it smooth more in the X axis than in the Y axis, this reverts that.
+                                Vector2.Divide(inflation, barSize.Yx));
+                        }
+                    }
+                }
+
+                shader.Unbind();
+            }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                base.Dispose(isDisposing);
+
+                vertexBatch.Dispose();
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
 
         private readonly Bindable<ColorOption> colorOption = new Bindable<ColorOption>(ColorOption.Default);
 
-        [BackgroundDependencyLoader]
+        [BackgroundDependencyLoader(true)]
         private void load(ShaderManager shaders, IBindable<WorkingBeatmap> beatmap, SkinManager skinManager, SentakkiRulesetConfigManager settings, OsuColour colours, DrawableSentakkiRuleset ruleset)
         {
             this.beatmap.BindTo(beatmap);
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             skin = skinManager.CurrentSkin.GetBoundCopy();
             skin.BindValueChanged(_ => colorOption.TriggerChange());
 
-            settings.BindWith(SentakkiRulesetSettings.RingColor, colorOption);
+            settings?.BindWith(SentakkiRulesetSettings.RingColor, colorOption);
             colorOption.BindValueChanged(c =>
             {
                 AccentColour = Color4.White.Opacity(0.2f);

--- a/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
@@ -97,7 +97,12 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                 else if (c.NewValue == ColorOption.Skin)
                     this.FadeColour(skin.Value.GetConfig<GlobalSkinColours, Color4>(GlobalSkinColours.MenuGlow)?.Value ?? Color4.White, 200);
 
-            }, true);
+            });
+        }
+
+        protected override void LoadComplete()
+        {
+            colorOption.TriggerChange();
         }
 
         private void updateAmplitudes()

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -6,25 +6,15 @@ using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
-using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.UI.Components;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
-using osu.Game.Screens.Menu;
 using osuTK;
-using osuTK.Graphics;
 using System;
-using osu.Game.Online.API;
-using osu.Game.Users;
-using osu.Game.Skinning;
-using osu.Framework.Extensions.Color4Extensions;
-using osu.Game.Screens.Play;
 
 namespace osu.Game.Rulesets.Sentakki.UI
 {
@@ -142,11 +132,10 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
         private class VisualisationContainer : BeatSyncedContainer
         {
-            private PlayfieldVisualisation visualisation;
+            private readonly PlayfieldVisualisation visualisation;
             private readonly Bindable<bool> kiaiEffect = new Bindable<bool>(true);
 
-            [BackgroundDependencyLoader(true)]
-            private void load(SentakkiRulesetConfigManager settings, OsuColour colours, DrawableSentakkiRuleset ruleset, IAPIProvider api, SkinManager skinManager)
+            public VisualisationContainer()
             {
                 FillAspectRatio = 1;
                 FillMode = FillMode.Fit;

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
             Size = new Vector2(600);
             AddRangeInternal(new Drawable[]
             {
-                new VisualisationContainer(),
+                new PlayfieldVisualisation(),
                 ring = new SentakkiRing(),
                 HitObjectContainer,
                 judgementLayer = new JudgementContainer<DrawableSentakkiJudgement>
@@ -128,36 +128,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
             if (result.IsHit && judgedObject.HitObject.Kiai)
                 ring.KiaiBeat();
-        }
-
-        private class VisualisationContainer : BeatSyncedContainer
-        {
-            private readonly PlayfieldVisualisation visualisation;
-            private readonly Bindable<bool> kiaiEffect = new Bindable<bool>(true);
-
-            public VisualisationContainer()
-            {
-                FillAspectRatio = 1;
-                FillMode = FillMode.Fit;
-                RelativeSizeAxes = Axes.Both;
-                Size = new Vector2(.99f);
-                Anchor = Anchor.Centre;
-                Origin = Anchor.Centre;
-                Child = visualisation = new PlayfieldVisualisation
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                };
-            }
-
-            protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, TrackAmplitudes amplitudes)
-            {
-                if (effectPoint.KiaiMode && kiaiEffect.Value)
-                    visualisation.FadeIn(200);
-                else
-                    visualisation.FadeOut(500);
-            }
         }
     }
 }


### PR DESCRIPTION
Doing this will also avoid a rare crash caused by NaN height visualizer bars.

My initial idea was to change the visualizer on the main osu repo, but I have no idea of the implications that may occur due to the change(Is thread-safety needed and whatnot). But seeing as the original visualizer wasn't intended to be used in gameplay, I figured that it can remain as is.