### PR TITLE
Replace note glow with a drop shadow

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -219,9 +219,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             HitObjectLine.UpdateVisual(totalMove);
 
-            // Auto should trigger a hit, just so it visually looks the same
-            if (Auto && Time.Current >= HitObject.StartTime)
-                HitArea.Hit.Invoke();
+            // Auto should pretend to trigger a hit, just so it visually looks the same even if the note is guaranteed to give a perfect judgement
+            if (Auto)
+                if (Time.Current >= HitObject.StartTime)
+                    HitArea.Hit.Invoke();
+                else
+                    HitArea.Release.Invoke(); //Make sure note is released...To avoid autoplay rewind visual issue.
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -100,12 +100,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             if (Result.HasResult) return;
             if (needReset)
             {
-                var newEdge = circle.GlowEdgeEffect.Value;
                 circle.Size = Vector2.One;
-                newEdge.Radius = 15;
-                circle.GlowEdgeEffect.Value = newEdge;
-                currentColour = Color4.HotPink;
-                needReset = false;
             }
 
             double fadeIn = touchAnimationDuration.Value * GameplaySpeed;
@@ -141,41 +136,31 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 bool activated = (SentakkiActionInputManager?.PressedActions.Any() ?? false) && IsHovered;
                 if (activated || Auto)
                 {
-                    float amount = 1f;
                     double prevProg = timeHeld / (HitObject as IHasDuration).Duration;
                     timeHeld += Clock.ElapsedFrameTime;
                     double progress = timeHeld / (HitObject as IHasDuration).Duration;
 
                     if (progress >= .25f && prevProg < .25f)
                     {
-                        var newEdge = circle.GlowEdgeEffect.Value;
                         circle.ResizeTo(1.033f, 100);
-                        newEdge.Radius = 25;
-                        circle.GlowEdgeEffect.Value = newEdge;
                         this.TransformTo(nameof(currentColour), colours.ForHitResult(HitResult.Meh), 100);
                     }
 
                     else if (progress >= .50f && prevProg < .50f)
                     {
-                        var newEdge = circle.GlowEdgeEffect.Value;
                         circle.ResizeTo(1.066f, 100);
-                        newEdge.Radius = 35;
-                        circle.GlowEdgeEffect.Value = newEdge;
                         this.TransformTo(nameof(currentColour), colours.ForHitResult(HitResult.Good), 100);
                     }
                     else if (progress >= .75f && prevProg < .75f)
                     {
-                        var newEdge = circle.GlowEdgeEffect.Value;
                         circle.ResizeTo(1.1f, 100);
-                        newEdge.Radius = 45;
-                        circle.GlowEdgeEffect.Value = newEdge;
                         this.TransformTo(nameof(currentColour), colours.ForHitResult(HitResult.Great), 100);
                     }
 
                     if (HoldStartTime == null)
                     {
-                        circle.FadeTo(amount, 100);
-                        circle.ScaleTo(amount, 100);
+                        circle.FadeTo(1, 100);
+                        circle.ScaleTo(1, 100);
                         HoldStartTime = Clock.CurrentTime;
                     }
                 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -98,9 +98,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.Update();
             if (Result.HasResult) return;
+            // Used to prevent rewind visual issues
             if (needReset)
             {
                 circle.Size = Vector2.One;
+                currentColour = Color4.HotPink;
+                needReset = false;
             }
 
             double fadeIn = touchAnimationDuration.Value * GameplaySpeed;
@@ -145,7 +148,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         circle.ResizeTo(1.033f, 100);
                         this.TransformTo(nameof(currentColour), colours.ForHitResult(HitResult.Meh), 100);
                     }
-
                     else if (progress >= .50f && prevProg < .50f)
                     {
                         circle.ResizeTo(1.066f, 100);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/GlowPiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/GlowPiece.cs
@@ -31,9 +31,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                 EdgeEffect = new EdgeEffectParameters
                 {
                     Hollow = true,
-                    Type = EdgeEffectType.Glow,
+                    Type = EdgeEffectType.Shadow,
                     Radius = 15,
-                    Colour = Colour,
+                    Colour = Color4.Black,
                 }
             };
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         private readonly FlashPiece flash;
         private readonly ExplodePiece explode;
         private readonly Container note;
-        public readonly GlowPiece Glow;
+        public readonly ShadowPiece Glow;
 
         public double Duration = 0;
 
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                     RelativeSizeAxes=Axes.Both,
                     Children = new Drawable[]
                     {
-                        Glow = new GlowPiece(){
+                        Glow = new ShadowPiece(){
                             Alpha = 0,
                         },
                         new CircularContainer

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -34,9 +34,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                     RelativeSizeAxes=Axes.Both,
                     Children = new Drawable[]
                     {
-                        Glow = new ShadowPiece(){
-                            Alpha = 0,
-                        },
+                        Glow = new ShadowPiece(),
                         new CircularContainer
                         {
                             RelativeSizeAxes = Axes.Both,

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         private readonly FlashPiece flash;
         private readonly ExplodePiece explode;
         private readonly Container note;
-        public readonly ShadowPiece Glow;
+        public readonly HoldGlowPiece Glow;
 
         public double Duration = 0;
 
@@ -34,7 +34,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                     RelativeSizeAxes=Axes.Both,
                     Children = new Drawable[]
                     {
-                        Glow = new ShadowPiece(),
+                        new ShadowPiece(),
+                        Glow = new HoldGlowPiece(){
+                            Alpha = 0
+                        },
                         new CircularContainer
                         {
                             RelativeSizeAxes = Axes.Both,

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldGlow.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldGlow.cs
@@ -1,0 +1,41 @@
+﻿using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
+{
+    public class HoldGlowPiece : Container
+    {
+        public HoldGlowPiece()
+        {
+            RelativeSizeAxes = Axes.Both;
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            RelativeSizeAxes = Axes.Both;
+            Padding = new MarginPadding(1);
+        }
+
+        protected override void LoadComplete()
+        {
+            Child = new CircularContainer
+            {
+                Alpha = .5f,
+                Masking = true,
+                RelativeSizeAxes = Axes.Both,
+                EdgeEffect = new EdgeEffectParameters
+                {
+                    Hollow = false,
+                    Type = EdgeEffectType.Glow,
+                    Radius = 10,
+                    Colour = Colour,
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldGlow.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldGlow.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                 {
                     Hollow = false,
                     Type = EdgeEffectType.Glow,
-                    Radius = 10,
+                    Radius = 5,
                     Colour = Colour,
                 }
             };

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/ShadowPiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/ShadowPiece.cs
@@ -1,11 +1,6 @@
-﻿using osu.Framework.Allocation;
-using osu.Framework.Bindables;
-using osu.Framework.Graphics;
+﻿using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
@@ -17,7 +12,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             RelativeSizeAxes = Axes.Both;
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
-            RelativeSizeAxes = Axes.Both;
             Padding = new MarginPadding(1);
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/ShadowPiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/ShadowPiece.cs
@@ -10,9 +10,9 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 {
-    public class GlowPiece : Container
+    public class ShadowPiece : Container
     {
-        public GlowPiece()
+        public ShadowPiece()
         {
             RelativeSizeAxes = Axes.Both;
             Anchor = Anchor.Centre;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TapCircle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TapCircle.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         private readonly CirclePiece circle;
         private readonly FlashPiece flash;
         private readonly ExplodePiece explode;
-        private readonly GlowPiece glow;
+        private readonly ShadowPiece glow;
 
         public TapCircle()
         {
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 
             InternalChildren = new Drawable[]
             {
-                glow = new GlowPiece(),
+                glow = new ShadowPiece(),
                 circle = new CirclePiece(),
                 flash = new FlashPiece(),
                 explode = new ExplodePiece(),

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchBlobs.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchBlobs.cs
@@ -3,6 +3,7 @@ using osu.Framework.Bindables;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osuTK;
 using osuTK.Graphics;
@@ -13,13 +14,34 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
     {
         public TouchBlob()
         {
-            Masking = true;
             Size = new Vector2(80);
             Scale = new Vector2(.5f);
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             Children = new Drawable[]
             {
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Padding = new MarginPadding(1),
+                    Child = new Container
+                    {
+                        Alpha = .5f,
+                        Masking = true,
+                        RelativeSizeAxes = Axes.Both,
+                        CornerRadius = 20,
+                        CornerExponent = 2.5f,
+                        EdgeEffect = new EdgeEffectParameters
+                        {
+                            Hollow = true,
+                            Type = EdgeEffectType.Shadow,
+                            Radius = 15,
+                            Colour = Color4.Black,
+                        }
+                    }
+                },
                 new Container
                 {
                     CornerRadius = 20,
@@ -36,7 +58,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                         Alpha= 0,
                         AlwaysPresent = true
                     }
-                },
+},
                 new Container
                 {
                     Masking = true,
@@ -45,7 +67,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                     Child = new Container
                     {
                         CornerRadius = 20,
-                    CornerExponent = 2.5f,
+                        CornerExponent = 2.5f,
                         RelativeSizeAxes = Axes.Both,
                         Masking = true,
                         BorderThickness = 15,
@@ -69,7 +91,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                     Child = new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Alpha= 0,
+                        Alpha = 0,
                         AlwaysPresent = true
                     }
                 },

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
@@ -18,8 +18,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
     public class TouchHoldCircle : CircularContainer
     {
         public double Duration;
-
-        public readonly ShadowPiece Glow;
         private readonly ExplodePiece explode;
         private readonly FlashPiece flash;
         public readonly CircularProgress Progress;
@@ -40,9 +38,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 
             InternalChildren = new Drawable[]
             {
-                Glow = new ShadowPiece(){
-                    Alpha = .5f,
-                },
+                new ShadowPiece(),
                 ring = new CircularContainer
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -126,13 +122,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 
         private readonly IBindable<ArmedState> state = new Bindable<ArmedState>();
         private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
-        public readonly Bindable<EdgeEffectParameters> GlowEdgeEffect = new Bindable<EdgeEffectParameters>(new EdgeEffectParameters
-        {
-            Hollow = true,
-            Type = EdgeEffectType.Shadow,
-            Radius = 15,
-            Colour = Color4.Black,
-        });
 
         [BackgroundDependencyLoader]
         private void load(TextureStore textures, DrawableHitObject drawableObject)
@@ -146,16 +135,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             accentColour.BindValueChanged(colour =>
             {
                 explode.Colour = colour.NewValue;
-                Glow.Colour = colour.NewValue;
                 Progress.Colour = colour.NewValue;
                 fillCircle.Colour = colour.NewValue;
-                // EdgeColor
-                var newEdge = GlowEdgeEffect.Value;
-                newEdge.Colour = colour.NewValue;
-                GlowEdgeEffect.Value = newEdge;
             }, true);
-
-            GlowEdgeEffect.BindValueChanged(value => { if (Glow.Children.Count > 0) (Glow.Child as CircularContainer).EdgeEffect = value.NewValue; }, true);
         }
 
         private void updateState(ValueChangedEvent<ArmedState> state)
@@ -165,7 +147,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                 case ArmedState.Hit:
                     const double flash_in = 40;
                     const double flash_out = 100;
-                    Glow.Delay(Duration).FadeOut(400);
 
                     flash.Delay(Duration).FadeTo(0.8f, flash_in)
                          .Then()

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
@@ -129,9 +129,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         public readonly Bindable<EdgeEffectParameters> GlowEdgeEffect = new Bindable<EdgeEffectParameters>(new EdgeEffectParameters
         {
             Hollow = true,
-            Type = EdgeEffectType.Glow,
+            Type = EdgeEffectType.Shadow,
             Radius = 15,
-            Colour = Color4.HotPink,
+            Colour = Color4.Black,
         });
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldCircle.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
     {
         public double Duration;
 
-        public readonly GlowPiece Glow;
+        public readonly ShadowPiece Glow;
         private readonly ExplodePiece explode;
         private readonly FlashPiece flash;
         public readonly CircularProgress Progress;
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 
             InternalChildren = new Drawable[]
             {
-                Glow = new GlowPiece(){
+                Glow = new ShadowPiece(){
                     Alpha = .5f,
                 },
                 ring = new CircularContainer


### PR DESCRIPTION
IMO improves readability of notes.

HOLD notes also have the shadow visible by default, with a tint layer underneath the note body serving as the hold indicator.
TOUCH holds lose their colour changing glow, but the main body still changes colour accordingly.