### PR TITLE
Fix performance issues when using default note speed

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -29,7 +29,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public DrawableSentakkiHitObject(SentakkiHitObject hitObject)
             : base(hitObject)
         {
-            AnimationDuration.BindValueChanged(_ => queueTransformReset());
         }
 
         private DrawableSentakkiRuleset drawableSentakkiRuleset;
@@ -42,6 +41,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         private void load(DrawableSentakkiRuleset drawableRuleset)
         {
             drawableSentakkiRuleset = drawableRuleset;
+        }
+
+        protected override void LoadAsyncComplete()
+        {
+            base.LoadAsyncComplete();
+            AnimationDuration.BindValueChanged(_ => queueTransformReset(), true);
         }
 
         protected override void Update()


### PR DESCRIPTION
This was due to the `LifetimeStart` not being set correctly for the DHO (and more importantly, the proxied notes) due to the AnimationDuration bindable not triggering the callback used to set the correct lifetimes if they are the default value, causing them to not alive before they should.

---

An interesting finding is that, by starting with the default note speed(on current master, which doesn't set the lifetime properly), and then adjusting it so that it corrects `LifetimeStart` yields much greater update rate than if it was set correctly in the first place (up to 700 during break time, compared to barely hitting 300). The difference in the set values of LifetimeStart leads me to believe that there is something expensive in the first update of drawables that causes this, which is mitigated somewhat by having all of the "first updates be way earlier than they should be".

Removing the proxying yields similar results (700+ update rate on break time), but then the lifetime of the (previously proxied) is now dependent on the DHO it originated from, and I'm under the assumption that their first update is also delayed till the parent's LifetimeStart...

_I used [this beatmap](https://osu.ppy.sh/beatmapsets/1139945#osu/2381064) to test the overall update performance, definitely far from the "best-case scenario", but similar trends can be observed even on "saner" beatmaps_