### PR TITLE
Consistently use lane number instead of a angles within hitobjects

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneBreakNote.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneBreakNote.cs
@@ -35,9 +35,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
             {
                 IsBreak = true,
                 StartTime = Time.Current + 1000,
-                Position = new Vector2(0, -66f),
-                Angle = 0,
-                EndPosition = new Vector2(0, -296.5f),
             };
 
             circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneHoldNote.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneHoldNote.cs
@@ -45,9 +45,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
             {
                 StartTime = Time.Current + 1000,
                 EndTime = Time.Current + 1000 + duration,
-                Position = new Vector2(0, -66),
-                EndPosition = new Vector2(0, -296.5f),
-                Angle = 0f,
             };
 
             circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneTapNote.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneTapNote.cs
@@ -34,9 +34,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
             var circle = new Tap
             {
                 StartTime = Time.Current + 1000,
-                Position = new Vector2(0, -66f),
-                Angle = 0,
-                EndPosition = new Vector2(0, -296.5f),
             };
 
             circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneTouchHold.cs
@@ -34,7 +34,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
             {
                 StartTime = Time.Current + 1000,
                 Duration = 5000,
-                Position = new Vector2(0, 0)
             };
 
             circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             Vector2 newPos = (original as IHasPosition)?.Position ?? Vector2.Zero;
             newPos.Y = 384 - newPos.Y;
 
-            int path = newPos.GetDegreesFromPosition(CENTRE_POINT).GetNotePathFromDegrees();
+            int lane = newPos.GetDegreesFromPosition(CENTRE_POINT).GetNoteLaneFromDegrees();
             List<SentakkiHitObject> objects = new List<SentakkiHitObject>();
 
             if (EnabledExperiments.Value.HasFlag(ConversionExperiments.patternv2))
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                 switch (original)
                 {
                     case IHasPathWithRepeats _:
-                        objects.AddRange(Conversions.CreateHoldNote(original, path, beatmap, random, EnabledExperiments.Value));
+                        objects.AddRange(Conversions.CreateHoldNote(original, lane, beatmap, random, EnabledExperiments.Value));
                         break;
 
                     case IHasDuration _:
@@ -74,9 +74,9 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 
                     default:
                         if (EnabledExperiments.Value.HasFlag(ConversionExperiments.touch) && (random2.Next() % 10 == 0))
-                            objects.AddRange(Conversions.CreateTouchNote(original, path, random, EnabledExperiments.Value));
+                            objects.AddRange(Conversions.CreateTouchNote(original, lane, random, EnabledExperiments.Value));
                         else
-                            objects.AddRange(Conversions.CreateTapNote(original, path, random, EnabledExperiments.Value));
+                            objects.AddRange(Conversions.CreateTapNote(original, lane, random, EnabledExperiments.Value));
                         break;
                 }
 

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiNoteConversions.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiNoteConversions.cs
@@ -67,7 +67,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         public static SentakkiHitObject CreateTouchHold(HitObject original)
         => new TouchHold
         {
-
             StartTime = original.StartTime,
             EndTime = (original as IHasDuration).EndTime,
             Samples = original.Samples,

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiNoteConversions.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiNoteConversions.cs
@@ -26,11 +26,9 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             notes.Add(new Tap
             {
                 IsBreak = strong,
-                Angle = path.GetAngleFromPath(),
+                Path = path,
                 Samples = original.Samples,
-                StartTime = original.StartTime,
-                EndPosition = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.INTERSECTDISTANCE, path),
-                Position = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.NOTESTARTDISTANCE, path),
+                StartTime = original.StartTime
             });
             if (twin && experimental.HasFlag(ConversionExperiments.twins))
             {
@@ -39,11 +37,9 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                 notes.Add(new Tap
                 {
                     IsBreak = strong,
-                    Angle = newPath.GetAngleFromPath(),
+                    Path = newPath,
                     Samples = original.Samples,
-                    StartTime = original.StartTime,
-                    EndPosition = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.INTERSECTDISTANCE, newPath),
-                    Position = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.NOTESTARTDISTANCE, newPath),
+                    StartTime = original.StartTime
                 });
                 foreach (var note in notes)
                     note.HasTwin = true;
@@ -62,7 +58,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             {
                 Samples = original.Samples,
                 StartTime = original.StartTime,
-                Position = newPos,
+                Position = newPos
             }};
 
             return notes;
@@ -71,7 +67,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         public static SentakkiHitObject CreateTouchHold(HitObject original)
         => new TouchHold
         {
-            Position = Vector2.Zero,
+
             StartTime = original.StartTime,
             EndTime = (original as IHasDuration).EndTime,
             Samples = original.Samples,
@@ -88,12 +84,10 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             notes.Add(new Hold
             {
                 IsBreak = strong,
-                Angle = path.GetAngleFromPath(),
+                Path = path,
                 NodeSamples = curveData.NodeSamples,
                 StartTime = original.StartTime,
-                EndTime = original.GetEndTime(),
-                EndPosition = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.INTERSECTDISTANCE, path),
-                Position = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.NOTESTARTDISTANCE, path),
+                EndTime = original.GetEndTime()
             });
 
             if (experimental.HasFlag(ConversionExperiments.twins))
@@ -105,12 +99,10 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                     notes.Add(new Hold
                     {
                         IsBreak = strong,
-                        Angle = newPath.GetAngleFromPath(),
+                        Path = newPath,
                         NodeSamples = curveData.NodeSamples,
                         StartTime = original.StartTime,
                         EndTime = original.GetEndTime(),
-                        EndPosition = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.INTERSECTDISTANCE, newPath),
-                        Position = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.NOTESTARTDISTANCE, newPath),
                     });
                     foreach (var note in notes)
                         note.HasTwin = true;
@@ -160,11 +152,9 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                     case SliderEventType.Repeat:
                         hitObjects.Add(new Tap
                         {
-                            Angle = newPath.GetAngleFromPath(),
+                            Path = newPath,
                             Samples = getTickSamples(original.Samples),
                             StartTime = e.Time,
-                            EndPosition = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.INTERSECTDISTANCE, newPath),
-                            Position = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.NOTESTARTDISTANCE, newPath),
                         });
                         break;
                 }

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiNoteConversions.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiNoteConversions.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 {
     public static class Conversions
     {
-        public static List<SentakkiHitObject> CreateTapNote(HitObject original, int path, Random rng, ConversionExperiments experimental = ConversionExperiments.none)
+        public static List<SentakkiHitObject> CreateTapNote(HitObject original, int lane, Random rng, ConversionExperiments experimental = ConversionExperiments.none)
         {
             List<SentakkiHitObject> notes = new List<SentakkiHitObject>();
             bool strong = original.Samples.Any(s => s.Name == HitSampleInfo.HIT_FINISH);
@@ -26,18 +26,18 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             notes.Add(new Tap
             {
                 IsBreak = strong,
-                Path = path,
+                Lane = lane,
                 Samples = original.Samples,
                 StartTime = original.StartTime
             });
             if (twin && experimental.HasFlag(ConversionExperiments.twins))
             {
-                int newPath = path;
-                while (path == newPath) newPath = rng.Next(0, 8);
+                int newPath = lane;
+                while (lane == newPath) newPath = rng.Next(0, 8);
                 notes.Add(new Tap
                 {
                     IsBreak = strong,
-                    Path = newPath,
+                    Lane = newPath,
                     Samples = original.Samples,
                     StartTime = original.StartTime
                 });
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             return notes;
         }
 
-        public static List<SentakkiHitObject> CreateTouchNote(HitObject original, int path, Random rng, ConversionExperiments experimental = ConversionExperiments.none)
+        public static List<SentakkiHitObject> CreateTouchNote(HitObject original, int lane, Random rng, ConversionExperiments experimental = ConversionExperiments.none)
         {
             Vector2 newPos = (original as IHasPosition)?.Position ?? Vector2.Zero;
             newPos.Y = 384 - newPos.Y - 192;
@@ -72,7 +72,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             Samples = original.Samples,
         };
 
-        public static List<SentakkiHitObject> CreateHoldNote(HitObject original, int path, IBeatmap beatmap, Random rng, ConversionExperiments experimental = ConversionExperiments.none)
+        public static List<SentakkiHitObject> CreateHoldNote(HitObject original, int lane, IBeatmap beatmap, Random rng, ConversionExperiments experimental = ConversionExperiments.none)
         {
             var curveData = original as IHasPathWithRepeats;
 
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             notes.Add(new Hold
             {
                 IsBreak = strong,
-                Path = path,
+                Lane = lane,
                 NodeSamples = curveData.NodeSamples,
                 StartTime = original.StartTime,
                 EndTime = original.GetEndTime()
@@ -93,12 +93,12 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             {
                 if (twin)
                 {
-                    int newPath = path;
-                    while (path == newPath) newPath = rng.Next(0, 8);
+                    int newLane = lane;
+                    while (lane == newLane) newLane = rng.Next(0, 8);
                     notes.Add(new Hold
                     {
                         IsBreak = strong,
-                        Path = newPath,
+                        Lane = newLane,
                         NodeSamples = curveData.NodeSamples,
                         StartTime = original.StartTime,
                         EndTime = original.GetEndTime(),
@@ -108,7 +108,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                 }
                 else
                 {
-                    var taps = CreateTapFromTicks(original, path, beatmap, rng);
+                    var taps = CreateTapFromTicks(original, lane, beatmap, rng);
                     if (taps.Any())
                         notes.AddRange(taps);
                 }
@@ -117,7 +117,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             return notes;
         }
 
-        public static List<SentakkiHitObject> CreateTapFromTicks(HitObject original, int path, IBeatmap beatmap, Random rng)
+        public static List<SentakkiHitObject> CreateTapFromTicks(HitObject original, int lane, IBeatmap beatmap, Random rng)
         {
             var curve = original as IHasPathWithRepeats;
             double spanDuration = curve.Duration / (curve.RepeatCount + 1);
@@ -142,8 +142,8 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 
             foreach (var e in SliderEventGenerator.Generate(original.StartTime, spanDuration, velocity, tickDistance, curve.Path.Distance, curve.RepeatCount + 1, legacyLastTickOffset, CancellationToken.None))
             {
-                int newPath = path;
-                while (newPath == path) newPath = rng.Next(0, 8);
+                int newLane = lane;
+                while (newLane == lane) newLane = rng.Next(0, 8);
 
                 switch (e.Type)
                 {
@@ -151,7 +151,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                     case SliderEventType.Repeat:
                         hitObjects.Add(new Tap
                         {
-                            Path = newPath,
+                            Lane = newLane,
                             Samples = getTickSamples(original.Samples),
                             StartTime = e.Time,
                         });

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
@@ -124,12 +124,10 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             return new Hold
             {
                 IsBreak = isBreak,
-                Angle = notePath.GetAngleFromPath(),
+                Path = notePath,
                 NodeSamples = (original as IHasPathWithRepeats).NodeSamples,
                 StartTime = original.StartTime,
-                EndTime = original.GetEndTime(),
-                EndPosition = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.INTERSECTDISTANCE, notePath),
-                Position = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.NOTESTARTDISTANCE, notePath),
+                EndTime = original.GetEndTime()
             };
         }
         private IEnumerable<SentakkiHitObject> createTapsFromTicks(HitObject original)
@@ -164,16 +162,14 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                     case SliderEventType.Repeat:
                         yield return new Tap
                         {
-                            Angle = notePath.GetAngleFromPath(),
+                            Path = notePath,
                             Samples = original.Samples.Select(s => new HitSampleInfo
                             {
                                 Bank = s.Bank,
                                 Name = @"slidertick",
                                 Volume = s.Volume
                             }).ToList(),
-                            StartTime = e.Time,
-                            EndPosition = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.INTERSECTDISTANCE, notePath),
-                            Position = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.NOTESTARTDISTANCE, notePath),
+                            StartTime = e.Time
                         };
                         break;
                 }
@@ -186,11 +182,9 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             return new Tap
             {
                 IsBreak = isBreak,
-                Angle = notePath.GetAngleFromPath(),
+                Path = notePath,
                 Samples = original.Samples,
                 StartTime = original.StartTime,
-                EndPosition = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.INTERSECTDISTANCE, notePath),
-                Position = SentakkiExtensions.GetPathPosition(SentakkiPlayfield.NOTESTARTDISTANCE, notePath),
             };
         }
 

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
@@ -30,17 +30,17 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             rng = new Random(seed);
         }
 
-        //The patterns will generate the note path to be used based on the current offset
+        //The patterns will generate the note lane to be used based on the current offset
         // argument list is (offset, diff)
         private List<Func<bool, int>> patternlist => new List<Func<bool, int>>{
-            //Stream pattern, path difference determined by offset2
+            //Stream pattern, lane difference determined by offset2
             (twin)=> {
                 if(twin) return offset + 4;
                 else offset+=offset2;
                 return offset;
             },
             // Back and forth, works better with longer combos
-            // Path difference determined by offset2, but will make sure offset2 is never 0.
+            // Lane difference determined by offset2, but will make sure offset2 is never 0.
             (twin)=>{
                 offset2 = offset2 == 0 ? 1 : offset2;
                 offset+=offset2;
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         private int offset = 0;
         private int offset2 = 0;
 
-        private int getNewPath(bool twin = false) => patternlist[currentPattern].Invoke(twin);
+        private int getNewLane(bool twin = false) => patternlist[currentPattern].Invoke(twin);
 
         public void CreateNewPattern()
         {
@@ -120,11 +120,11 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         // Individual note generation code, because it's cleaner
         private SentakkiHitObject createHoldNote(HitObject original, bool twin = false, bool isBreak = false)
         {
-            int notePath = getNewPath(twin);
+            int noteLane = getNewLane(twin);
             return new Hold
             {
                 IsBreak = isBreak,
-                Path = notePath,
+                Lane = noteLane,
                 NodeSamples = (original as IHasPathWithRepeats).NodeSamples,
                 StartTime = original.StartTime,
                 EndTime = original.GetEndTime()
@@ -132,7 +132,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         }
         private IEnumerable<SentakkiHitObject> createTapsFromTicks(HitObject original)
         {
-            int notePath = getNewPath(true);
+            int noteLane = getNewLane(true);
 
             var curve = original as IHasPathWithRepeats;
             double spanDuration = curve.Duration / (curve.RepeatCount + 1);
@@ -162,7 +162,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                     case SliderEventType.Repeat:
                         yield return new Tap
                         {
-                            Path = notePath,
+                            Lane = noteLane,
                             Samples = original.Samples.Select(s => new HitSampleInfo
                             {
                                 Bank = s.Bank,
@@ -178,11 +178,11 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 
         private SentakkiHitObject createTapNote(HitObject original, bool twin = false, bool isBreak = false)
         {
-            int notePath = getNewPath(twin);
+            int noteLane = getNewLane(twin);
             return new Tap
             {
                 IsBreak = isBreak,
-                Path = notePath,
+                Lane = noteLane,
                 Samples = original.Samples,
                 StartTime = original.StartTime,
             };

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -84,9 +84,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 }
             });
 
-            hitObject.PathBindable.BindValueChanged(r =>
+            hitObject.LaneBindable.BindValueChanged(r =>
             {
-                Rotation = r.NewValue.GetAngleFromPath();
+                Rotation = r.NewValue.GetRotationForLane();
                 HitArea.NotePath = r.NewValue;
             }, true);
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -43,12 +43,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public DrawableHold(Hold hitObject)
             : base(hitObject)
         {
+            hitObject.PathBindable.BindValueChanged(r => Rotation = r.NewValue.GetAngleFromPath(), true);
             AccentColour.Value = hitObject.NoteColor;
             Size = new Vector2(80);
             Position = Vector2.Zero;
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
-            Rotation = HitObject.Angle;
             AlwaysPresent = true;
             AddRangeInternal(new Drawable[]{
                 HitObjectLine = new HitObjectLine(),
@@ -82,7 +82,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         isHitting.Value = false;
                         NoteBody.Glow.FadeOut(100);
                     },
-                    NoteAngle = HitObject.Angle
+                    NoteAngle = hitObject.PathBindable.Value.GetAngleFromPath()
                 }
             });
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -43,7 +43,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public DrawableHold(Hold hitObject)
             : base(hitObject)
         {
-            hitObject.PathBindable.BindValueChanged(r => Rotation = r.NewValue.GetAngleFromPath(), true);
             AccentColour.Value = hitObject.NoteColor;
             Size = new Vector2(80);
             Position = Vector2.Zero;
@@ -82,9 +81,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         isHitting.Value = false;
                         NoteBody.Glow.FadeOut(100);
                     },
-                    NoteAngle = hitObject.PathBindable.Value.GetAngleFromPath()
                 }
             });
+
+            hitObject.PathBindable.BindValueChanged(r =>
+            {
+                Rotation = r.NewValue.GetAngleFromPath();
+                HitArea.NotePath = r.NewValue;
+            }, true);
         }
 
         protected override void AddNestedHitObject(DrawableHitObject hitObject)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         // Used for the animation update
         protected readonly Bindable<double> AnimationDuration = new Bindable<double>(1000);
 
-        protected override float SamplePlaybackPosition => (SentakkiExtensions.GetPathPosition(SentakkiPlayfield.INTERSECTDISTANCE, HitObject.Path).X / (SentakkiPlayfield.INTERSECTDISTANCE * 2)) + .5f;
+        protected override float SamplePlaybackPosition => (SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, HitObject.Lane).X / (SentakkiPlayfield.INTERSECTDISTANCE * 2)) + .5f;
         public SentakkiAction[] HitActions { get; set; } = new[]
         {
             SentakkiAction.Button1,

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         // Used for the animation update
         protected readonly Bindable<double> AnimationDuration = new Bindable<double>(1000);
 
-        protected override float SamplePlaybackPosition => (HitObject.EndPosition.X + SentakkiPlayfield.INTERSECTDISTANCE) / (SentakkiPlayfield.INTERSECTDISTANCE * 2);
+        protected override float SamplePlaybackPosition => SentakkiExtensions.GetPathPosition(SentakkiPlayfield.INTERSECTDISTANCE, HitObject.Path).X / (SentakkiPlayfield.INTERSECTDISTANCE * 2) + .5f;
         public SentakkiAction[] HitActions { get; set; } = new[]
         {
             SentakkiAction.Button1,

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         // Used for the animation update
         protected readonly Bindable<double> AnimationDuration = new Bindable<double>(1000);
 
-        protected override float SamplePlaybackPosition => SentakkiExtensions.GetPathPosition(SentakkiPlayfield.INTERSECTDISTANCE, HitObject.Path).X / (SentakkiPlayfield.INTERSECTDISTANCE * 2) + .5f;
+        protected override float SamplePlaybackPosition => (SentakkiExtensions.GetPathPosition(SentakkiPlayfield.INTERSECTDISTANCE, HitObject.Path).X / (SentakkiPlayfield.INTERSECTDISTANCE * 2)) + .5f;
         public SentakkiAction[] HitActions { get; set; } = new[]
         {
             SentakkiAction.Button1,

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -24,8 +24,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public DrawableTap(SentakkiHitObject hitObject)
             : base(hitObject)
         {
-
-            hitObject.PathBindable.BindValueChanged(r => Rotation = r.NewValue.GetAngleFromPath(), true);
             AccentColour.Value = hitObject.NoteColor;
             Size = Vector2.Zero;
             Origin = Anchor.Centre;
@@ -49,9 +47,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         return true;
                     },
                     Position = new Vector2(0, -SentakkiPlayfield.INTERSECTDISTANCE),
-                    NoteAngle = HitObject.PathBindable.Value.GetAngleFromPath()
                 },
             });
+            hitObject.PathBindable.BindValueChanged(r =>
+            {
+                Rotation = r.NewValue.GetAngleFromPath();
+                HitArea.NotePath = r.NewValue;
+            }, true);
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -49,9 +49,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     Position = new Vector2(0, -SentakkiPlayfield.INTERSECTDISTANCE),
                 },
             });
-            hitObject.PathBindable.BindValueChanged(r =>
+            hitObject.LaneBindable.BindValueChanged(r =>
             {
-                Rotation = r.NewValue.GetAngleFromPath();
+                Rotation = r.NewValue.GetRotationForLane();
                 HitArea.NotePath = r.NewValue;
             }, true);
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -5,6 +5,8 @@ using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Sentakki.UI;
+using osu.Framework.Utils;
 using osuTK;
 using osuTK.Graphics;
 using System;
@@ -22,21 +24,19 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public DrawableTap(SentakkiHitObject hitObject)
             : base(hitObject)
         {
+
+            hitObject.PathBindable.BindValueChanged(r => Rotation = r.NewValue.GetAngleFromPath(), true);
             AccentColour.Value = hitObject.NoteColor;
             Size = Vector2.Zero;
             Origin = Anchor.Centre;
             Anchor = Anchor.Centre;
             AlwaysPresent = true;
             AddRangeInternal(new Drawable[] {
-                HitObjectLine = new HitObjectLine
-                {
-                    Rotation = HitObject.Angle,
-                },
+                HitObjectLine = new HitObjectLine(),
                 CirclePiece = new TapCircle()
                 {
                     Scale = new Vector2(0f),
-                    Rotation = hitObject.Angle,
-                    Position = HitObject.Position
+                    Position = new Vector2(0, -SentakkiPlayfield.NOTESTARTDISTANCE)
                 },
                 HitArea = new HitReceptor()
                 {
@@ -48,8 +48,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         UpdateResult(true);
                         return true;
                     },
-                    Position = hitObject.EndPosition,
-                    NoteAngle = HitObject.Angle
+                    Position = new Vector2(0, -SentakkiPlayfield.INTERSECTDISTANCE),
+                    NoteAngle = HitObject.PathBindable.Value.GetAngleFromPath()
                 },
             });
         }
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             // Calculate position
             float moveAmount = Math.Clamp((float)((currentProg - animTime) / animTime), 0, 1);
-            CirclePiece.Position = HitObject.Position + ((HitObject.EndPosition - HitObject.Position) * moveAmount);
+            CirclePiece.Y = (float)Interpolation.Lerp(-SentakkiPlayfield.NOTESTARTDISTANCE, -SentakkiPlayfield.INTERSECTDISTANCE, moveAmount);
 
             // Handle hidden and fadeIn modifications
             if (IsHidden)
@@ -135,12 +135,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     break;
 
                 case ArmedState.Miss:
-                    var c = HitObject.Angle + 90;
-                    var d = c * (float)(Math.PI / 180);
 
                     CirclePiece.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
                        .FadeColour(Color4.Red, time_fade_miss, Easing.OutQuint)
-                       .MoveToOffset(new Vector2(-(100 * (float)Math.Cos(d)), -(100 * (float)Math.Sin(d))), time_fade_hit, Easing.OutCubic)
+                       .MoveToOffset(new Vector2(0, -100), time_fade_hit, Easing.OutCubic)
                        .FadeOut(time_fade_miss);
 
                     this.ScaleTo(1f, time_fade_miss).Expire();

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         public Drawable ProxiedLayer => this;
 
-        protected override float SamplePlaybackPosition => (HitObject.Position.X + SentakkiPlayfield.INTERSECTDISTANCE) / (SentakkiPlayfield.INTERSECTDISTANCE * 2);
+        protected override float SamplePlaybackPosition => (HitObject as Touch).Position.X / (SentakkiPlayfield.INTERSECTDISTANCE * 2) + .5f;
 
         protected override double InitialLifetimeOffset => 6000;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         public Drawable ProxiedLayer => this;
 
-        protected override float SamplePlaybackPosition => (HitObject as Touch).Position.X / (SentakkiPlayfield.INTERSECTDISTANCE * 2) + .5f;
+        protected override float SamplePlaybackPosition => ((HitObject as Touch).Position.X / (SentakkiPlayfield.INTERSECTDISTANCE * 2)) + .5f;
 
         protected override double InitialLifetimeOffset => 6000;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         private SentakkiInputManager sentakkiActionInputManager;
         internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= GetContainingInputManager() as SentakkiInputManager;
 
-        public DrawableTouch(SentakkiHitObject hitObject) : base(hitObject)
+        public DrawableTouch(Touch hitObject) : base(hitObject)
         {
             Size = new Vector2(80);
             Position = hitObject.Position;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HitReceptor.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HitReceptor.cs
@@ -21,10 +21,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         public Func<bool> Hit;
         public Action Release;
 
-        public float NoteAngle = -1;
+        public int? NotePath = null;
         public bool HoverAction()
         {
-            if (!SentakkiActionInputManager.CurrentAngles.Contains(NoteAngle))
+            if (!!NotePath.HasValue || SentakkiActionInputManager.CurrentPath.Contains(NotePath.Value))
             {
                 if (SentakkiActionInputManager.PressedActions.Any(action => OnPressed(action)))
                     actions.AddRange(SentakkiActionInputManager.PressedActions.Except(actions));
@@ -44,7 +44,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         {
             if (IsHovered)
             {
-                SentakkiActionInputManager.CurrentAngles.Add(NoteAngle);
+                if (NotePath.HasValue)
+                    SentakkiActionInputManager.CurrentPath.Add(NotePath.Value);
                 actions.Add(action);
                 return Hit?.Invoke() ?? false;
             }
@@ -57,13 +58,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             if (!actions.Any())
             {
                 Release?.Invoke();
-                SentakkiActionInputManager.CurrentAngles.Remove(NoteAngle);
+                if (NotePath.HasValue)
+                    SentakkiActionInputManager.CurrentPath.Remove(NotePath.Value);
             }
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            SentakkiActionInputManager.CurrentAngles.Remove(NoteAngle);
+            SentakkiActionInputManager.CurrentPath.Remove(NotePath.Value);
             if (actions.Any())
             {
                 actions.Clear();

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HitReceptor.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HitReceptor.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         public int? NotePath = null;
         public bool HoverAction()
         {
-            if (!!NotePath.HasValue || SentakkiActionInputManager.CurrentPath.Contains(NotePath.Value))
+            if (!NotePath.HasValue || !SentakkiActionInputManager.CurrentPath.Contains(NotePath.Value))
             {
                 if (SentakkiActionInputManager.PressedActions.Any(action => OnPressed(action)))
                     actions.AddRange(SentakkiActionInputManager.PressedActions.Except(actions));
@@ -65,7 +65,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            SentakkiActionInputManager.CurrentPath.Remove(NotePath.Value);
+            if (NotePath.HasValue)
+                SentakkiActionInputManager.CurrentPath.Remove(NotePath.Value);
             if (actions.Any())
             {
                 actions.Clear();

--- a/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
@@ -63,14 +63,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             }
         }
 
-        public override int Path
+        public override int Lane
         {
-            get => base.Path;
+            get => base.Lane;
             set
             {
-                base.Path = value;
-                Head.Path = value;
-                Tail.Path = value;
+                base.Lane = value;
+                Head.Lane = value;
+                Tail.Lane = value;
             }
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
@@ -63,25 +63,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             }
         }
 
-        public override float Angle
+        public override int Path
         {
-            get => base.Angle;
+            get => base.Path;
             set
             {
-                base.Angle = value;
-                Head.Angle = value;
-                Tail.Angle = value;
-            }
-        }
-
-        public override Vector2 EndPosition
-        {
-            get => base.EndPosition;
-            set
-            {
-                base.EndPosition = value;
-                Head.EndPosition = value;
-                Tail.EndPosition = value;
+                base.Path = value;
+                Head.Path = value;
+                Tail.Path = value;
             }
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
@@ -1,4 +1,5 @@
-﻿using osu.Game.Rulesets.Judgements;
+﻿using osu.Framework.Bindables;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Sentakki.Judgements;
 using osu.Game.Rulesets.Sentakki.Scoring;
 using osu.Game.Rulesets.Scoring;
@@ -17,13 +18,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         public override Judgement CreateJudgement() => IsBreak ? new SentakkiBreakJudgement() : new SentakkiJudgement();
 
         public virtual Color4 NoteColor => IsBreak ? Color4.OrangeRed : (HasTwin ? Color4.Gold : Color4Extensions.FromHex("ff0064"));
-        public virtual Vector2 EndPosition { get; set; }
-        public virtual float Angle { get; set; }
 
-        public Vector2 Position { get; set; }
-
-        public float X => Position.X;
-        public float Y => Position.Y;
+        public readonly BindableInt PathBindable = new BindableInt(0);
+        public virtual int Path
+        {
+            get => PathBindable.Value;
+            set => PathBindable.Value = value;
+        }
 
         protected override HitWindows CreateHitWindows() => new SentakkiHitWindows();
     }

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
@@ -19,11 +19,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
         public virtual Color4 NoteColor => IsBreak ? Color4.OrangeRed : (HasTwin ? Color4.Gold : Color4Extensions.FromHex("ff0064"));
 
-        public readonly BindableInt PathBindable = new BindableInt(0);
-        public virtual int Path
+        public readonly BindableInt LaneBindable = new BindableInt(0);
+        public virtual int Lane
         {
-            get => PathBindable.Value;
-            set => PathBindable.Value = value;
+            get => LaneBindable.Value;
+            set => LaneBindable.Value = value;
         }
 
         protected override HitWindows CreateHitWindows() => new SentakkiHitWindows();

--- a/osu.Game.Rulesets.Sentakki/Objects/Touch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Touch.cs
@@ -1,16 +1,16 @@
 using osu.Game.Rulesets.Sentakki.Scoring;
 using osu.Game.Rulesets.Scoring;
 using osuTK.Graphics;
+using osuTK;
 
 namespace osu.Game.Rulesets.Sentakki.Objects
 {
     public class Touch : SentakkiHitObject
     {
+        public Vector2 Position { get; set; }
+
         public override bool IsBreak => false;
         public override Color4 NoteColor => HasTwin ? Color4.Gold : Color4.Cyan;
-
-        public override float Angle => 0;
-
         protected override HitWindows CreateHitWindows() => new SentakkiTouchHitWindows();
     }
 }

--- a/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
@@ -6,13 +6,13 @@ namespace osu.Game.Rulesets.Sentakki
 {
     public static class SentakkiExtensions
     {
-        public static float GetAngleFromPath(this int path)
+        public static float GetRotationForLane(this int lane)
         {
-            while (path < 0) path += 8;
-            path %= 8;
-            return SentakkiPlayfield.PATHANGLES[path];
+            while (lane < 0) lane += 8;
+            lane %= 8;
+            return SentakkiPlayfield.LANEANGLES[lane];
         }
-        public static Vector2 GetPathPosition(float distance, int path) => GetCircularPosition(distance, path.GetAngleFromPath());
+        public static Vector2 GetPositionAlongLane(float distance, int lane) => GetCircularPosition(distance, lane.GetRotationForLane());
 
         public static Vector2 GetCircularPosition(float distance, float angle)
         {
@@ -21,15 +21,15 @@ namespace osu.Game.Rulesets.Sentakki
 
         public static float GetDegreesFromPosition(this Vector2 target, Vector2 self) => (float)MathHelper.RadiansToDegrees(Math.Atan2(target.X - self.X, target.Y - self.Y));
 
-        public static int GetNotePathFromDegrees(this float degrees)
+        public static int GetNoteLaneFromDegrees(this float degrees)
         {
             if (degrees < 0) degrees += 360;
             if (degrees >= 360) degrees %= 360;
             int result = 0;
 
-            for (int i = 0; i < SentakkiPlayfield.PATHANGLES.Length; ++i)
+            for (int i = 0; i < SentakkiPlayfield.LANEANGLES.Length; ++i)
             {
-                if (SentakkiPlayfield.PATHANGLES[i] - degrees >= -22.5f && SentakkiPlayfield.PATHANGLES[i] - degrees <= 22.5f)
+                if (SentakkiPlayfield.LANEANGLES[i] - degrees >= -22.5f && SentakkiPlayfield.LANEANGLES[i] - degrees <= 22.5f)
                     result = i;
             }
             return result;

--- a/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Sentakki
         {
         }
 
-        public List<float> CurrentAngles = new List<float>();
+        public List<int> CurrentPath = new List<int>();
     }
 
     public enum SentakkiAction

--- a/osu.Game.Rulesets.Sentakki/UI/Components/SentakkiRing.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/SentakkiRing.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             };
 
             // Add dots to the actual ring
-            foreach (float pathAngle in SentakkiPlayfield.PATHANGLES)
+            foreach (float pathAngle in SentakkiPlayfield.LANEANGLES)
             {
                 AddInternal(new CircularContainer
                 {

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -105,8 +105,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
             var sentakkiObj = (DrawableSentakkiHitObject)judgedObject;
 
-            var b = sentakkiObj.HitObject.Angle + 90;
-            var a = b *= (float)(Math.PI / 180);
             DrawableSentakkiJudgement explosion;
             switch (judgedObject)
             {
@@ -131,8 +129,8 @@ namespace osu.Game.Rulesets.Sentakki.UI
                     {
                         Origin = Anchor.Centre,
                         Anchor = Anchor.Centre,
-                        Position = new Vector2(-(240 * (float)Math.Cos(a)), -(240 * (float)Math.Sin(a))),
-                        Rotation = sentakkiObj.HitObject.Angle,
+                        Position = SentakkiExtensions.GetPathPosition(240, sentakkiObj.HitObject.Path),
+                        Rotation = sentakkiObj.HitObject.Path.GetAngleFromPath(),
                     };
                     break;
             }

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -31,17 +31,17 @@ namespace osu.Game.Rulesets.Sentakki.UI
         public static readonly float INTERSECTDISTANCE = 296.5f;
         public static readonly float NOTESTARTDISTANCE = 66f;
 
-        public static readonly float[] PATHANGLES =
-            {
-                22.5f,
-                67.5f,
-                112.5f,
-                157.5f,
-                202.5f,
-                247.5f,
-                292.5f,
-                337.5f
-            };
+        public static readonly float[] LANEANGLES =
+        {
+            22.5f,
+            67.5f,
+            112.5f,
+            157.5f,
+            202.5f,
+            247.5f,
+            292.5f,
+            337.5f
+        };
 
         // Touch notes always appear above other notes, regardless of start time
         private readonly TouchNoteProxyContainer touchNoteContainer;
@@ -129,8 +129,8 @@ namespace osu.Game.Rulesets.Sentakki.UI
                     {
                         Origin = Anchor.Centre,
                         Anchor = Anchor.Centre,
-                        Position = SentakkiExtensions.GetPathPosition(240, sentakkiObj.HitObject.Path),
-                        Rotation = sentakkiObj.HitObject.Path.GetAngleFromPath(),
+                        Position = SentakkiExtensions.GetPositionAlongLane(240, sentakkiObj.HitObject.Lane),
+                        Rotation = sentakkiObj.HitObject.Lane.GetRotationForLane(),
                     };
                     break;
             }


### PR DESCRIPTION
Angles will still be used where necessary (path and judgement rotation), but all other cases have been replaced with angles because it is much easier to mentally process than angles..

Perhaps I want to make laned hitobjects use a `IHasLane` interface...