### PR TITLE
Fix note animations not accounting for ModTimeRamp speed adjustments

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -207,8 +207,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 case ArmedState.Hit:
                     using (BeginDelayedSequence((HitObject as IHasDuration).Duration + Tail.Result.TimeOffset, true))
                     {
-                        this.ScaleTo(1f, time_fade_hit);
                         HitObjectLine.FadeOut();
+                        using (BeginDelayedSequence(time_fade_miss, true))
+                        {
+                            this.FadeOut();
+                            Expire();
+                        }
                     }
                     break;
 
@@ -223,6 +227,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
                         using (BeginDelayedSequence(time_fade_miss, true))
                         {
+                            this.FadeOut();
                             Expire();
                         }
                     }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 AddRangeInternal(new Drawable[]{
                     breakSound = new SkinnableSound(new SampleInfo("Break"))
                 });
-            AdjustedAnimationDuration.BindValueChanged(_ => invalidateTransforms());
+            AdjustedAnimationDuration.BindValueChanged(_ => InvalidateTransforms());
         }
 
         private DrawableSentakkiRuleset drawableSentakkiRuleset;
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             AdjustedAnimationDuration.Value = AnimationDuration.Value * GameplaySpeed;
         }
 
-        private void invalidateTransforms()
+        protected virtual void InvalidateTransforms()
         {
             foreach (var transform in Transforms)
             {
@@ -81,8 +81,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 internalChild.ApplyTransformsAt(double.MinValue, true);
                 internalChild.ClearTransforms(true);
             }
-            UpdateInitialTransforms();
-            UpdateStateTransforms(State.Value);
+            using (BeginAbsoluteSequence(HitObject.StartTime - InitialLifetimeOffset))
+            {
+                UpdateInitialTransforms();
+                double offset = Result?.TimeOffset ?? 0;
+                using (BeginDelayedSequence(InitialLifetimeOffset + offset))
+                    UpdateStateTransforms(State.Value);
+            }
         }
 
         protected virtual bool PlayBreakSample => true;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -147,6 +147,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             ApplyResult(r => r.Type = result);
         }
 
+        protected override void InvalidateTransforms()
+        {
+        }
+
         protected override void UpdateStateTransforms(ArmedState state)
         {
             base.UpdateStateTransforms(state);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -98,6 +98,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         /// </summary>
         public double? HoldStartTime { get; private set; }
 
+        protected override void InvalidateTransforms()
+        {
+        }
+
         protected override void UpdateInitialTransforms()
         {
             double fadeIn = AnimationDuration.Value * GameplaySpeed;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchBlobs.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchBlobs.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                         Alpha= 0,
                         AlwaysPresent = true
                     }
-},
+                },
                 new Container
                 {
                     Masking = true,

--- a/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
         private Track speedAdjustmentTrack => workingBeatmap.Value.Track;
 
-        public double GameplaySpeed => speedAdjustmentTrack.AggregateFrequency.Value * speedAdjustmentTrack.AggregateTempo.Value;
+        public double GameplaySpeed => speedAdjustmentTrack.Rate;
 
         private Bindable<WorkingBeatmap> workingBeatmap;
 

--- a/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Framework.Audio.Track;
 using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
@@ -12,6 +13,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
 using System.Collections.Generic;
+using System;
 
 namespace osu.Game.Rulesets.Sentakki.UI
 {
@@ -23,15 +25,16 @@ namespace osu.Game.Rulesets.Sentakki.UI
         {
         }
 
-        private readonly Track speedAdjustmentTrack = new TrackVirtual(0);
+        private Track speedAdjustmentTrack => workingBeatmap.Value.Track;
 
         public double GameplaySpeed => speedAdjustmentTrack.AggregateFrequency.Value * speedAdjustmentTrack.AggregateTempo.Value;
 
+        private Bindable<WorkingBeatmap> workingBeatmap;
+
         [BackgroundDependencyLoader(true)]
-        private void load()
+        private void load(Bindable<WorkingBeatmap> WorkingBeatmap)
         {
-            foreach (var mod in Mods.OfType<IApplicableToTrack>())
-                mod.ApplyToTrack(speedAdjustmentTrack);
+            workingBeatmap = WorkingBeatmap;
         }
 
         protected override Playfield CreatePlayfield() => new SentakkiPlayfield();


### PR DESCRIPTION
Fixes #90 

This dumps using virtual track in favor of DI-ing the WorkingBeatmap, and getting the track rate from there.

Actual laned notes will now be consistent throughout the whole track.

Unfortunately due to the touch-based notes using a fade/scale in instead of moving, invalidating them causes jarring differences. I have disabled them for now as they don't really benefit much from the adjustments (TouchHold is duration based, and Touch is based on HitWindows, both depend on real time)