### PR TITLE
Remove perfect judgement

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/Statistics/TestSceneJudgementChart.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Statistics/TestSceneJudgementChart.cs
@@ -13,12 +13,12 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Statistics
         private List<HitEvent> testevents = new List<HitEvent>
         {
             // Tap
-            new HitEvent(0,HitResult.Perfect,new Tap(),new Tap(), null),
-            new HitEvent(0,HitResult.Perfect,new Tap(),new Tap(), null),
-            new HitEvent(0,HitResult.Perfect,new Tap(),new Tap(), null),
-            new HitEvent(0,HitResult.Perfect,new Tap(),new Tap(), null),
-            new HitEvent(0,HitResult.Perfect,new Tap(),new Tap(), null),
-            new HitEvent(0,HitResult.Perfect,new Tap(),new Tap(), null),
+            new HitEvent(0,HitResult.Great,new Tap(),new Tap(), null),
+            new HitEvent(0,HitResult.Great,new Tap(),new Tap(), null),
+            new HitEvent(0,HitResult.Great,new Tap(),new Tap(), null),
+            new HitEvent(0,HitResult.Great,new Tap(),new Tap(), null),
+            new HitEvent(0,HitResult.Great,new Tap(),new Tap(), null),
+            new HitEvent(0,HitResult.Great,new Tap(),new Tap(), null),
             new HitEvent(0,HitResult.Good,new Tap(),new Tap(), null),
             new HitEvent(0,HitResult.Good,new Tap(),new Tap(), null),
             new HitEvent(0,HitResult.Good,new Tap(),new Tap(), null),
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Statistics
             new HitEvent(0,HitResult.Miss,new Tap(),new Tap(), null),
             new HitEvent(0,HitResult.Miss,new Tap(),new Tap(), null),
             // Holds
-            new HitEvent(0,HitResult.Perfect,new Hold(),new Tap(), null),
+            new HitEvent(0,HitResult.Great,new Hold(),new Tap(), null),
             // Touch
             new HitEvent(0,HitResult.Good,new Touch(),new Tap(), null),
             new HitEvent(0,HitResult.Good,new Touch(),new Tap(), null),
@@ -41,10 +41,10 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Statistics
             new HitEvent(0,HitResult.Meh,new Touch(),new Tap(), null),
             new HitEvent(0,HitResult.Miss,new Touch(),new Tap(), null),
             new HitEvent(0,HitResult.Miss,new Touch(),new Tap(), null),
-            new HitEvent(0,HitResult.Perfect,new Touch(),new Tap(), null),
-            new HitEvent(0,HitResult.Perfect,new Touch(),new Tap(), null),
+            new HitEvent(0,HitResult.Great,new Touch(),new Tap(), null),
+            new HitEvent(0,HitResult.Great,new Touch(),new Tap(), null),
             // Breaks
-            new HitEvent(0,HitResult.Perfect,new Tap(){IsBreak = true},new Tap(), null),
+            new HitEvent(0,HitResult.Great,new Tap(){IsBreak = true},new Tap(), null),
             new HitEvent(0,HitResult.Good,new Tap(){IsBreak = true},new Tap(), null),
             new HitEvent(0,HitResult.Good,new Tap(){IsBreak = true},new Tap(), null),
             new HitEvent(0,HitResult.Good,new Tap(){IsBreak = true},new Tap(), null),

--- a/osu.Game.Rulesets.Sentakki/Judgements/SentakkiJudgement.cs
+++ b/osu.Game.Rulesets.Sentakki/Judgements/SentakkiJudgement.cs
@@ -5,6 +5,6 @@ namespace osu.Game.Rulesets.Sentakki.Judgements
 {
     public class SentakkiJudgement : Judgement
     {
-        public override HitResult MaxResult => HitResult.Perfect;
+        public override HitResult MaxResult => HitResult.Great;
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     if (!headContainer.First().Result.HasResult)
                         headContainer.First().MissForcefully();
 
-                    if (Auto) result = HitResult.Perfect;
+                    if (Auto) result = HitResult.Great;
                     ApplyResult(r => r.Type = result);
                 }
             }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -140,14 +140,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     double totalHoldRatio = TotalHoldTime / ((IHasDuration)HitObject).Duration;
                     HitResult result;
 
-                    if (totalHoldRatio >= .9)
-                        result = HitResult.Perfect;
-                    else if (totalHoldRatio >= .75)
+                    if (totalHoldRatio >= .75)
                         result = HitResult.Great;
                     else if (totalHoldRatio >= .5)
                         result = HitResult.Good;
                     else if (totalHoldRatio >= .25)
-                        result = HitResult.Ok;
+                        result = HitResult.Meh;
                     else
                         result = HitResult.Miss;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHoldHead.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHoldHead.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             if (!userTriggered)
             {
                 if (Auto && timeOffset > 0)
-                    ApplyResult(r => r.Type = HitResult.Perfect);
+                    ApplyResult(r => r.Type = HitResult.Great);
 
                 if (!HitObject.HitWindows.CanBeHit(timeOffset))
                     ApplyResult(r => r.Type = HitResult.Miss);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public override void PlaySamples()
         {
             base.PlaySamples();
-            if (PlayBreakSample && breakSound != null && Result.Type == HitResult.Perfect && breakEnabled.Value && (!gameplayClock?.IsSeeking ?? false))
+            if (PlayBreakSample && breakSound != null && Result.Type == HitResult.Great && breakEnabled.Value && (!gameplayClock?.IsSeeking ?? false))
             {
                 const float balance_adjust_amount = 0.4f;
                 breakSound.Balance.Value = balance_adjust_amount * (userPositionalHitSounds.Value ? SamplePlaybackPosition - 0.5f : 0);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiJudgement.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiJudgement.cs
@@ -41,11 +41,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             {
                 switch (Result.Type)
                 {
-                    case HitResult.Perfect:
-                        sentakkiJudgementText.Text = "Critical";
-                        sentakkiJudgementText.Colour = Color4.Yellow;
-                        break;
-
                     case HitResult.Great:
                         sentakkiJudgementText.Text = "Perfect";
                         break;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -185,7 +185,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 {
                     SlideNodes.Last().ForceJudgement(false);
                     if (SlideNodes.Count(node => !node.Result.IsHit) <= 2)
-                        ApplyResult(r => r.Type = HitResult.Good);
+                        ApplyResult(r => r.Type = HitResult.Meh);
                     else
                         ApplyResult(r => r.Type = HitResult.Miss);
                 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideNode.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideNode.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             OnNewResult += (DrawableHitObject hitObject, JudgementResult result) =>
             {
-                hitPreviousNodes(result.Type >= HitResult.Perfect);
+                hitPreviousNodes(result.Type >= HitResult.Great);
                 if (result.IsHit)
                     Slide.Slidepath.Progress = (HitObject as SlideBody.SlideNode).Progress;
             };

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             if (!userTriggered)
             {
                 if (Auto && timeOffset > 0)
-                    ApplyResult(r => r.Type = HitResult.Perfect);
+                    ApplyResult(r => r.Type = HitResult.Great);
 
                 if (!HitObject.HitWindows.CanBeHit(timeOffset))
                 {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -143,7 +143,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             if (!userTriggered || AutoTouch)
             {
                 if ((Auto || AutoTouch) && timeOffset > 0)
-                    ApplyResult(r => r.Type = HitResult.Perfect);
+                    ApplyResult(r => r.Type = HitResult.Great);
 
                 if (!HitObject.HitWindows.CanBeHit(timeOffset))
                     ApplyResult(r => r.Type = HitResult.Miss);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -61,14 +61,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             HitResult resultType;
 
-            if (result >= .9)
-                resultType = HitResult.Perfect;
-            else if (result >= .75)
+            if (result >= .75)
                 resultType = HitResult.Great;
             else if (result >= .5)
                 resultType = HitResult.Good;
             else if (result >= .25)
-                resultType = HitResult.Ok;
+                resultType = HitResult.Meh;
             else
                 resultType = HitResult.Miss;
 

--- a/osu.Game.Rulesets.Sentakki/Scoring/SentakkiHitWindows.cs
+++ b/osu.Game.Rulesets.Sentakki/Scoring/SentakkiHitWindows.cs
@@ -8,7 +8,6 @@ namespace osu.Game.Rulesets.Sentakki.Scoring
         {
             switch (result)
             {
-                case HitResult.Perfect:
                 case HitResult.Great:
                 case HitResult.Good:
                 case HitResult.Meh:
@@ -24,7 +23,6 @@ namespace osu.Game.Rulesets.Sentakki.Scoring
             new DifficultyRange(HitResult.Meh, 144, 144, 144),
             new DifficultyRange(HitResult.Good, 96, 96, 96),
             new DifficultyRange(HitResult.Great, 48, 48, 48),
-            new DifficultyRange(HitResult.Perfect, 16, 16, 16)
         };
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Scoring/SentakkiSlideHitWindows.cs
+++ b/osu.Game.Rulesets.Sentakki/Scoring/SentakkiSlideHitWindows.cs
@@ -8,8 +8,7 @@ namespace osu.Game.Rulesets.Sentakki.Scoring
             new DifficultyRange(HitResult.Miss, 576, 576, 576),
             new DifficultyRange(HitResult.Meh, 576, 576, 576),
             new DifficultyRange(HitResult.Good, 416, 416, 416),
-            new DifficultyRange(HitResult.Great, 288, 288, 288),
-            new DifficultyRange(HitResult.Perfect, 224, 224, 224)
+            new DifficultyRange(HitResult.Great, 288, 288, 288)
         };
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Scoring/SentakkiTouchHitWindows.cs
+++ b/osu.Game.Rulesets.Sentakki/Scoring/SentakkiTouchHitWindows.cs
@@ -9,7 +9,6 @@ namespace osu.Game.Rulesets.Sentakki.Scoring
             new DifficultyRange(HitResult.Meh, 288, 288, 288),
             new DifficultyRange(HitResult.Good, 240, 240, 240),
             new DifficultyRange(HitResult.Great, 192, 192, 192),
-            new DifficultyRange(HitResult.Perfect, 144, 144, 144)
         };
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Statistics/JudgementChart.cs
+++ b/osu.Game.Rulesets.Sentakki/Statistics/JudgementChart.cs
@@ -90,7 +90,6 @@ namespace osu.Game.Rulesets.Sentakki.Statistics
                 {
                     switch (e.Result)
                     {
-                        case HitResult.Perfect:
                         case HitResult.Great:
                             ++GreatCount;
                             goto case HitResult.Good;


### PR DESCRIPTION
Further mitigation to the changes caused by ppy/osu#10288.

The max result is now Great, for all notes.

Might consider shifting the judgements from `Meh/Good/Great` to `Good/Great/Perfect`, once `Perfects` have their own hit result colours.