### PR TITLE
Give each lane a dedicated key and positional input zone

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModHardRock.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModHardRock.cs
@@ -22,12 +22,12 @@ namespace osu.Game.Rulesets.Sentakki.Mods
             {
                 switch (d)
                 {
-                    case DrawableHold hold:
-                        hold.HitArea.Size = new Vector2(160);
+                    case DrawableHold _:
+                        //hold.HitArea.Size = new Vector2(160);
                         break;
 
-                    case DrawableTap tap:
-                        tap.HitArea.Size = new Vector2(160);
+                    case DrawableTap _:
+                        //tap.HitArea.Size = new Vector2(160);
                         break;
                 }
             }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -228,6 +228,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             if (AllJudged) return;
             if (HoldStartTime is null) return;
 
+            if (action != SentakkiAction.Key1 + ((SentakkiLanedHitObject)HitObject).Lane)
+                return;
+
             Tail.UpdateResult();
             HoldStartTime = null;
             isHitting.Value = false;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -6,6 +6,8 @@ using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.UI;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osuTK;
 using osuTK.Graphics;
@@ -14,9 +16,8 @@ using System.Diagnostics;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
-    public class DrawableTap : DrawableSentakkiHitObject
+    public class DrawableTap : DrawableSentakkiHitObject, IKeyBindingHandler<SentakkiAction>
     {
-        public readonly HitReceptor HitArea;
         public readonly Drawable TapVisual;
         public readonly HitObjectLine HitObjectLine;
         protected override double InitialLifetimeOffset => 8000;
@@ -32,18 +33,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             AddRangeInternal(new Drawable[] {
                 HitObjectLine = new HitObjectLine(),
                 TapVisual = CreateTapRepresentation(),
-                HitArea = new HitReceptor(HitObject as SentakkiLanedHitObject)
-                {
-                    Hit = () =>
-                    {
-                        if (AllJudged)
-                            return false;
-
-                        UpdateResult(true);
-                        return true;
-                    },
-                    Position = new Vector2(0, -SentakkiPlayfield.INTERSECTDISTANCE),
-                },
             });
         }
 
@@ -122,5 +111,15 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     break;
             }
         }
+
+        public virtual bool OnPressed(SentakkiAction action)
+        {
+            if (action != SentakkiAction.Key1 + ((SentakkiLanedHitObject)HitObject).Lane)
+                return false;
+
+            return UpdateResult(true);
+        }
+
+        public void OnReleased(SentakkiAction action) { }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiLanedHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiLanedHitObject.cs
@@ -1,4 +1,5 @@
 using osu.Framework.Bindables;
+using osu.Game.Rulesets.Sentakki;
 
 namespace osu.Game.Rulesets.Sentakki.Objects
 {

--- a/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
@@ -50,5 +50,29 @@ namespace osu.Game.Rulesets.Sentakki
 
         [Description("Button 2")]
         Button2,
+
+        [Description("Key 1")]
+        Key1,
+
+        [Description("Key 2")]
+        Key2,
+
+        [Description("Key 3")]
+        Key3,
+
+        [Description("Key 4")]
+        Key4,
+
+        [Description("Key 5")]
+        Key5,
+
+        [Description("Key 6")]
+        Key6,
+
+        [Description("Key 7")]
+        Key7,
+
+        [Description("Key 8")]
+        Key8,
     }
 }

--- a/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
@@ -35,6 +35,11 @@ namespace osu.Game.Rulesets.Sentakki
 
         public IEnumerable<SentakkiAction> PressedActions => KeyBindingContainer.PressedActions;
 
+
+        // For makeshift virtual input handling
+        public void TriggerPressed(SentakkiAction action) => KeyBindingContainer.TriggerPressed(action);
+        public void TriggerReleased(SentakkiAction action) => KeyBindingContainer.TriggerReleased(action);
+
         public SentakkiInputManager(RulesetInfo ruleset)
             : base(ruleset, 0, SimultaneousBindingMode.Unique)
         {

--- a/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
@@ -35,7 +35,6 @@ namespace osu.Game.Rulesets.Sentakki
 
         public IEnumerable<SentakkiAction> PressedActions => KeyBindingContainer.PressedActions;
 
-
         // For makeshift virtual input handling
         public void TriggerPressed(SentakkiAction action) => KeyBindingContainer.TriggerPressed(action);
         public void TriggerReleased(SentakkiAction action) => KeyBindingContainer.TriggerReleased(action);

--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -96,6 +96,14 @@ namespace osu.Game.Rulesets.Sentakki
             new KeyBinding(InputKey.X, SentakkiAction.Button2),
             new KeyBinding(InputKey.MouseLeft, SentakkiAction.Button1),
             new KeyBinding(InputKey.MouseRight, SentakkiAction.Button2),
+            new KeyBinding(InputKey.Number1, SentakkiAction.Key1),
+            new KeyBinding(InputKey.Number2, SentakkiAction.Key2),
+            new KeyBinding(InputKey.Number3, SentakkiAction.Key3),
+            new KeyBinding(InputKey.Number4, SentakkiAction.Key4),
+            new KeyBinding(InputKey.Number5, SentakkiAction.Key5),
+            new KeyBinding(InputKey.Number6, SentakkiAction.Key6),
+            new KeyBinding(InputKey.Number7, SentakkiAction.Key7),
+            new KeyBinding(InputKey.Number8, SentakkiAction.Key8),
         };
 
         public override StatisticRow[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap) => new[]

--- a/osu.Game.Rulesets.Sentakki/UI/Lane.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Lane.cs
@@ -55,25 +55,11 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
             private void handleKeyPress(ValueChangedEvent<int> keys)
             {
-                ReplayState<SentakkiAction> RemovalState = new ReplayState<SentakkiAction>()
-                {
-                    PressedActions = SentakkiActionInputManager.PressedActions.ToList()
-                };
-
-                RemovalState.PressedActions.RemoveAll(x => x == SentakkiAction.Key1 + ((Lane)Parent).LaneNumber);
-
                 if (keys.NewValue > keys.OldValue || keys.NewValue == 0)
-                    RemovalState.Apply(SentakkiActionInputManager.CurrentState, sentakkiActionInputManager);
+                    SentakkiActionInputManager.TriggerReleased(SentakkiAction.Key1 + ((Lane)Parent).LaneNumber);
 
                 if (keys.NewValue > keys.OldValue)
-                {
-                    ReplayState<SentakkiAction> NewState = new ReplayState<SentakkiAction>()
-                    {
-                        PressedActions = SentakkiActionInputManager.PressedActions.ToList()
-                    };
-                    NewState.PressedActions.Add(SentakkiAction.Key1 + ((Lane)Parent).LaneNumber);
-                    NewState.Apply(SentakkiActionInputManager.CurrentState, sentakkiActionInputManager);
-                }
+                    SentakkiActionInputManager.TriggerPressed(SentakkiAction.Key1 + ((Lane)Parent).LaneNumber);
             }
         }
     }

--- a/osu.Game.Rulesets.Sentakki/UI/Lane.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Lane.cs
@@ -34,12 +34,12 @@ namespace osu.Game.Rulesets.Sentakki.UI
             public LaneReceptor()
             {
                 Position = SentakkiExtensions.GetCircularPosition(SentakkiPlayfield.INTERSECTDISTANCE, 0);
-                Size = new Vector2(240);
+                Size = new Vector2(300);
 
                 Anchor = Anchor.Centre;
                 Origin = Anchor.Centre;
 
-                CornerRadius = 120;
+                CornerRadius = 150;
                 CornerExponent = 2;
                 currentKeys.BindValueChanged(handleKeyPress);
             }

--- a/osu.Game.Rulesets.Sentakki/UI/Lane.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Lane.cs
@@ -1,19 +1,77 @@
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 using osu.Game.Rulesets.UI;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Screens.Play;
+using static osu.Game.Input.Handlers.ReplayInputHandler;
+using osuTK;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace osu.Game.Rulesets.Sentakki.UI
 {
     public class Lane : Playfield
     {
+        public int LaneNumber { get; set; }
+
         public Lane()
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             RelativeSizeAxes = Axes.None;
             AddRangeInternal(new Drawable[]{
-                HitObjectContainer
+                HitObjectContainer,
+                new LaneReceptor()
             });
+        }
+
+        public class LaneReceptor : CompositeDrawable
+        {
+            private SentakkiInputManager sentakkiActionInputManager;
+            internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= GetContainingInputManager() as SentakkiInputManager;
+
+            public override bool HandlePositionalInput => true;
+            public LaneReceptor()
+            {
+                Position = SentakkiExtensions.GetCircularPosition(SentakkiPlayfield.INTERSECTDISTANCE, 0);
+                Size = new Vector2(240);
+
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+
+                CornerRadius = 120;
+                CornerExponent = 2;
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+                ReplayState<SentakkiAction> state = new ReplayState<SentakkiAction>()
+                {
+                    PressedActions = SentakkiActionInputManager.PressedActions.ToList()
+                };
+
+                if (IsHovered && SentakkiActionInputManager.PressedActions.Any(x => x < SentakkiAction.Key1))
+                {
+                    if (!state.PressedActions.Contains(SentakkiAction.Key1 + ((Lane)Parent).LaneNumber))
+                        state.PressedActions.Add(SentakkiAction.Key1 + ((Lane)Parent).LaneNumber);
+                }
+                else
+                {
+                    if (state.PressedActions.Contains(SentakkiAction.Key1 + ((Lane)Parent).LaneNumber))
+                        state.PressedActions.RemoveAll(x => x == SentakkiAction.Key1 + ((Lane)Parent).LaneNumber);
+                }
+
+                state.Apply(SentakkiActionInputManager.CurrentState, SentakkiActionInputManager);
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/LanedPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/LanedPlayfield.cs
@@ -25,9 +25,13 @@ namespace osu.Game.Rulesets.Sentakki.UI
             AddInternal(slideBodyProxyContainer = new SortedDrawableProxyContainer());
             AddInternal(lanedNoteProxyContainer = new SortedDrawableProxyContainer());
 
-            foreach (var angle in SentakkiPlayfield.LANEANGLES)
+            for (int i = 0; i < 8; ++i)
             {
-                var lane = new Lane { Rotation = angle, };
+                var lane = new Lane
+                {
+                    Rotation = i.GetRotationForLane(),
+                    LaneNumber = i
+                };
                 Lanes.Add(lane);
                 AddInternal(lane);
                 AddNested(lane);


### PR DESCRIPTION
Prerequisites:
* [x] Depends on #104 

~~**Breaks replays due to their inability to store non legacy states**~~ Switching to directly triggering actions in `KeyBindingContainer` makes replays work again, but only if the auxiliary actions are used. Keyboard only/touch will not be preserved for now.

This allows each lane to receive its own keybindings, for those who want to play using a keyboard or another device that is appropriate. The notes will only handle actions matching the specific lane they are in. 

The positional input zones of each lane will act like a dedicated lane button has been pressed whenever Button1/Button2 is pressed while it is being hovered. This closely mimics the way maimai handles touch input. And this change will further simplify the implementation of touch handling.