### PR TITLE
Fix build error caused by change in osu.Game

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
@@ -29,47 +29,47 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 new SettingsCheckbox
                 {
                     LabelText = "Use maimai style judgement text (In-game only)",
-                    Bindable = config.GetBindable<bool>(SentakkiRulesetSettings.MaimaiJudgements)
+                    Current = config.GetBindable<bool>(SentakkiRulesetSettings.MaimaiJudgements)
                 },
                 new SettingsCheckbox
                 {
                     LabelText = "Show Kiai effects",
-                    Bindable = config.GetBindable<bool>(SentakkiRulesetSettings.KiaiEffects)
+                    Current = config.GetBindable<bool>(SentakkiRulesetSettings.KiaiEffects)
                 },
                 new SettingsCheckbox
                 {
                     LabelText = "Play Break sample when hitting BREAKs perfectly",
-                    Bindable = config.GetBindable<bool>(SentakkiRulesetSettings.BreakSounds)
+                    Current = config.GetBindable<bool>(SentakkiRulesetSettings.BreakSounds)
                 },
                 new SettingsCheckbox
                 {
                     LabelText = "Play Slide sample when beginning to slide",
-                    Bindable = config.GetBindable<bool>(SentakkiRulesetSettings.SlideSounds)
+                    Current = config.GetBindable<bool>(SentakkiRulesetSettings.SlideSounds)
                 },
                 new SettingsCheckbox
                 {
                     LabelText = "Show note start indicators",
-                    Bindable = config.GetBindable<bool>(SentakkiRulesetSettings.ShowNoteStartIndicators)
+                    Current = config.GetBindable<bool>(SentakkiRulesetSettings.ShowNoteStartIndicators)
                 },
                 new SettingsEnumDropdown<ColorOption>
                 {
                     LabelText = "Ring Colour",
-                    Bindable = config.GetBindable<ColorOption>(SentakkiRulesetSettings.RingColor)
+                    Current = config.GetBindable<ColorOption>(SentakkiRulesetSettings.RingColor)
                 },
                 new SettingsSlider<double, NoteTimeSlider>
                 {
                     LabelText = "Note entry speed",
-                    Bindable = config.GetBindable<double>(SentakkiRulesetSettings.AnimationDuration),
+                    Current = config.GetBindable<double>(SentakkiRulesetSettings.AnimationDuration),
                 },
                 new SettingsSlider<double, TouchTimeSlider>
                 {
                     LabelText = "Touch note fade-in speed",
-                    Bindable = config.GetBindable<double>(SentakkiRulesetSettings.TouchAnimationDuration),
+                    Current = config.GetBindable<double>(SentakkiRulesetSettings.TouchAnimationDuration),
                 },
                 new SettingsSlider<float>
                 {
                     LabelText = "Ring Opacity",
-                    Bindable = config.GetBindable<float>(SentakkiRulesetSettings.RingOpacity),
+                    Current = config.GetBindable<float>(SentakkiRulesetSettings.RingOpacity),
                     KeyboardStep = 0.01f,
                     DisplayAsPercentage = true
                 },

--- a/osu.Game.Rulesets.Sentakki/osu.Game.Rulesets.Sentakki.csproj
+++ b/osu.Game.Rulesets.Sentakki/osu.Game.Rulesets.Sentakki.csproj
@@ -10,6 +10,6 @@
     <AssemblyName>osu.Game.Rulesets.Sentakki</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2020.1005.0"/>
+    <PackageReference Include="ppy.osu.Game" Version="2020.1009.0"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Bindable was changed to Current as a part of a future code refactor in osu.Game

This causes most, if not all community rulesets to fail in the building stage. Luckily, in this case, Sentakki only has the settings problem, with Cytosu and Tau having obsoleted code in other parts as well.
A compatibility layer was added to make sure that existing builds are compatible with newer versions, but building rulesets now require Bindables in the SettingSubsection.cs to be changed to Current.

Note: Build will most likely fail as the latest NuGet package for osu.Game hasn’t reflected this change yet.