### PR TITLE
Remove lenience in HOLD tail

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHoldTail.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHoldTail.cs
@@ -5,13 +5,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
     public class DrawableHoldTail : DrawableSentakkiHitObject
     {
-        /// <summary>
-        /// Lenience of release hit windows. This is to make cases where the hold note release
-        /// is timed alongside presses of other hit objects less awkward.
-        /// Todo: This shouldn't exist for non-LegacyBeatmapDecoder beatmaps
-        /// </summary>
-        private const double release_window_lenience = 1.5;
-
         private readonly DrawableHold holdNote;
 
         public DrawableHoldTail(DrawableHold holdNote)
@@ -27,9 +20,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             Debug.Assert(HitObject.HitWindows != null);
-
-            // Factor in the release lenience
-            timeOffset /= release_window_lenience;
 
             if (!userTriggered)
             {


### PR DESCRIPTION
This shouldn't exist with the new HitWindows, and also makes the state transforms be a bit off.