### PR TITLE
Tweak default note colours

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneBreakNote.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneBreakNote.cs
@@ -37,7 +37,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
                 Position = new Vector2(0, -66f),
                 Angle = 0,
                 EndPosition = new Vector2(0, -296.5f),
-                NoteColor = Color4.OrangeRed,
             };
 
             circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneHoldNote.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneHoldNote.cs
@@ -48,7 +48,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
                 Position = new Vector2(0, -66),
                 EndPosition = new Vector2(0, -296.5f),
                 Angle = 0f,
-                NoteColor = Color4.Crimson,
             };
 
             circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneTapNote.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneTapNote.cs
@@ -37,7 +37,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
                 Position = new Vector2(0, -66f),
                 Angle = 0,
                 EndPosition = new Vector2(0, -296.5f),
-                NoteColor = Color4.Orange,
             };
 
             circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneTouchNote.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneTouchNote.cs
@@ -38,7 +38,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
             {
                 StartTime = Time.Current + 1000,
                 Position = Vector2.Zero,
-                NoteColor = Color4.Cyan,
             };
 
             circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiNoteConversions.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiNoteConversions.cs
@@ -27,7 +27,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             {
                 notes.Add(new Break
                 {
-                    NoteColor = Color4.OrangeRed,
                     Angle = path.GetAngleFromPath(),
                     Samples = original.Samples,
                     StartTime = original.StartTime,
@@ -40,7 +39,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                     while (path == newPath) newPath = rng.Next(0, 8);
                     notes.Add(new Break
                     {
-                        NoteColor = Color4.OrangeRed,
                         Angle = newPath.GetAngleFromPath(),
                         Samples = original.Samples,
                         StartTime = original.StartTime,
@@ -53,7 +51,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             {
                 notes.Add(new Tap
                 {
-                    NoteColor = Color4.Orange,
                     Angle = path.GetAngleFromPath(),
                     Samples = original.Samples,
                     StartTime = original.StartTime,
@@ -66,7 +63,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                     while (path == newPath) newPath = rng.Next(0, 8);
                     notes.Add(new Tap
                     {
-                        NoteColor = Color4.Orange,
                         Angle = newPath.GetAngleFromPath(),
                         Samples = original.Samples,
                         StartTime = original.StartTime,
@@ -86,7 +82,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 
             List<SentakkiHitObject> notes = new List<SentakkiHitObject>{new Touch
             {
-                NoteColor = Color4.Cyan,
                 Samples = original.Samples,
                 StartTime = original.StartTime,
                 Position = newPos,
@@ -113,7 +108,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 
             notes.Add(new Hold
             {
-                NoteColor = Color4.Crimson,
                 Angle = path.GetAngleFromPath(),
                 NodeSamples = curveData.NodeSamples,
                 StartTime = original.StartTime,
@@ -130,7 +124,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                     while (path == newPath) newPath = rng.Next(0, 8);
                     notes.Add(new Hold
                     {
-                        NoteColor = Color4.Crimson,
                         Angle = newPath.GetAngleFromPath(),
                         NodeSamples = curveData.NodeSamples,
                         StartTime = original.StartTime,
@@ -184,7 +177,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                     case SliderEventType.Repeat:
                         hitObjects.Add(new Tap
                         {
-                            NoteColor = Color4.Orange,
                             Angle = newPath.GetAngleFromPath(),
                             Samples = getTickSamples(original.Samples),
                             StartTime = e.Time,

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
@@ -110,7 +110,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             int notePath = getNewPath(twin);
             return new Hold
             {
-                NoteColor = Color4.Crimson,
                 Angle = notePath.GetAngleFromPath(),
                 NodeSamples = (original as IHasPathWithRepeats).NodeSamples,
                 StartTime = original.StartTime,
@@ -151,7 +150,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                     case SliderEventType.Repeat:
                         yield return new Tap
                         {
-                            NoteColor = Color4.Orange,
                             Angle = notePath.GetAngleFromPath(),
                             Samples = original.Samples.Select(s => new HitSampleInfo
                             {
@@ -174,7 +172,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             int notePath = getNewPath(twin);
             return new T
             {
-                NoteColor = (typeof(T) == typeof(Break)) ? Color4.OrangeRed : Color4.Orange,
                 Angle = notePath.GetAngleFromPath(),
                 Samples = original.Samples,
                 StartTime = original.StartTime,
@@ -189,7 +186,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             newPos = new Vector2((newPos.X / 512 * 400) - 200, (newPos.Y / 384 * 400) - 200);
             return new Touch
             {
-                NoteColor = Color4.Cyan,
                 Samples = original.Samples,
                 StartTime = original.StartTime,
                 Position = newPos

--- a/osu.Game.Rulesets.Sentakki/Objects/Break.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Break.cs
@@ -2,11 +2,13 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.Judgements;
 using osu.Game.Rulesets.Sentakki.Scoring;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.Objects
 {
     public class Break : Tap
     {
+        public override Color4 NoteColor { get; set; } = Color4.OrangeRed;
         public override Judgement CreateJudgement() => new SentakkiBreakJudgement();
         protected override HitWindows CreateHitWindows() => new SentakkiHitWindows();
     }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -64,6 +64,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         beginHoldAt(Time.Current - Head.HitObject.StartTime);
                         Head.UpdateResult();
 
+                        note.Glow.FadeIn(50);
+
                         return true;
                     },
                     Release = () =>
@@ -74,6 +76,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         Tail.UpdateResult();
                         HoldStartTime = null;
                         isHitting.Value = false;
+                        note.Glow.FadeOut(100);
                     },
                     NoteAngle = HitObject.Angle
                 }
@@ -212,14 +215,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             HitObjectLine.UpdateVisual(totalMove);
 
-            // Hit feedback glow
-            if (Time.Current >= HitObject.StartTime)
-            {
-                if (isHitting.Value || Auto)
-                    note.Glow.FadeIn(50);
-                else
-                    note.Glow.FadeOut(100);
-            }
+            // Auto should trigger a hit, just so it visually looks the same
+            if (Auto && Time.Current >= HitObject.StartTime)
+                HitArea.Hit.Invoke();
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -61,10 +61,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     Hit = () => {
                         if (AllJudged || HoldStartTime != null)
                             return false;
-                        beginHoldAt(Time.Current - Head.HitObject.StartTime);
-                        Head.UpdateResult();
 
-                        note.Glow.FadeIn(50);
+                        if(beginHoldAt(Time.Current - Head.HitObject.StartTime))
+                        {
+                            Head.UpdateResult();
+                            note.Glow.FadeIn(50);
+                        }
 
                         return true;
                     },
@@ -259,13 +261,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             }
         }
 
-        private void beginHoldAt(double timeOffset)
+        private bool beginHoldAt(double timeOffset)
         {
             if (timeOffset < -Head.HitObject.HitWindows.WindowFor(HitResult.Miss))
-                return;
+                return false;
 
             HoldStartTime = Time.Current;
             isHitting.Value = true;
+            return true;
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -81,11 +81,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                                 AlwaysPresent = true,
                             }
                         },
-                        new CircularContainer
+                        new Container
                         {
+                            Masking = true,
+                            CornerExponent = 2.5f,
+                            CornerRadius = 5f,
+                            Rotation = 45,
                             Position = new Vector2(0, -40),
                             Size = new Vector2(20),
-                            Masking = true,
                             BorderColour = Color4.Gray,
                             BorderThickness = 2,
                             Anchor = Anchor.BottomCentre,
@@ -97,11 +100,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                                 Colour = Color4.White,
                             }
                         },
-                        new CircularContainer
+                        new Container
                         {
+                            Masking = true,
+                            CornerExponent = 2.5f,
+                            CornerRadius = 5f,
+                            Rotation = 45,
                             Position = new Vector2(0, 40),
                             Size = new Vector2(20),
-                            Masking = true,
                             BorderColour = Color4.Gray,
                             BorderThickness = 2,
                             Anchor = Anchor.TopCentre,

--- a/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
@@ -5,10 +5,14 @@ using osu.Game.Rulesets.Scoring;
 using System.Collections.Generic;
 using System.Linq;
 using osuTK;
+using osuTK.Graphics;
+
 namespace osu.Game.Rulesets.Sentakki.Objects
 {
     public class Hold : SentakkiHitObject, IHasDuration
     {
+        public override Color4 NoteColor { get; set; } = Color4.Crimson;
+
         private List<IList<HitSampleInfo>> nodeSamples = new List<IList<HitSampleInfo>>();
 
         public List<IList<HitSampleInfo>> NodeSamples

--- a/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 {
     public class Hold : SentakkiHitObject, IHasDuration
     {
-        public override Color4 NoteColor { get; set; } = Color4.Crimson;
+        public override Color4 NoteColor { get; set; } = Color4.Orange;
 
         private List<IList<HitSampleInfo>> nodeSamples = new List<IList<HitSampleInfo>>();
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
@@ -11,8 +11,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 {
     public class Hold : SentakkiHitObject, IHasDuration
     {
-        public override Color4 NoteColor { get; set; } = Color4.Orange;
-
         private List<IList<HitSampleInfo>> nodeSamples = new List<IList<HitSampleInfo>>();
 
         public List<IList<HitSampleInfo>> NodeSamples

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
     {
         public override Judgement CreateJudgement() => new SentakkiJudgement();
 
-        public Color4 NoteColor { get; set; }
+        public virtual Color4 NoteColor { get; set; } = Color4.Orange;
         public virtual Vector2 EndPosition { get; set; }
         public virtual float Angle { get; set; }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
@@ -5,6 +5,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Objects;
 using osuTK;
 using osuTK.Graphics;
+using osu.Framework.Extensions.Color4Extensions;
 
 namespace osu.Game.Rulesets.Sentakki.Objects
 {
@@ -12,7 +13,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
     {
         public override Judgement CreateJudgement() => new SentakkiJudgement();
 
-        public virtual Color4 NoteColor { get; set; } = Color4.Orange;
+        public virtual Color4 NoteColor { get; set; } = Color4Extensions.FromHex("ff0064");
         public virtual Vector2 EndPosition { get; set; }
         public virtual float Angle { get; set; }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Touch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Touch.cs
@@ -1,10 +1,13 @@
 using osu.Game.Rulesets.Sentakki.Scoring;
 using osu.Game.Rulesets.Scoring;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.Objects
 {
     public class Touch : SentakkiHitObject
     {
+        public override Color4 NoteColor { get; set; } = Color4.Cyan;
+
         public override float Angle => 0;
 
         // This is not actually used during the result check, since all valid hits result in a perfect judgement


### PR DESCRIPTION
Hold notes now share the same colour as Taps. To slightly help with differentiating Holds and Taps, the dots in hold notes are now squares.

Twins are given a brighter Gold colour compared to normal notes, matching maimai. Twin breaks unaffected.