### PR TITLE
Make obtainable TOUCHHOLD judgements much clearer

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -10,6 +10,7 @@ using osu.Game.Graphics;
 using osuTK;
 using osuTK.Graphics;
 using System.Linq;
+using osu.Framework.Graphics.Effects;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
@@ -126,22 +127,30 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     timeHeld += Clock.ElapsedFrameTime;
                     double progress = timeHeld / (HitObject as IHasDuration).Duration;
                     Color4 newColor = Color4.HotPink;
+                    var newEdge = circle.GlowEdgeEffect.Value;
                     if (progress > .2f)
                     {
                         amount += .033f;
                         newColor = colours.ForHitResult(HitResult.Meh);
+                        newEdge.Colour = colours.ForHitResult(HitResult.Meh);
+                        newEdge.Radius = 25;
                     }
 
                     if (progress > .5f)
                     {
                         amount += .033f;
                         newColor = colours.ForHitResult(HitResult.Good);
+                        newEdge.Colour = colours.ForHitResult(HitResult.Good);
+                        newEdge.Radius = 35;
                     }
                     if (progress > .8f)
                     {
                         amount += .034f;
                         newColor = colours.ForHitResult(HitResult.Great);
+                        newEdge.Colour = colours.ForHitResult(HitResult.Great);
+                        newEdge.Radius = 45;
                     }
+                    circle.GlowEdgeEffect.Value = newEdge;
 
                     this.TransformTo(nameof(currentColour), newColor, 100);
                     circle.FadeTo(amount, 100);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -58,11 +58,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             {
                 if (result >= .9)
                     r.Type = HitResult.Perfect;
-                else if (result >= .8)
+                else if (result >= .75)
                     r.Type = HitResult.Great;
                 else if (result >= .5)
                     r.Type = HitResult.Good;
-                else if (result >= .2)
+                else if (result >= .25)
                     r.Type = HitResult.Ok;
                 else if (Time.Current >= (HitObject as IHasDuration)?.EndTime)
                     r.Type = HitResult.Miss;
@@ -128,7 +128,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     double progress = timeHeld / (HitObject as IHasDuration).Duration;
                     Color4 newColor = Color4.HotPink;
                     var newEdge = circle.GlowEdgeEffect.Value;
-                    if (progress > .2f)
+                    if (progress > .25f)
                     {
                         amount += .033f;
                         newColor = colours.ForHitResult(HitResult.Meh);
@@ -143,7 +143,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         newEdge.Colour = colours.ForHitResult(HitResult.Good);
                         newEdge.Radius = 35;
                     }
-                    if (progress > .8f)
+                    if (progress > .75f)
                     {
                         amount += .034f;
                         newColor = colours.ForHitResult(HitResult.Great);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -44,6 +44,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         private double timeHeld = 0;
         private bool buttonHeld = false;
 
+        // This is used to reset the animation I used to achieve the judgement feedback.
+        private bool needReset = false;
+
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             if (Time.Current < HitObject.StartTime) return;
@@ -67,6 +70,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 else if (Time.Current >= (HitObject as IHasDuration)?.EndTime)
                     r.Type = HitResult.Miss;
             });
+            needReset = true;
         }
 
         private readonly Bindable<double> touchAnimationDuration = new Bindable<double>(1000);
@@ -85,10 +89,24 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             set => AccentColour.Value = value;
         }
 
+        /// <summary>
+        /// Time at which the user started holding this hold note. Null if the user is not holding this hold note.
+        /// </summary>
+        public double? HoldStartTime { get; private set; }
+
         protected override void Update()
         {
             base.Update();
             if (Result.HasResult) return;
+            if (needReset)
+            {
+                var newEdge = circle.GlowEdgeEffect.Value;
+                circle.Size = Vector2.One;
+                newEdge.Radius = 15;
+                circle.GlowEdgeEffect.Value = newEdge;
+                currentColour = Color4.HotPink;
+                needReset = false;
+            }
 
             double fadeIn = touchAnimationDuration.Value * GameplaySpeed;
             double animStart = HitObject.StartTime - fadeIn;
@@ -124,45 +142,54 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 if (activated || Auto)
                 {
                     float amount = 1f;
+                    double prevProg = timeHeld / (HitObject as IHasDuration).Duration;
                     timeHeld += Clock.ElapsedFrameTime;
                     double progress = timeHeld / (HitObject as IHasDuration).Duration;
-                    Color4 newColor = Color4.HotPink;
-                    var newEdge = circle.GlowEdgeEffect.Value;
-                    if (progress > .25f)
+
+                    if (progress >= .25f && prevProg < .25f)
                     {
-                        amount += .033f;
-                        newColor = colours.ForHitResult(HitResult.Meh);
-                        newEdge.Colour = colours.ForHitResult(HitResult.Meh);
+                        var newEdge = circle.GlowEdgeEffect.Value;
+                        circle.ResizeTo(1.033f, 100);
                         newEdge.Radius = 25;
+                        circle.GlowEdgeEffect.Value = newEdge;
+                        this.TransformTo(nameof(currentColour), colours.ForHitResult(HitResult.Meh), 100);
                     }
 
-                    if (progress > .5f)
+                    else if (progress >= .50f && prevProg < .50f)
                     {
-                        amount += .033f;
-                        newColor = colours.ForHitResult(HitResult.Good);
-                        newEdge.Colour = colours.ForHitResult(HitResult.Good);
+                        var newEdge = circle.GlowEdgeEffect.Value;
+                        circle.ResizeTo(1.066f, 100);
                         newEdge.Radius = 35;
+                        circle.GlowEdgeEffect.Value = newEdge;
+                        this.TransformTo(nameof(currentColour), colours.ForHitResult(HitResult.Good), 100);
                     }
-                    if (progress > .75f)
+                    else if (progress >= .75f && prevProg < .75f)
                     {
-                        amount += .034f;
-                        newColor = colours.ForHitResult(HitResult.Great);
-                        newEdge.Colour = colours.ForHitResult(HitResult.Great);
+                        var newEdge = circle.GlowEdgeEffect.Value;
+                        circle.ResizeTo(1.1f, 100);
                         newEdge.Radius = 45;
+                        circle.GlowEdgeEffect.Value = newEdge;
+                        this.TransformTo(nameof(currentColour), colours.ForHitResult(HitResult.Great), 100);
                     }
-                    circle.GlowEdgeEffect.Value = newEdge;
 
-                    this.TransformTo(nameof(currentColour), newColor, 100);
-                    circle.FadeTo(amount, 100);
-                    circle.ScaleTo(amount, 100);
+                    if (HoldStartTime == null)
+                    {
+                        circle.FadeTo(amount, 100);
+                        circle.ScaleTo(amount, 100);
+                        HoldStartTime = Clock.CurrentTime;
+                    }
                 }
                 else
                 {
-                    circle.FadeTo(.5f, 100);
-                    circle.ScaleTo(.8f, 200);
+                    if (HoldStartTime != null)
+                    {
+                        circle.FadeTo(.5f, 100);
+                        circle.ScaleTo(.8f, 200);
+                        HoldStartTime = Clock.CurrentTime;
+                    }
                 }
-                base.Update();
             }
+            base.Update();
         }
 
         protected override void UpdateStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -155,7 +155,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     this.TransformTo(nameof(currentColour), newColor, 100);
                     circle.FadeTo(amount, 100);
                     circle.ScaleTo(amount, 100);
-                    circle.Glow.FadeTo((amount - .9f) * 5, 100);
                 }
                 else
                 {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
@@ -11,6 +11,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
 using osuTK.Graphics;
+using osu.Framework.Graphics.Effects;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 {
@@ -40,7 +41,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             InternalChildren = new Drawable[]
             {
                 Glow = new GlowPiece(){
-                    Alpha = 0f,
+                    Alpha = .5f,
                 },
                 ring = new CircularContainer
                 {
@@ -139,6 +140,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             {
                 explode.Colour = colour.NewValue;
                 Glow.Colour = colour.NewValue;
+                if (Glow.Children.Count > 0)
+                    (Glow.Child as CircularContainer).EdgeEffect = new EdgeEffectParameters
+                    {
+                        Hollow = true,
+                        Type = EdgeEffectType.Glow,
+                        Radius = 15,
+                        Colour = colour.NewValue,
+                    };
                 Progress.Colour = colour.NewValue;
                 fillCircle.Colour = colour.NewValue;
             }, true);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
@@ -160,8 +160,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 
         private void updateState(ValueChangedEvent<ArmedState> state)
         {
-
-
             switch (state.NewValue)
             {
                 case ArmedState.Hit:

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
@@ -126,6 +126,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 
         private readonly IBindable<ArmedState> state = new Bindable<ArmedState>();
         private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
+        public readonly Bindable<EdgeEffectParameters> GlowEdgeEffect = new Bindable<EdgeEffectParameters>(new EdgeEffectParameters
+        {
+            Hollow = true,
+            Type = EdgeEffectType.Glow,
+            Radius = 15,
+            Colour = Color4.HotPink,
+        });
 
         [BackgroundDependencyLoader]
         private void load(TextureStore textures, DrawableHitObject drawableObject)
@@ -140,17 +147,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             {
                 explode.Colour = colour.NewValue;
                 Glow.Colour = colour.NewValue;
-                if (Glow.Children.Count > 0)
-                    (Glow.Child as CircularContainer).EdgeEffect = new EdgeEffectParameters
-                    {
-                        Hollow = true,
-                        Type = EdgeEffectType.Glow,
-                        Radius = 15,
-                        Colour = colour.NewValue,
-                    };
                 Progress.Colour = colour.NewValue;
                 fillCircle.Colour = colour.NewValue;
             }, true);
+
+            GlowEdgeEffect.BindValueChanged(value => { if (Glow.Children.Count > 0) (Glow.Child as CircularContainer).EdgeEffect = value.NewValue; }, true);
         }
 
         private void updateState(ValueChangedEvent<ArmedState> state)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
@@ -156,13 +156,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 
         private void updateState(ValueChangedEvent<ArmedState> state)
         {
-            Glow.FadeOut(400);
+
 
             switch (state.NewValue)
             {
                 case ArmedState.Hit:
                     const double flash_in = 40;
                     const double flash_out = 100;
+                    Glow.Delay(Duration).FadeOut(400);
 
                     flash.Delay(Duration).FadeTo(0.8f, flash_in)
                          .Then()

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
@@ -149,6 +149,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                 Glow.Colour = colour.NewValue;
                 Progress.Colour = colour.NewValue;
                 fillCircle.Colour = colour.NewValue;
+                // EdgeColor
+                var newEdge = GlowEdgeEffect.Value;
+                newEdge.Colour = colour.NewValue;
+                GlowEdgeEffect.Value = newEdge;
             }, true);
 
             GlowEdgeEffect.BindValueChanged(value => { if (Glow.Children.Count > 0) (Glow.Child as CircularContainer).EdgeEffect = value.NewValue; }, true);


### PR DESCRIPTION
Internally TOUCHHOLDS keep track of how much of its lifespan was held down, but gave no feedback to the player on what judgement they could get.

This change makes the hold note change color whenever a judgement threshold is passed, changing to the appropriate judgement color.