### PR TITLE
Change how options affect animation speed for notes

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Configurations/SentakkiRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Sentakki/Configurations/SentakkiRulesetConfigManager.cs
@@ -16,8 +16,8 @@ namespace osu.Game.Rulesets.Sentakki.Configuration
             base.InitialiseDefaults();
 
             Set(SentakkiRulesetSettings.KiaiEffects, true);
-            Set(SentakkiRulesetSettings.AnimationDuration, 500, 50.0, 1000, 50.0);
-            Set(SentakkiRulesetSettings.TouchAnimationDuration, 500, 50.0, 1000, 50.0);
+            Set(SentakkiRulesetSettings.AnimationDuration, 1000, 100, 2000, 100.0);
+            Set(SentakkiRulesetSettings.TouchAnimationDuration, 500, 50, 1000, 50.0);
             Set(SentakkiRulesetSettings.MaimaiJudgements, false);
             Set(SentakkiRulesetSettings.ShowNoteStartIndicators, false);
             Set(SentakkiRulesetSettings.RingColor, ColorOption.Default);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public readonly HitReceptor HitArea;
         private readonly HoldBody note;
         public readonly HitObjectLine HitObjectLine;
-        protected override double InitialLifetimeOffset => 6000;
+        protected override double InitialLifetimeOffset => 8000;
 
         /// <summary>
         /// Time at which the user started holding this hold note. Null if the user is not holding this hold note.
@@ -140,8 +140,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.Update();
             if (Result.HasResult) return;
-            double fadeIn = 500 * GameplaySpeed;
-            double moveTo = animationDuration.Value * GameplaySpeed;
+
+            double animSpeed = animationDuration.Value / 2;
+            double fadeIn = animSpeed * GameplaySpeed;
+            double moveTo = animSpeed * GameplaySpeed;
             double animStart = HitObject.StartTime - moveTo - fadeIn;
             double currentProg = Clock.CurrentTime - animStart;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public readonly HitReceptor HitArea;
         public readonly TapCircle CirclePiece;
         public readonly HitObjectLine HitObjectLine;
-        protected override double InitialLifetimeOffset => 6000;
+        protected override double InitialLifetimeOffset => 8000;
 
         public DrawableTap(SentakkiHitObject hitObject)
             : base(hitObject)
@@ -66,8 +66,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.Update();
             if (Result.HasResult) return;
-            double fadeIn = 500 * GameplaySpeed;
-            double moveTo = animationDuration.Value * GameplaySpeed;
+
+            double animSpeed = animationDuration.Value / 2;
+
+            double fadeIn = animSpeed * GameplaySpeed;
+            double moveTo = animSpeed * GameplaySpeed;
             double animStart = HitObject.StartTime - moveTo - fadeIn;
             double currentProg = Clock.CurrentTime - animStart;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -1,4 +1,7 @@
-﻿using osu.Framework.Graphics;
+﻿using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Sentakki.Configuration;
+using osu.Framework.Graphics;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
@@ -18,7 +21,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         private SentakkiInputManager sentakkiActionInputManager;
         internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= GetContainingInputManager() as SentakkiInputManager;
 
-        protected override double InitialLifetimeOffset => 2000;
+        protected override double InitialLifetimeOffset => 4000;
 
         public DrawableTouchHold(TouchHold hitObject)
             : base(hitObject)
@@ -64,11 +67,20 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             });
         }
 
+        private readonly Bindable<double> touchAnimationDuration = new Bindable<double>(1000);
+
+        [BackgroundDependencyLoader(true)]
+        private void load(SentakkiRulesetConfigManager sentakkiConfigs)
+        {
+            sentakkiConfigs?.BindWith(SentakkiRulesetSettings.TouchAnimationDuration, touchAnimationDuration);
+        }
+
         protected override void Update()
         {
             base.Update();
             if (Result.HasResult) return;
-            double fadeIn = 500 * GameplaySpeed;
+
+            double fadeIn = touchAnimationDuration.Value * GameplaySpeed;
             double animStart = HitObject.StartTime - fadeIn;
             double currentProg = Clock.CurrentTime - animStart;
 

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
@@ -51,14 +51,14 @@ namespace osu.Game.Rulesets.Sentakki.UI
                     LabelText = "Ring Colour",
                     Bindable = config.GetBindable<ColorOption>(SentakkiRulesetSettings.RingColor)
                 },
-                new SettingsSlider<double, TimeSlider>
+                new SettingsSlider<double, NoteTimeSlider>
                 {
-                    LabelText = "Note speed",
+                    LabelText = "Note entry speed",
                     Bindable = config.GetBindable<double>(SentakkiRulesetSettings.AnimationDuration),
                 },
-                new SettingsSlider<double, TimeSlider>
+                new SettingsSlider<double, TouchTimeSlider>
                 {
-                    LabelText = "Touch note speed",
+                    LabelText = "Touch note fade-in speed",
                     Bindable = config.GetBindable<double>(SentakkiRulesetSettings.TouchAnimationDuration),
                 },
                 new SettingsSlider<float>
@@ -71,7 +71,20 @@ namespace osu.Game.Rulesets.Sentakki.UI
             };
         }
 
-        private class TimeSlider : OsuSliderBar<double>
+        private class NoteTimeSlider : OsuSliderBar<double>
+        {
+            private string speedRating()
+            {
+                double speed = (2200 - Current.Value) / 200;
+
+                if (speed == 10.5)
+                    return "Sonic";
+
+                return speed.ToString();
+            }
+            public override string TooltipText => Current.Value.ToString("N0") + "ms (" + speedRating() + ")";
+        }
+        private class TouchTimeSlider : OsuSliderBar<double>
         {
             private string speedRating()
             {


### PR DESCRIPTION
**Note animation speed** affects both the fade-in and the move speed of rim notes (TAPs and HOLDs)
**Touch note fade-in speed**  only affects the fade-in speed of TOUCH based notes (TOUCH and TOUCH HOLDs)

The minimum and maximum values of each slider has also been changed to accommodate the changes in animations.