### PR TITLE
Force SortedProxyContainer to sort on every update frame

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/SortedDrawableProxyContainer.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SortedDrawableProxyContainer.cs
@@ -1,9 +1,7 @@
-using System;
 using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Sentakki.UI
 {
@@ -25,9 +23,15 @@ namespace osu.Game.Rulesets.Sentakki.UI
         {
             // Put earlier hitobjects towards the end of the list, so they show above the rest
             int i = getStartTimeOf(drawableMap[y]).CompareTo(getStartTimeOf(drawableMap[x]));
-            return i == 0 ? CompareReverseChildID(x, y) : i;
+            return i == 0 ? base.Compare(x, y) : i;
         }
 
         private double getStartTimeOf(DrawableHitObject hitObject) => hitObject.StartTimeBindable.Value;
+
+        protected override void Update()
+        {
+            base.Update();
+            SortInternal();
+        }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/SortedDrawableProxyContainer.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SortedDrawableProxyContainer.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Rulesets.Sentakki.UI
         protected override void Update()
         {
             base.Update();
+
+            // Used to resolve a potential edge case bug that could happen when abusing the animation speed slider or gameplay rewind
             SortInternal();
         }
     }


### PR DESCRIPTION
Resolves #149, for the time being at least.

Personally not really fond of this solution, but it's the only solution I've got for now. I will need to learn up on how comparisons are used in `LifetimeManagementContainer`s.