### PR TITLE
Add nested ScorePadding objects in BREAKS instead of using a separate judgement type

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Judgements/SentakkiBreakJudgement.cs
+++ b/osu.Game.Rulesets.Sentakki/Judgements/SentakkiBreakJudgement.cs
@@ -5,44 +5,5 @@ namespace osu.Game.Rulesets.Sentakki.Judgements
     public class SentakkiBreakJudgement : SentakkiJudgement
     {
         public override HitResult MaxResult => HitResult.Perfect;
-        protected override int NumericResultFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Meh:
-                    return 1000;
-
-                case HitResult.Good:
-                    return 2000;
-
-                case HitResult.Great:
-                    return 2500;
-                case HitResult.Perfect:
-                    return 2600;
-            }
-        }
-
-        protected override double HealthIncreaseFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Miss:
-                    return -0.4;
-
-                case HitResult.Meh:
-                case HitResult.Good:
-                case HitResult.Great:
-                    return 0.4;
-
-                case HitResult.Perfect:
-                    return 0.6;
-            }
-        }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Judgements/SentakkiBreakJudgement.cs
+++ b/osu.Game.Rulesets.Sentakki/Judgements/SentakkiBreakJudgement.cs
@@ -1,9 +1,0 @@
-using osu.Game.Rulesets.Scoring;
-
-namespace osu.Game.Rulesets.Sentakki.Judgements
-{
-    public class SentakkiBreakJudgement : SentakkiJudgement
-    {
-        public override HitResult MaxResult => HitResult.Perfect;
-    }
-}

--- a/osu.Game.Rulesets.Sentakki/Judgements/SentakkiJudgement.cs
+++ b/osu.Game.Rulesets.Sentakki/Judgements/SentakkiJudgement.cs
@@ -5,45 +5,6 @@ namespace osu.Game.Rulesets.Sentakki.Judgements
 {
     public class SentakkiJudgement : Judgement
     {
-        public override HitResult MaxResult => HitResult.Great;
-
-        protected override int NumericResultFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Meh:
-                    return 250;
-
-                case HitResult.Good:
-                    return 400;
-
-                case HitResult.Great:
-                case HitResult.Perfect:
-                    return 500;
-            }
-        }
-
-        protected override double HealthIncreaseFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Miss:
-                    return -0.1;
-
-                case HitResult.Meh:
-                case HitResult.Good:
-                case HitResult.Great:
-                    return 0.2;
-
-                case HitResult.Perfect:
-                    return 0.3;
-            }
-        }
+        public override HitResult MaxResult => HitResult.Perfect;
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModAutoplay.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModAutoplay.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Sentakki.Mods
             foreach (var d in drawables.OfType<DrawableSentakkiHitObject>())
             {
                 d.Auto = true;
-                foreach (DrawableSentakkiHitObject nested in d.NestedHitObjects)
+                foreach (DrawableSentakkiHitObject nested in d.NestedHitObjects.Where(obj => obj is DrawableSentakkiHitObject))
                     nested.Auto = true;
             }
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableScorePaddingObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableScorePaddingObject.cs
@@ -1,0 +1,14 @@
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Judgements;
+using System;
+
+public class DrawableScorePaddingObject : DrawableHitObject<ScorePaddingObject>
+{
+    public DrawableScorePaddingObject(ScorePaddingObject hitObject)
+        : base(hitObject)
+    {
+    }
+
+    public new void ApplyResult(Action<JudgementResult> application) => base.ApplyResult(application);
+}

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using osu.Game.Rulesets.Judgements;
 using System.Linq;
 using osu.Framework.Graphics.Containers;
+using System;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
@@ -68,7 +69,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 });
             AddInternal(scorePaddingObjects = new Container<DrawableScorePaddingObject>());
             AdjustedAnimationDuration.BindValueChanged(_ => InvalidateTransforms());
-            OnNewResult += applyBreakResult;
         }
 
         private DrawableSentakkiRuleset drawableSentakkiRuleset;
@@ -146,11 +146,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             return base.CreateNestedHitObject(hitObject);
         }
 
-        private void applyBreakResult(DrawableHitObject hitObject, JudgementResult judgement)
+        protected new void ApplyResult(Action<JudgementResult> application)
         {
-            if (hitObject != this) return;
-            foreach (DrawableScorePaddingObject breakObj in scorePaddingObjects)
-                breakObj.ApplyResult(r => r.Type = judgement.Type);
+            // Apply judgement to this object
+            base.ApplyResult(application);
+
+            // Also give Break note score padding a judgement
+            foreach (var breakObj in scorePaddingObjects)
+                breakObj.ApplyResult(application);
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 AddRangeInternal(new Drawable[]{
                     breakSound = new SkinnableSound(new SampleInfo("Break")),
                 });
-            AddInternal(nestedBreakObjects = new Container<SentakkiDrawableBreak>());
+            AddInternal(scorePaddingObjects = new Container<DrawableScorePaddingObject>());
             AdjustedAnimationDuration.BindValueChanged(_ => InvalidateTransforms());
             OnNewResult += applyBreakResult;
         }
@@ -124,24 +124,24 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             }
         }
 
-        private Container<SentakkiDrawableBreak> nestedBreakObjects;
+        private Container<DrawableScorePaddingObject> scorePaddingObjects;
 
         protected override void ClearNestedHitObjects()
         {
             base.ClearNestedHitObjects();
-            nestedBreakObjects.Clear();
+            scorePaddingObjects.Clear();
         }
         protected override void AddNestedHitObject(DrawableHitObject hitObject)
         {
             base.AddNestedHitObject(hitObject);
-            if (hitObject is SentakkiDrawableBreak x)
-                nestedBreakObjects.Add(x);
+            if (hitObject is DrawableScorePaddingObject x)
+                scorePaddingObjects.Add(x);
         }
 
         protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)
         {
-            if (hitObject is SentakkiHitObject.SentakkiBreakDummyObject x)
-                return new SentakkiDrawableBreak(x);
+            if (hitObject is ScorePaddingObject x)
+                return new DrawableScorePaddingObject(x);
 
             return base.CreateNestedHitObject(hitObject);
         }
@@ -149,20 +149,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         private void applyBreakResult(DrawableHitObject hitObject, JudgementResult judgement)
         {
             if (hitObject != this) return;
-            foreach (SentakkiDrawableBreak breakObj in nestedBreakObjects)
-                breakObj.ApplyHitResult(judgement.Type);
-
-
-
-        }
-
-        public class SentakkiDrawableBreak : DrawableHitObject
-        {
-            public override bool DisplayResult => false;
-            public SentakkiDrawableBreak(SentakkiHitObject.SentakkiBreakDummyObject hitObject)
-            : base(hitObject) { }
-
-            public void ApplyHitResult(HitResult result) => ApplyResult(r => r.Type = result);
+            foreach (DrawableScorePaddingObject breakObj in scorePaddingObjects)
+                breakObj.ApplyResult(r => r.Type = judgement.Type);
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/ScorePaddingObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/ScorePaddingObject.cs
@@ -1,0 +1,15 @@
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Sentakki.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Rulesets.Sentakki.Objects
+{
+    // Used to increase the weighting of an object
+    public class ScorePaddingObject : HitObject
+    {
+        public override Judgement CreateJudgement() => new SentakkiJudgement();
+
+        protected override HitWindows CreateHitWindows() => HitWindows.Empty;
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
@@ -7,6 +7,7 @@ using osu.Game.Rulesets.Objects;
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
+using System.Threading;
 
 namespace osu.Game.Rulesets.Sentakki.Objects
 {
@@ -15,10 +16,29 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         public virtual bool IsBreak { get; set; } = false;
         public virtual bool HasTwin { get; set; } = false;
 
-        public override Judgement CreateJudgement() => IsBreak ? new SentakkiBreakJudgement() : new SentakkiJudgement();
+        public override Judgement CreateJudgement() => new SentakkiJudgement();
 
         public virtual Color4 NoteColor => IsBreak ? Color4.OrangeRed : (HasTwin ? Color4.Gold : Color4Extensions.FromHex("ff0064"));
 
         protected override HitWindows CreateHitWindows() => new SentakkiHitWindows();
+
+        protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
+        {
+            base.CreateNestedHitObjects(cancellationToken);
+
+            if (IsBreak)
+                for (int i = 0; i < 5; ++i)
+                    AddNested(new SentakkiBreakDummyObject()
+                    {
+                        StartTime = StartTime
+                    });
+        }
+
+        // Used to increase weighting of notes with break modifier
+        public class SentakkiBreakDummyObject : HitObject
+        {
+            protected override HitWindows CreateHitWindows() => HitWindows.Empty;
+            public override Judgement CreateJudgement() => new SentakkiJudgement();
+        }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             base.CreateNestedHitObjects(cancellationToken);
 
             if (IsBreak)
-                for (int i = 0; i < 5; ++i)
+                for (int i = 0; i < 4; ++i)
                     AddNested(new ScorePaddingObject());
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
             if (IsBreak)
                 for (int i = 0; i < 4; ++i)
-                    AddNested(new ScorePaddingObject());
+                    AddNested(new ScorePaddingObject() { StartTime = this.GetEndTime() });
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
@@ -28,17 +28,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
             if (IsBreak)
                 for (int i = 0; i < 5; ++i)
-                    AddNested(new SentakkiBreakDummyObject()
-                    {
-                        StartTime = StartTime
-                    });
-        }
-
-        // Used to increase weighting of notes with break modifier
-        public class SentakkiBreakDummyObject : HitObject
-        {
-            protected override HitWindows CreateHitWindows() => HitWindows.Empty;
-            public override Judgement CreateJudgement() => new SentakkiJudgement();
+                    AddNested(new ScorePaddingObject());
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Slide.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Slide.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
         {
-            base.CreateNestedHitObjects(cancellationToken);
+            //base.CreateNestedHitObjects(cancellationToken);
 
             AddNested(new Tap
             {

--- a/osu.Game.Rulesets.Sentakki/Scoring/SentakkiScoreProcessor.cs
+++ b/osu.Game.Rulesets.Sentakki/Scoring/SentakkiScoreProcessor.cs
@@ -6,7 +6,5 @@ namespace osu.Game.Rulesets.Sentakki.Scoring
     {
         protected override double DefaultAccuracyPortion => 0.9;
         protected override double DefaultComboPortion => 0.1;
-
-        public override HitWindows CreateHitWindows() => new SentakkiHitWindows();
     }
 }

--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -10,6 +10,7 @@ using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Sentakki.Beatmaps;
+using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Difficulty;
 using osu.Game.Rulesets.Sentakki.Mods;
@@ -24,6 +25,7 @@ using osu.Game.Rulesets.UI;
 using System.Collections.Generic;
 using System;
 using osuTK;
+using System.Linq;
 
 namespace osu.Game.Rulesets.Sentakki
 {
@@ -124,7 +126,7 @@ namespace osu.Game.Rulesets.Sentakki
             {
                 Columns = new[]
                 {
-                    new StatisticItem("Judgement Distribution", new JudgementChart(score.HitEvents)
+                    new StatisticItem("Judgement Distribution", new JudgementChart(score.HitEvents.Where(e=>e.HitObject is SentakkiHitObject).ToList())
                     {
                         RelativeSizeAxes = Axes.X,
                         Size = new Vector2(1, 250)

--- a/osu.Game.Rulesets.Sentakki/Statistics/JudgementChart.cs
+++ b/osu.Game.Rulesets.Sentakki/Statistics/JudgementChart.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Graphics.UserInterface;
 using osuTK.Graphics;
 using osuTK;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace osu.Game.Rulesets.Sentakki.Statistics
 {
@@ -102,10 +103,10 @@ namespace osu.Game.Rulesets.Sentakki.Statistics
                     }
                 }
 
-                Color4 textColour = HitEvents.Count == 0 ? Color4Extensions.FromHex("bcbcbc") : (GreatCount == HitEvents.Count) ? Color4.White : Color4Extensions.FromHex("#3c5394");
-                Color4 boxColour = HitEvents.Count == 0 ? Color4Extensions.FromHex("808080") : (GreatCount == HitEvents.Count) ? Color4Extensions.FromHex("fda908") : Color4Extensions.FromHex("#DCE9F9");
-                Color4 borderColour = HitEvents.Count == 0 ? Color4Extensions.FromHex("536277") : (GreatCount == HitEvents.Count) ? Color4Extensions.FromHex("fda908") : Color4Extensions.FromHex("#98b8df");
-                Color4 numberColour = (GreatCount == HitEvents.Count && HitEvents.Count > 0) ? Color4.White : Color4Extensions.FromHex("#3c5394");
+                Color4 textColour = !HitEvents.Any() ? Color4Extensions.FromHex("bcbcbc") : (GreatCount == HitEvents.Count) ? Color4.White : Color4Extensions.FromHex("#3c5394");
+                Color4 boxColour = !HitEvents.Any() ? Color4Extensions.FromHex("808080") : (GreatCount == HitEvents.Count) ? Color4Extensions.FromHex("fda908") : Color4Extensions.FromHex("#DCE9F9");
+                Color4 borderColour = !HitEvents.Any() ? Color4Extensions.FromHex("536277") : (GreatCount == HitEvents.Count) ? Color4Extensions.FromHex("fda908") : Color4Extensions.FromHex("#98b8df");
+                Color4 numberColour = (GreatCount == HitEvents.Count && HitEvents.Any()) ? Color4.White : Color4Extensions.FromHex("#3c5394");
 
                 Anchor = Anchor.TopCentre;
                 Origin = Anchor.TopCentre;
@@ -153,7 +154,7 @@ namespace osu.Game.Rulesets.Sentakki.Statistics
                         Children = new Drawable[]{
                             new Box{
                                 RelativeSizeAxes = Axes.Both,
-                                Colour = (HitEvents.Count ==0) ? Color4Extensions.FromHex("343434"):Color4.DarkGray,
+                                Colour = !HitEvents.Any() ? Color4Extensions.FromHex("343434"):Color4.DarkGray,
                             }
                         }
                     },

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -123,7 +123,8 @@ namespace osu.Game.Rulesets.Sentakki.UI
             if (!judgedObject.DisplayResult || !DisplayJudgements.Value)
                 return;
 
-            var sentakkiObj = (DrawableSentakkiHitObject)judgedObject;
+            var sentakkiObj = judgedObject as DrawableSentakkiHitObject;
+            if (sentakkiObj is null) return;
 
             DrawableSentakkiJudgement explosion;
             switch (judgedObject.HitObject)


### PR DESCRIPTION
This is to mitigate the changes caused by https://github.com/ppy/osu/pull/10288.

This allows notes with the Break modifier to roughly retain the same weighting. It's not exactly the same, as the score values are different as well. Combo will also increase by 5 every time a Break note is judged.

Greats and Perfects will have different scoring on all note types, so gameplay will be more punishing in general.

Further damage control will come in future PRs.