### PR TITLE
Slightly alter note transforms

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         if(beginHoldAt(Time.Current - Head.HitObject.StartTime))
                         {
                             Head.UpdateResult();
-                            NoteBody.FadeColour(AccentColour.Value,50);
+                            NoteBody.Note.FadeColour(AccentColour.Value,50);
                         }
 
                         return true;
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         HoldStartTime = null;
                         isHitting.Value = false;
                         if(!AllJudged)
-                        NoteBody.FadeColour(Color4.Gray,100);
+                        NoteBody.Note.FadeColour(Color4.Gray,100);
                     },
                 }
             });
@@ -171,7 +171,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                             .ResizeHeightTo(80, stretchTime);
 
                     if (HoldStartTime == null)
-                        NoteBody.Delay(animTime).FadeColour(Color4.Gray, 100);
+                        NoteBody.Note.Delay(animTime).FadeColour(Color4.Gray, 100);
 
                     HitObjectLine.ScaleTo(1, animTime);
                 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -79,6 +79,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         Tail.UpdateResult();
                         HoldStartTime = null;
                         isHitting.Value = false;
+                        if(!AllJudged)
                         NoteBody.FadeColour(Color4.Gray,100);
                     },
                 }
@@ -145,66 +146,43 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             HitObjectLine.Colour = HitObject.NoteColor;
         }
 
+        protected override void UpdateInitialTransforms()
+        {
+            double animTime = AnimationDuration.Value / 2 * GameplaySpeed;
+            double animStart = HitObject.StartTime - (animTime * 2);
+            using (BeginAbsoluteSequence(animStart, true))
+            {
+                HitObjectLine.FadeInFromZero(animTime);
+                NoteBody.FadeInFromZero(animTime).ScaleTo(1, animTime);
+
+                using (BeginDelayedSequence(animTime, true))
+                {
+                    // This is the movable length (not including start position)
+                    float totalMovableDistance = SentakkiPlayfield.INTERSECTDISTANCE - SentakkiPlayfield.NOTESTARTDISTANCE;
+                    float originalStretchAmount = (float)(totalMovableDistance / animTime * (HitObject as IHasDuration).Duration);
+                    float stretchAmount = Math.Clamp((float)(totalMovableDistance / animTime * (HitObject as IHasDuration).Duration), 0, totalMovableDistance);
+                    float stretchTime = (float)(stretchAmount / totalMovableDistance * animTime);
+                    float excessDistance = (float)((-SentakkiPlayfield.INTERSECTDISTANCE + SentakkiPlayfield.NOTESTARTDISTANCE) / animTime * 144);
+
+                    NoteBody.ResizeHeightTo(80 + stretchAmount, stretchTime)
+                            .Delay((HitObject as IHasDuration).Duration)
+                            .MoveToY(-SentakkiPlayfield.INTERSECTDISTANCE + (Width / 2) + excessDistance, animTime + 144)
+                            .Delay(animTime - stretchTime)
+                            .ResizeHeightTo(80, stretchTime);
+
+                    if (HoldStartTime == null)
+                        NoteBody.Delay(animTime).FadeColour(Color4.Gray, 100);
+
+                    HitObjectLine.ScaleTo(1, animTime);
+                }
+            }
+        }
         protected override void Update()
         {
             base.Update();
             if (Result.HasResult) return;
 
-            double animTime = AnimationDuration.Value / 2 * GameplaySpeed;
-            double animStart = HitObject.StartTime - (animTime * 2);
-            double currentProg = Clock.CurrentTime - animStart;
-
-            // Calculate initial entry animation
-            float fadeAmount = Math.Clamp((float)(currentProg / animTime), 0, 1);
-            HitObjectLine.Alpha = fadeAmount;
-            NoteBody.Alpha = fadeAmount;
-            NoteBody.Scale = new Vector2(fadeAmount);
-
-            // This is the movable length (not including start position)
-            float totalMovableDistance = SentakkiPlayfield.INTERSECTDISTANCE - SentakkiPlayfield.NOTESTARTDISTANCE;
-            float adjustedStartPoint = SentakkiPlayfield.NOTESTARTDISTANCE - (Width / 2);
-
-            // Calculate total length of hold note
-            double length = (float)(totalMovableDistance / animTime * (HitObject as IHasDuration).Duration);
-
-            // Calculate time taken to extend to desired length
-            double extendTime = length / totalMovableDistance * animTime;
-
-            // Start strecthing
-            float extendAmount = Math.Clamp((float)((currentProg - animTime) / extendTime), 0, 1);
-            NoteBody.Height = (float)(80 + (length * extendAmount));
-
-            // Move the note once idle time is over
-            float moveAmount = Math.Max((float)((currentProg - animTime - (HitObject as IHasDuration).Duration) / animTime), 0);
-            NoteBody.Y = -adjustedStartPoint - (totalMovableDistance * moveAmount);
-
-            //Shrink note
-            float holdProgress = (float)Math.Clamp((Time.Current - HitObject.StartTime) / (HitObject as IHasDuration).Duration, 0, 1);
-            float shrinkAmount = (float)length * holdProgress;
-            NoteBody.Height -= shrinkAmount;
-
-            // Handle hidden and fadeIn modifications
-            if (IsHidden)
-            {
-                float hideAmount = Math.Clamp((float)((currentProg - animTime) / (animTime / 2)), 0, 1);
-                // Provide feedback, and allow users to see the length of the note
-                if (Time.Current >= HitObject.StartTime && (isHitting.Value || Auto))
-                    hideAmount /= 2;
-
-                Alpha = 1 - hideAmount;
-            }
-            else if (IsFadeIn)
-            {
-                float fadeInAmount = Math.Clamp((float)((currentProg - animTime) / animTime), 0, 1);
-                Alpha = 1 * fadeInAmount;
-            }
-
-            // Make sure HitObjectLine is adjusted with the moving note
-            float totalMove = Math.Clamp((float)((currentProg - animTime) / animTime), 0, 1);
-
-            HitObjectLine.UpdateVisual(totalMove);
-
-            // Auto should pretend to trigger a hit, just so it visually looks the same even if the note is guaranteed to give a perfect judgement
+            // Let autoplay mimic players.
             if (Auto)
                 if (Time.Current >= HitObject.StartTime)
                     HitArea.Hit.Invoke();
@@ -222,27 +200,25 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.UpdateStateTransforms(state);
             const double time_fade_hit = 400, time_fade_miss = 400;
-            HitObjectLine.FadeOut();
 
             switch (state)
             {
-                case ArmedState.Idle:
-                    NoteBody.FadeColour(Color4.Gray, 100);
-                    break;
                 case ArmedState.Hit:
-                    using (BeginAbsoluteSequence(Time.Current, true))
+                    using (BeginDelayedSequence((HitObject as IHasDuration).Duration + Tail.Result.TimeOffset, true))
                     {
                         this.ScaleTo(1f, time_fade_hit);
+                        HitObjectLine.FadeOut();
                     }
                     break;
 
                 case ArmedState.Miss:
-                    using (BeginAbsoluteSequence(Time.Current, true))
+                    using (BeginDelayedSequence((HitObject as IHasDuration).Duration + Tail.Result.TimeOffset, true))
                     {
                         NoteBody.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
                             .FadeColour(Color4.Red, time_fade_miss, Easing.OutQuint)
                             .MoveToOffset(new Vector2(0, -100), time_fade_hit, Easing.OutCubic)
                             .FadeOut(time_fade_miss);
+                        HitObjectLine.FadeOut();
 
                         using (BeginDelayedSequence(time_fade_miss, true))
                         {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         if(beginHoldAt(Time.Current - Head.HitObject.StartTime))
                         {
                             Head.UpdateResult();
-                            NoteBody.Glow.FadeIn(50);
+                            NoteBody.FadeColour(AccentColour.Value,50);
                         }
 
                         return true;
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         Tail.UpdateResult();
                         HoldStartTime = null;
                         isHitting.Value = false;
-                        NoteBody.Glow.FadeOut(100);
+                        NoteBody.FadeColour(Color4.Gray,100);
                     },
                 }
             });
@@ -144,14 +144,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             settings?.BindWith(SentakkiRulesetSettings.AnimationDuration, AnimationDuration);
             HitObjectLine.Colour = HitObject.NoteColor;
         }
-        private float holdProgress = 0;
-        private bool needreset = false;
 
         protected override void Update()
         {
             base.Update();
             if (Result.HasResult) return;
-            if (needreset) { holdProgress = 0; needreset = false; }
 
             double animTime = AnimationDuration.Value / 2 * GameplaySpeed;
             double animStart = HitObject.StartTime - (animTime * 2);
@@ -181,8 +178,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             float moveAmount = Math.Max((float)((currentProg - animTime - (HitObject as IHasDuration).Duration) / animTime), 0);
             NoteBody.Y = -adjustedStartPoint - (totalMovableDistance * moveAmount);
 
-            if (HoldStartTime != null)
-                holdProgress = (float)Math.Clamp((Time.Current - HitObject.StartTime) / (HitObject as IHasDuration).Duration, 0, 1);
+            //Shrink note
+            float holdProgress = (float)Math.Clamp((Time.Current - HitObject.StartTime) / (HitObject as IHasDuration).Duration, 0, 1);
             float shrinkAmount = (float)length * holdProgress;
             NoteBody.Height -= shrinkAmount;
 
@@ -218,10 +215,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             if (Tail.AllJudged)
-            {
                 ApplyResult(r => r.Type = (Head.IsHit || Tail.IsHit) ? HitResult.Perfect : HitResult.Miss);
-                needreset = true;
-            }
         }
 
         protected override void UpdateStateTransforms(ArmedState state)
@@ -232,6 +226,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             switch (state)
             {
+                case ArmedState.Idle:
+                    NoteBody.FadeColour(Color4.Gray, 100);
+                    break;
                 case ArmedState.Hit:
                     using (BeginAbsoluteSequence(Time.Current, true))
                     {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -1,4 +1,4 @@
-using osu.Framework.Allocation;
+﻿using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -177,13 +177,16 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             NoteBody.Height = (float)(80 + (length * extendAmount));
 
             // Move the note once idle time is over
-            float moveAmount = Math.Clamp((float)((currentProg - animTime - (HitObject as IHasDuration).Duration) / animTime), 0, 1);
+            float moveAmount = Math.Max((float)((currentProg - animTime - (HitObject as IHasDuration).Duration) / animTime), 0);
             NoteBody.Y = -adjustedStartPoint - (totalMovableDistance * moveAmount);
 
-            // Start shrinking when the time comes
-            float shrinkAmount = Math.Abs(NoteBody.Y) + NoteBody.Height - SentakkiPlayfield.INTERSECTDISTANCE - 40;
-            if (shrinkAmount > 0)
-                NoteBody.Height -= shrinkAmount;
+            if (HoldStartTime != null)
+            {
+                // Start shrinking when the time comes
+                float shrinkAmount = Math.Abs(NoteBody.Y) + NoteBody.Height - SentakkiPlayfield.INTERSECTDISTANCE - 40;
+                if (shrinkAmount > 0)
+                    NoteBody.Height -= shrinkAmount;
+            }
 
             // Handle hidden and fadeIn modifications
             if (IsHidden)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             HitObjectLine.Alpha = fadeAmount;
 
             // Calculate position
-            float moveAmount = Math.Clamp((float)((currentProg - animTime) / animTime), 0, 1);
+            float moveAmount = Math.Max((float)((currentProg - animTime) / animTime), 0);
             CirclePiece.Y = (float)Interpolation.Lerp(-SentakkiPlayfield.NOTESTARTDISTANCE, -SentakkiPlayfield.INTERSECTDISTANCE, moveAmount);
 
             // Handle hidden and fadeIn modifications

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -105,69 +105,23 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         private readonly DefaultEasingFunction outSine = new DefaultEasingFunction(Easing.OutSine);
         private readonly DefaultEasingFunction inQuint = new DefaultEasingFunction(Easing.InQuint);
 
-        protected override void Update()
+        protected override void UpdateInitialTransforms()
         {
-            base.Update();
-            if (Result.HasResult) return;
-
             double fadeIn = AnimationDuration.Value * GameplaySpeed;
             double moveTo = HitObject.HitWindows.WindowFor(HitResult.Meh) * 2 * GameplaySpeed;
-            double animStart = HitObject.StartTime - fadeIn - moveTo;
-            double currentProg = Clock.CurrentTime - animStart;
 
-            // Calculate initial entry animation
-            float fadeAmount = Math.Clamp((float)(currentProg / fadeIn), 0, 1);
-
-            Alpha = fadeAmount * (float)outSine.ApplyEasing(fadeAmount);
-            Scale = new Vector2(fadeAmount * (float)outSine.ApplyEasing(fadeAmount));
-
-            // Calculate position
-            float moveAmount = Math.Clamp((float)((currentProg - fadeIn) / moveTo), 0, 1);
-
-            // Used to simplify this crazy arse manual animating
-            float moveAnimFormula(float originalValue) => (float)(originalValue - (originalValue * inQuint.ApplyEasing(moveAmount)));
-
-            blob1.Position = new Vector2(moveAnimFormula(40), 0);
-            blob2.Position = new Vector2(moveAnimFormula(-40), 0);
-            blob3.Position = new Vector2(0, moveAnimFormula(40));
-            blob4.Position = new Vector2(0, moveAnimFormula(-40));
-
-            // Used to simplify this crazy arse manual animating
-            float sizeAnimFormula() => (float)(.5 + .5 * inQuint.ApplyEasing(moveAmount));
-
-            blob1.Scale = new Vector2(sizeAnimFormula());
-            blob2.Scale = new Vector2(sizeAnimFormula());
-            blob3.Scale = new Vector2(sizeAnimFormula());
-            blob4.Scale = new Vector2(sizeAnimFormula());
-
-            // Might be literally jank, but it removes bad edges after animation finishes
-            if (moveAmount == 1)
+            using (BeginAbsoluteSequence(HitObject.StartTime - fadeIn - moveTo, true))
             {
-                blob2.Alpha = 0;
-                blob3.Alpha = 0;
-                blob4.Alpha = 0;
-            }
-            else
-            {
-                blob2.Alpha = 1;
-                blob3.Alpha = 1;
-                blob4.Alpha = 1;
-            }
+                this.FadeIn(fadeIn, Easing.OutSine).ScaleTo(1, fadeIn, Easing.OutSine);
 
-
-            // Handle hidden and fadeIn modifications
-            if (IsHidden)
-            {
-                float hideAmount = Math.Clamp((float)((currentProg - fadeIn) / (moveTo / 2)), 0, 1);
-
-                Alpha = 1 - hideAmount;
+                using (BeginDelayedSequence(fadeIn, true))
+                {
+                    blob1.MoveTo(new Vector2(0), moveTo, Easing.InQuint).ScaleTo(1, moveTo, Easing.InQuint);
+                    blob2.MoveTo(new Vector2(0), moveTo, Easing.InQuint).ScaleTo(1, moveTo, Easing.InQuint).Then().FadeOut();
+                    blob3.MoveTo(new Vector2(0), moveTo, Easing.InQuint).ScaleTo(1, moveTo, Easing.InQuint).Then().FadeOut();
+                    blob4.MoveTo(new Vector2(0), moveTo, Easing.InQuint).ScaleTo(1, moveTo, Easing.InQuint).Then().FadeOut();
+                }
             }
-            else if (IsFadeIn)
-            {
-                // Using existing moveAmount because it serves our needs
-                Alpha = 1 * moveAmount;
-            }
-
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -92,6 +92,20 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         /// </summary>
         public double? HoldStartTime { get; private set; }
 
+        protected override void UpdateInitialTransforms()
+        {
+            circle.Progress.Current.Value = 0;
+            double fadeIn = AnimationDuration.Value * GameplaySpeed;
+            using (BeginAbsoluteSequence(HitObject.StartTime - fadeIn, true))
+            {
+                this.FadeInFromZero(fadeIn).ScaleTo(1, fadeIn);
+                using (BeginDelayedSequence(fadeIn, true))
+                {
+                    circle.Progress.FillTo(1, (HitObject as IHasDuration).Duration);
+                }
+            }
+        }
+
         protected override void Update()
         {
             base.Update();
@@ -102,33 +116,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 circle.Size = Vector2.One;
                 currentColour = Color4.HotPink;
                 needReset = false;
-            }
-
-            double fadeIn = AnimationDuration.Value * GameplaySpeed;
-            double animStart = HitObject.StartTime - fadeIn;
-            double currentProg = Clock.CurrentTime - animStart;
-
-            // Calculate initial entry animation
-            float fadeAmount = Math.Clamp((float)(currentProg / fadeIn), 0, 1);
-
-            Alpha = fadeAmount;
-            Scale = new Vector2(fadeAmount);
-
-            // Calculate progressbar fill
-            float fillAmount = Math.Clamp((float)((currentProg - fadeIn) / (HitObject as TouchHold).Duration), 0, 1);
-            circle.Progress.Current.Value = fillAmount;
-
-            if (IsHidden)
-            {
-                float hideAmount = Math.Min((float)((currentProg - fadeIn) / 125), 1);
-
-                if (hideAmount > 0)
-                {
-                    if (Time.Current >= HitObject.StartTime && activated)
-                        hideAmount /= 2;
-
-                    Alpha = 1 - hideAmount;
-                }
             }
 
             // Input and feedback

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HitObjectLine.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HitObjectLine.cs
@@ -23,6 +23,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
+            Scale = new Vector2(.22f);
+            Size = new Vector2(299);
+            Alpha = 0;
         }
 
         [BackgroundDependencyLoader]
@@ -31,19 +34,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             lineTexture = textures.Get("HitObjectLine");
             AddInternal(lineSprite = new Sprite()
             {
-                Size = new Vector2(299),
-                Scale = new Vector2(.22f),
+                RelativeSizeAxes = Axes.Both,
                 Rotation = -45,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.BottomLeft,
                 Texture = lineTexture
             });
-        }
-
-        public void UpdateVisual(double progress)
-        {
-            float newSize = .22f + (float)(.78f * progress);
-            lineSprite.Scale = new Vector2(newSize);
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -14,7 +14,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         private readonly FlashPiece flash;
         private readonly ExplodePiece explode;
         private readonly Container note;
-        public readonly HoldGlowPiece Glow;
 
         public double Duration = 0;
 
@@ -35,9 +34,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                     Children = new Drawable[]
                     {
                         new ShadowPiece(),
-                        Glow = new HoldGlowPiece(){
-                            Alpha = 0
-                        },
                         new CircularContainer
                         {
                             RelativeSizeAxes = Axes.Both,
@@ -139,12 +135,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             state.BindValueChanged(updateState, true);
 
             accentColour.BindTo(drawableObject.AccentColour);
-            accentColour.BindValueChanged(colour =>
-            {
-                explode.Colour = colour.NewValue;
-                note.Colour = colour.NewValue;
-                Glow.Colour = colour.NewValue;
-            }, true);
+            accentColour.BindValueChanged(colour => Colour = colour.NewValue, true);
         }
 
         private void updateState(ValueChangedEvent<ArmedState> state)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         private readonly FlashPiece flash;
         private readonly ExplodePiece explode;
         private readonly Container note;
+        private readonly ShadowPiece shadow;
 
         public double Duration = 0;
 
@@ -33,7 +34,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                     RelativeSizeAxes=Axes.Both,
                     Children = new Drawable[]
                     {
-                        new ShadowPiece(),
+                        shadow = new ShadowPiece(),
                         new CircularContainer
                         {
                             RelativeSizeAxes = Axes.Both,
@@ -157,6 +158,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 
                         using (BeginDelayedSequence(flash_in, true))
                         {
+                            shadow.FadeOut();
                             note.FadeOut();
                             this.FadeOut(800);
                         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -136,7 +136,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             state.BindValueChanged(updateState, true);
 
             accentColour.BindTo(drawableObject.AccentColour);
-            accentColour.BindValueChanged(colour => Colour = colour.NewValue, true);
+            accentColour.BindValueChanged(colour =>
+            {
+                explode.Colour = colour.NewValue;
+                note.Colour = colour.NewValue;
+            }, true);
         }
 
         private void updateState(ValueChangedEvent<ArmedState> state)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
     {
         private readonly FlashPiece flash;
         private readonly ExplodePiece explode;
-        private readonly Container note;
+        public readonly Container Note;
         private readonly ShadowPiece shadow;
 
         public double Duration = 0;
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             Size = new Vector2(80);
             InternalChildren = new Drawable[]
             {
-                note = new Container
+                Note = new Container
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -139,7 +139,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             accentColour.BindValueChanged(colour =>
             {
                 explode.Colour = colour.NewValue;
-                note.Colour = colour.NewValue;
+                Note.Colour = colour.NewValue;
             }, true);
         }
 
@@ -163,7 +163,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                         using (BeginDelayedSequence(flash_in, true))
                         {
                             shadow.FadeOut();
-                            note.FadeOut();
+                            Note.FadeOut();
                             this.FadeOut(800);
                         }
                     }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TapCircle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TapCircle.cs
@@ -67,6 +67,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                     {
                         //after the flash, we can hide some elements that were behind it
                         circle.FadeOut();
+                        glow.FadeOut();
 
                         this.FadeOut(800);
                     }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TapCircle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TapCircle.cs
@@ -43,12 +43,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             state.BindValueChanged(updateState, true);
 
             accentColour.BindTo(drawableObject.AccentColour);
-            accentColour.BindValueChanged(colour =>
-            {
-                explode.Colour = colour.NewValue;
-                glow.Colour = colour.NewValue;
-                circle.Colour = colour.NewValue;
-            }, true);
+            accentColour.BindValueChanged(colour => Colour = colour.NewValue, true);
         }
 
         private void updateState(ValueChangedEvent<ArmedState> state)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TapCircle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TapCircle.cs
@@ -43,7 +43,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             state.BindValueChanged(updateState, true);
 
             accentColour.BindTo(drawableObject.AccentColour);
-            accentColour.BindValueChanged(colour => Colour = colour.NewValue, true);
+            accentColour.BindValueChanged(colour =>
+            {
+                explode.Colour = colour.NewValue;
+                circle.Colour = colour.NewValue;
+            }, true);
         }
 
         private void updateState(ValueChangedEvent<ArmedState> state)


### PR DESCRIPTION
Notes will not stick to the ring anymore when the user doesn't hit it on time. The notes will intersect the ring exactly on `StartTime` and will exceed it to some degree depending on the note animation speed.

Under the hood changes include changing the manual update of animations to using transforms via `UpdateInitialTransforms()`. An invalidation will be trigged when the gameplay rate changes (Wind-up/down) or the relevant animation config is adjusted, and will reset all transforms to use the new values.