### PR TITLE
Fix a certain case where SlideNodes aren't given the proper start time

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -149,6 +149,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             switch (hitObject)
             {
                 case SlideBody.SlideNode node:
+                    node.StartTime = HitObject.StartTime + ShootDelay + (((HitObject as IHasDuration).Duration - ShootDelay) * node.Progress);
                     return new DrawableSlideNode(node, this)
                     {
                         Anchor = Anchor.Centre,

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideNode.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideNode.cs
@@ -50,9 +50,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             base.LoadComplete();
             ThisIndex = Slide.SlideNodes.IndexOf(this);
 
-            // Adjust StartTime to account for the delay, likely a shite way if I do say so myself. Need to revisit.
-            HitObject.StartTime = Slide.HitObject.StartTime + Slide.ShootDelay + (((Slide.HitObject as IHasDuration).Duration - Slide.ShootDelay) * (HitObject as SlideBody.SlideNode).Progress);
-
             OnNewResult += (DrawableHitObject hitObject, JudgementResult result) =>
             {
                 hitPreviousNodes(result.Type >= HitResult.Perfect);


### PR DESCRIPTION
Not sure where in the chain is the cause of the problem, but it seems to be consistently reproducible. Particularly on [RiraN - Unshakable Aspire map](https://osu.ppy.sh/beatmapsets/1237363#osu/2571858)

The fix is as simple as setting the `StartTime` before the creation of `DrawableSlideNode`, instead of within the `LoadComplete()` of the same drawable.