### PR TITLE
[Experimental] Implement pattern generator for std converts

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmap.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmap.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             int holds = HitObjects.Count(h => h is Hold);
             int centreHolds = HitObjects.Count(h => h is TouchHold);
             int breaks = HitObjects.Count(h => h is Break);
+            int touchs = HitObjects.Count(h => h is Touch);
 
             return new[]
             {
@@ -39,6 +40,12 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                 {
                     Name = "Break Count",
                     Content = breaks.ToString(),
+                    Icon = FontAwesome.Solid.Circle
+                },
+                new BeatmapStatistic
+                {
+                    Name = "Touch Count",
+                    Content = touchs.ToString(),
                     Icon = FontAwesome.Solid.Circle
                 },
             };

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
@@ -1,3 +1,4 @@
+﻿using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Objects;
@@ -24,7 +25,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         // https://github.com/ppy/osu/tree/master/osu.Game/Rulesets/Objects/Types
         public override bool CanConvert() => Beatmap.HitObjects.All(h => h is IHasPosition);
 
-        public ConversionExperiments EnabledExperiments = ConversionExperiments.none;
+        public Bindable<ConversionExperiments> EnabledExperiments = new Bindable<ConversionExperiments>();
 
         private SentakkiPatternGenerator patternGen;
 
@@ -39,6 +40,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             int seed = ((int)MathF.Round(difficulty.DrainRate + difficulty.CircleSize) * 20) + (int)(difficulty.OverallDifficulty * 41.2) + (int)MathF.Round(difficulty.ApproachRate);
             random = new Random(seed);
             random2 = new Random(seed);
+            patternGen.Experiments.BindTo(EnabledExperiments);
         }
 
         protected override IEnumerable<SentakkiHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap)
@@ -50,7 +52,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             int path = newPos.GetDegreesFromPosition(CENTRE_POINT).GetNotePathFromDegrees();
             List<SentakkiHitObject> objects = new List<SentakkiHitObject>();
 
-            if (EnabledExperiments.HasFlag(ConversionExperiments.patternv2))
+            if (EnabledExperiments.Value.HasFlag(ConversionExperiments.patternv2))
             {
                 if ((original as IHasCombo).NewCombo)
                     patternGen.CreateNewPattern();
@@ -61,7 +63,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                 switch (original)
                 {
                     case IHasPathWithRepeats _:
-                        objects.AddRange(Conversions.CreateHoldNote(original, path, beatmap, random, EnabledExperiments));
+                        objects.AddRange(Conversions.CreateHoldNote(original, path, beatmap, random, EnabledExperiments.Value));
                         break;
 
                     case IHasDuration _:
@@ -69,10 +71,10 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                         break;
 
                     default:
-                        if (EnabledExperiments.HasFlag(ConversionExperiments.touch) && (random2.Next() % 10 == 0))
-                            objects.AddRange(Conversions.CreateTouchNote(original, path, random, EnabledExperiments));
+                        if (EnabledExperiments.Value.HasFlag(ConversionExperiments.touch) && (random2.Next() % 10 == 0))
+                            objects.AddRange(Conversions.CreateTouchNote(original, path, random, EnabledExperiments.Value));
                         else
-                            objects.AddRange(Conversions.CreateTapNote(original, path, random, EnabledExperiments));
+                            objects.AddRange(Conversions.CreateTapNote(original, path, random, EnabledExperiments.Value));
                         break;
                 }
 

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
@@ -16,6 +16,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         twins = 1,
         touch = 2,
         randomTouch = 4,
+        patternv2 = 8
     }
 
     public class SentakkiBeatmapConverter : BeatmapConverter<SentakkiHitObject>
@@ -46,6 +47,8 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 
             int path = newPos.GetDegreesFromPosition(CENTRE_POINT).GetNotePathFromDegrees();
             List<SentakkiHitObject> objects = new List<SentakkiHitObject>();
+
+
 
             switch (original)
             {

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
@@ -1,4 +1,4 @@
-﻿using osu.Game.Beatmaps;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -15,8 +15,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         none = 0,
         twins = 1,
         touch = 2,
-        randomTouch = 4,
-        patternv2 = 8
+        patternv2 = 4
     }
 
     public class SentakkiBeatmapConverter : BeatmapConverter<SentakkiHitObject>
@@ -70,7 +69,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                         break;
 
                     default:
-                        if (EnabledExperiments.HasFlag(ConversionExperiments.touch) || (EnabledExperiments.HasFlag(ConversionExperiments.randomTouch) && (random2.Next() % 10 == 0)))
+                        if (EnabledExperiments.HasFlag(ConversionExperiments.touch) && (random2.Next() % 10 == 0))
                             objects.AddRange(Conversions.CreateTouchNote(original, path, random, EnabledExperiments));
                         else
                             objects.AddRange(Conversions.CreateTapNote(original, path, random, EnabledExperiments));

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
@@ -56,7 +56,9 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             {
                 if ((original as IHasCombo).NewCombo)
                     patternGen.CreateNewPattern();
-                yield return patternGen.GenerateNewNote(original);
+
+                foreach (var note in patternGen.GenerateNewNote(original).ToList())
+                    yield return note;
             }
             else
             {

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
@@ -1,0 +1,67 @@
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.UI;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osuTK;
+using osuTK.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Audio;
+using osu.Game.Beatmaps.ControlPoints;
+using System.Diagnostics;
+using System.Threading;
+
+namespace osu.Game.Rulesets.Sentakki.Beatmaps
+{
+    public class SentakkiPatternGenerator
+    {
+        private readonly Random rng;
+        public SentakkiPatternGenerator(IBeatmap beatmap)
+        {
+            var difficulty = beatmap.BeatmapInfo.BaseDifficulty;
+            int seed = ((int)MathF.Round(difficulty.DrainRate + difficulty.CircleSize) * 20) + (int)(difficulty.OverallDifficulty * 41.2) + (int)MathF.Round(difficulty.ApproachRate);
+            rng = new Random(seed);
+        }
+
+
+        //The patterns will generate the note path to be used based on the current offset
+        // argument list is (offset, diff)
+        private List<Func<int>> patternlist => new List<Func<int>>{
+            //Stream pattern, path difference determined by offset2
+            ()=> {
+                offset+=offset2;
+                return offset%8;
+            },
+        };
+        private int currentPattern = 0;
+        private int offset = 0;
+        private int offset2 = 0;
+
+        public void CreateNewPattern()
+        {
+            currentPattern = rng.Next(0, patternlist.Count); // Pick a pattern
+            offset = rng.Next(0, 8); // Give it a random offset for variety
+            offset2 = rng.Next(0, 7); // Give it a random offset for variety
+        }
+        public SentakkiHitObject GenerateNewNote(HitObject original)
+        {
+            int notePath = patternlist[currentPattern].Invoke();
+            switch (original)
+            {
+                default:
+                    return new Tap
+                    {
+                        NoteColor = Color4.Orange,
+                        Angle = notePath.GetAngleFromPath(),
+                        Samples = original.Samples,
+                        StartTime = original.StartTime,
+                        EndPosition = SentakkiExtensions.GetPosition(SentakkiPlayfield.INTERSECTDISTANCE, notePath),
+                        Position = SentakkiExtensions.GetPosition(SentakkiPlayfield.NOTESTARTDISTANCE, notePath),
+                    };
+            }
+
+        }
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         {
             currentPattern = rng.Next(0, patternlist.Count); // Pick a pattern
             offset = rng.Next(0, 8); // Give it a random offset for variety
-            offset2 = rng.Next(-3, 4); // Give it a random offset for variety
+            offset2 = rng.Next(-2, 3); // Give it a random offset for variety
         }
         public SentakkiHitObject GenerateNewNote(HitObject original)
         {

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
@@ -55,6 +55,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         public SentakkiHitObject GenerateNewNote(HitObject original)
         {
             int notePath = patternlist[currentPattern].Invoke();
+
             switch (original)
             {
                 case IHasPathWithRepeats hold:
@@ -73,7 +74,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 
                 default:
                     if (original.Samples.Any(s => s.Name == HitSampleInfo.HIT_FINISH))
-                    {
                         return new Break
                         {
                             NoteColor = Color4.OrangeRed,
@@ -83,7 +83,19 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                             EndPosition = SentakkiExtensions.GetPosition(SentakkiPlayfield.INTERSECTDISTANCE, notePath),
                             Position = SentakkiExtensions.GetPosition(SentakkiPlayfield.NOTESTARTDISTANCE, notePath),
                         };
+                    if (original.Samples.Any(s => s.Name == HitSampleInfo.HIT_WHISTLE))
+                    {
+                        Vector2 newPos = (original as IHasPosition)?.Position ?? Vector2.Zero;
+                        newPos = new Vector2((newPos.X / 512 * 400) - 200, (newPos.Y / 384 * 400) - 200);
+                        return new Touch
+                        {
+                            NoteColor = Color4.Cyan,
+                            Samples = original.Samples,
+                            StartTime = original.StartTime,
+                            Position = newPos
+                        };
                     }
+
                     return new Tap
                     {
                         NoteColor = Color4.Orange,

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
@@ -72,6 +72,18 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                     return Conversions.CreateTouchHold(original);
 
                 default:
+                    if (original.Samples.Any(s => s.Name == HitSampleInfo.HIT_FINISH))
+                    {
+                        return new Break
+                        {
+                            NoteColor = Color4.OrangeRed,
+                            Angle = notePath.GetAngleFromPath(),
+                            Samples = original.Samples,
+                            StartTime = original.StartTime,
+                            EndPosition = SentakkiExtensions.GetPosition(SentakkiPlayfield.INTERSECTDISTANCE, notePath),
+                            Position = SentakkiExtensions.GetPosition(SentakkiPlayfield.NOTESTARTDISTANCE, notePath),
+                        };
+                    }
                     return new Tap
                     {
                         NoteColor = Color4.Orange,
@@ -82,7 +94,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                         Position = SentakkiExtensions.GetPosition(SentakkiPlayfield.NOTESTARTDISTANCE, notePath),
                     };
             }
-
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
@@ -54,14 +54,14 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             offset = rng.Next(0, 8); // Give it a random offset for variety
             offset2 = rng.Next(-2, 3); // Give it a random offset for variety
         }
-        public SentakkiHitObject GenerateNewNote(HitObject original)
+        public IEnumerable<SentakkiHitObject> GenerateNewNote(HitObject original)
         {
             int notePath = patternlist[currentPattern].Invoke();
 
             switch (original)
             {
                 case IHasPathWithRepeats hold:
-                    return new Hold
+                    yield return new Hold
                     {
                         NoteColor = Color4.Crimson,
                         Angle = notePath.GetAngleFromPath(),
@@ -71,12 +71,14 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                         EndPosition = SentakkiExtensions.GetPosition(SentakkiPlayfield.INTERSECTDISTANCE, notePath),
                         Position = SentakkiExtensions.GetPosition(SentakkiPlayfield.NOTESTARTDISTANCE, notePath),
                     };
+                    break;
                 case IHasDuration _:
-                    return Conversions.CreateTouchHold(original);
+                    yield return Conversions.CreateTouchHold(original);
+                    break;
 
                 default:
                     if (original.Samples.Any(s => s.Name == HitSampleInfo.HIT_FINISH))
-                        return new Break
+                        yield return new Break
                         {
                             NoteColor = Color4.OrangeRed,
                             Angle = notePath.GetAngleFromPath(),
@@ -89,7 +91,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                     {
                         Vector2 newPos = (original as IHasPosition)?.Position ?? Vector2.Zero;
                         newPos = new Vector2((newPos.X / 512 * 400) - 200, (newPos.Y / 384 * 400) - 200);
-                        return new Touch
+                        yield return new Touch
                         {
                             NoteColor = Color4.Cyan,
                             Samples = original.Samples,
@@ -98,7 +100,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                         };
                     }
 
-                    return new Tap
+                    yield return new Tap
                     {
                         NoteColor = Color4.Orange,
                         Angle = notePath.GetAngleFromPath(),
@@ -107,6 +109,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                         EndPosition = SentakkiExtensions.GetPosition(SentakkiPlayfield.INTERSECTDISTANCE, notePath),
                         Position = SentakkiExtensions.GetPosition(SentakkiPlayfield.NOTESTARTDISTANCE, notePath),
                     };
+                    break;
             }
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
@@ -64,7 +64,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 
         public IEnumerable<SentakkiHitObject> GenerateNewNote(HitObject original)
         {
-            int notePath = getNewPath();
             switch (original)
             {
                 case IHasPathWithRepeats hold:

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
@@ -1,3 +1,4 @@
+using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.UI;
@@ -17,6 +18,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 {
     public class SentakkiPatternGenerator
     {
+        public Bindable<ConversionExperiments> Experiments = new Bindable<ConversionExperiments>();
         private readonly Random rng;
         public SentakkiPatternGenerator(IBeatmap beatmap)
         {
@@ -83,7 +85,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                             EndPosition = SentakkiExtensions.GetPosition(SentakkiPlayfield.INTERSECTDISTANCE, notePath),
                             Position = SentakkiExtensions.GetPosition(SentakkiPlayfield.NOTESTARTDISTANCE, notePath),
                         };
-                    if (original.Samples.Any(s => s.Name == HitSampleInfo.HIT_WHISTLE))
+                    if (Experiments.Value.HasFlag(ConversionExperiments.touch) && original.Samples.Any(s => s.Name == HitSampleInfo.HIT_WHISTLE))
                     {
                         Vector2 newPos = (original as IHasPosition)?.Position ?? Vector2.Zero;
                         newPos = new Vector2((newPos.X / 512 * 400) - 200, (newPos.Y / 384 * 400) - 200);

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
@@ -1,4 +1,4 @@
-﻿using osu.Game.Beatmaps;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Sentakki.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Framework.Graphics.Sprites;
@@ -25,28 +25,18 @@ namespace osu.Game.Rulesets.Sentakki.Mods
 
         public override double ScoreMultiplier => 1.00;
 
-        [SettingSource("Enable twin notes", "Allow more than one note to share the same times")]
+        [SettingSource("Twin notes", "Allow more than one note to share the same times")]
         public BindableBool EnableTwins { get; } = new BindableBool
         {
             Default = false,
             Value = false
         };
 
-        public enum TouchOptions
+        [SettingSource("Touch notes", "Allow TOUCHs to appear")]
+        public BindableBool EnableTouch { get; } = new BindableBool
         {
-            [Description("Off")]
-            none,
-            [Description("Replace all taps")]
-            replace,
-            [Description("Replace some taps")]
-            random,
-        }
-
-        [SettingSource("Touch notes", "Allow TOUCHs to replace taps for testing")]
-        public Bindable<TouchOptions> EnableTouch { get; } = new Bindable<TouchOptions>
-        {
-            Default = TouchOptions.none,
-            Value = TouchOptions.none,
+            Default = false,
+            Value = false,
         };
 
         [SettingSource("Use pattern generator for osu converts", "Use a pattern generator to generate convert beatmaps")]
@@ -61,10 +51,8 @@ namespace osu.Game.Rulesets.Sentakki.Mods
             if (EnableTwins.Value)
                 (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments |= ConversionExperiments.twins;
 
-            if (EnableTouch.Value == TouchOptions.replace)
+            if (EnableTouch.Value)
                 (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments |= ConversionExperiments.touch;
-            else if (EnableTouch.Value == TouchOptions.random)
-                (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments |= ConversionExperiments.randomTouch;
 
             if (EnablePatternGen.Value)
                 (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments |= ConversionExperiments.patternv2;

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
@@ -56,7 +56,6 @@ namespace osu.Game.Rulesets.Sentakki.Mods
 
             if (EnablePatternGen.Value)
                 (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments.Value |= ConversionExperiments.patternv2;
-
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
@@ -1,4 +1,4 @@
-using osu.Game.Beatmaps;
+﻿using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Sentakki.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Framework.Graphics.Sprites;
@@ -49,13 +49,13 @@ namespace osu.Game.Rulesets.Sentakki.Mods
         public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)
         {
             if (EnableTwins.Value)
-                (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments |= ConversionExperiments.twins;
+                (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments.Value |= ConversionExperiments.twins;
 
             if (EnableTouch.Value)
-                (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments |= ConversionExperiments.touch;
+                (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments.Value |= ConversionExperiments.touch;
 
             if (EnablePatternGen.Value)
-                (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments |= ConversionExperiments.patternv2;
+                (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments.Value |= ConversionExperiments.patternv2;
 
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
@@ -36,14 +36,14 @@ namespace osu.Game.Rulesets.Sentakki.Mods
         public BindableBool EnableTouch { get; } = new BindableBool
         {
             Default = false,
-            Value = false,
+            Value = true,
         };
 
         [SettingSource("Use pattern generator for osu converts", "Use a pattern generator to generate convert beatmaps")]
         public BindableBool EnablePatternGen { get; } = new BindableBool
         {
             Default = false,
-            Value = false
+            Value = true
         };
 
         public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
@@ -49,6 +49,13 @@ namespace osu.Game.Rulesets.Sentakki.Mods
             Value = TouchOptions.none,
         };
 
+        [SettingSource("Use pattern generator for osu converts", "Use a pattern generator to generate convert beatmaps")]
+        public BindableBool EnablePatternGen { get; } = new BindableBool
+        {
+            Default = false,
+            Value = false
+        };
+
         public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)
         {
             if (EnableTwins.Value)
@@ -58,6 +65,10 @@ namespace osu.Game.Rulesets.Sentakki.Mods
                 (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments |= ConversionExperiments.touch;
             else if (EnableTouch.Value == TouchOptions.random)
                 (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments |= ConversionExperiments.randomTouch;
+
+            if (EnablePatternGen.Value)
+                (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments |= ConversionExperiments.patternv2;
+
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
@@ -1,4 +1,4 @@
-﻿using osu.Game.Rulesets.Sentakki.UI;
+using osu.Game.Rulesets.Sentakki.UI;
 using osuTK;
 using System;
 
@@ -6,7 +6,12 @@ namespace osu.Game.Rulesets.Sentakki
 {
     public static class SentakkiExtensions
     {
-        public static float GetAngleFromPath(this int path) => SentakkiPlayfield.PATHANGLES[path];
+        public static float GetAngleFromPath(this int path)
+        {
+            while (path < 0) path += 8;
+            path %= 8;
+            return SentakkiPlayfield.PATHANGLES[path];
+        }
         public static Vector2 GetPosition(float distance, int path)
         {
             return new Vector2(-(distance * (float)Math.Cos((path.GetAngleFromPath() + 90f) * (float)(Math.PI / 180))), -(distance * (float)Math.Sin((path.GetAngleFromPath() + 90f) * (float)(Math.PI / 180))));


### PR DESCRIPTION
This pattern generator aims to generate beatmaps with more pattern variety, while making it closer to how maimai charts are made.

Currently this can be enabled within the `Experimental` mod options, and contains the following note patterns:
1. Stream
2. Back and forth

The pattern generator takes a consistent seed created from the beatmap difficulty values, and randomly generates the beatmap. The generator will pick another pattern every new combo, and generates all notes within that combo based on the selected pattern.

A lot of methods with duplicate functionality are left as I don't want to break old functionality yet.
Also replaced the dropdown for touch notes experiment with a simple toggle, since I don't think anyone would want to replace all taps.