### PR TITLE
Pool the visuals of SlidePaths

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneSlide.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Sentakki.UI.Components;
@@ -24,11 +25,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
         public TestSceneSlide()
         {
             Add(new SentakkiRing());
-
-            Add(slide = new SlideVisual()
-            {
-                Path = CreatePattern().Path
-            });
+            Add(slide = new SlideVisual());
 
             AddSliderStep("Path offset", 0, 7, 0, p =>
             {
@@ -52,6 +49,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
         }
         protected abstract SentakkiSlidePath CreatePattern();
 
+        [SetUpSteps]
         protected void RefreshSlide()
         {
             slide.Path = CreatePattern().Path;

--- a/osu.Game.Rulesets.Sentakki.Tests/TestSceneSentakkiPlayer.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/TestSceneSentakkiPlayer.cs
@@ -7,5 +7,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests
     public class TestSceneSentakkiPlayer : PlayerTestScene
     {
         protected override Ruleset CreatePlayerRuleset() => new SentakkiRuleset();
+        protected override bool Autoplay => true;
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideBody.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             get => path;
             set
             {
+                if (path == value)
+                    return;
                 path = value;
                 foreach (var segment in segments)
                     segment.ClearChevrons();

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideBody.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -93,8 +91,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             }
 
             segments.Add(currentSegment);
-
-            Console.WriteLine("Segments: " + segments.Count + ", Chevrons: " + segments.Sum(s => s.ChevronCount));
         }
         private void updateProgress(float progress)
         {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideBody.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Rulesets.Objects;
@@ -33,30 +35,38 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             set
             {
                 path = value;
-                ClearInternal();
+                foreach (var segment in segments)
+                    segment.ClearChevrons();
+                segments.Clear(false);
                 createVisuals();
                 updateProgress(progress);
             }
         }
 
+        private readonly Container<SlideSegment> segments;
+        private readonly DrawablePool<SlideSegment> segmentPool;
+        private readonly DrawablePool<SlideChevron> chevronPool;
+
         public SlideVisual()
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
+            AddRangeInternal(new Drawable[]{
+                segmentPool = new DrawablePool<SlideSegment>(15),
+                chevronPool = new DrawablePool<SlideChevron>(74),
+                segments = new Container<SlideSegment>(),
+            });
         }
-
-        private List<Container> segments = new List<Container>();
 
         private double chevronInterval;
         private void createVisuals()
         {
-            segments = new List<Container>();
             var distance = Path.Distance;
             int chevrons = (int)Math.Ceiling(distance / SlideBody.SLIDE_CHEVRON_DISTANCE);
             chevronInterval = 1.0 / chevrons;
 
             float? prevAngle = null;
-            Container currentSegment = new Container();
+            SlideSegment currentSegment = segmentPool.Get();
 
             // We add the chevrons starting from the last, so that earlier ones remain on top
             for (double i = chevrons - 1; i > 0; --i)
@@ -68,22 +78,23 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                 bool shouldHide = SentakkiExtensions.GetDeltaAngle(prevAngle ?? angle, angle) >= 89;
                 prevAngle = angle;
 
-                currentSegment.Add(new SlideChevron
+                currentSegment.Add(chevronPool.Get().With(c =>
                 {
-                    Position = currentPos,
-                    Rotation = angle,
-                    Alpha = shouldHide ? 0 : 1,
-                });
+                    c.Position = currentPos;
+                    c.Rotation = angle;
+                    c.Alpha = shouldHide ? 0 : 1;
+                }));
 
                 if (i % 5 == 0 && chevrons - 1 - i > 2)
                 {
                     segments.Add(currentSegment);
-                    currentSegment = new Container();
+                    currentSegment = segmentPool.Get();
                 }
             }
 
             segments.Add(currentSegment);
-            AddRangeInternal(segments);
+
+            Console.WriteLine("Segments: " + segments.Count + ", Chevrons: " + segments.Sum(s => s.ChevronCount));
         }
         private void updateProgress(float progress)
         {
@@ -92,22 +103,35 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             for (int i = segments.Count - 1; i >= 0; i--)
             {
                 var segment = segments[i];
-                segmentBounds += segment.Count * chevronInterval;
+                segmentBounds += segment.ChevronCount * chevronInterval;
                 segment.Alpha = (progress > segmentBounds) ? 0 : 1;
             }
         }
 
-        private class SlideChevron : Sprite
+        private class SlideSegment : PoolableDrawable
+        {
+            public void ClearChevrons() => ClearInternal(false);
+            public void Add(Drawable drawable) => AddInternal(drawable);
+            public int ChevronCount => InternalChildren.Count;
+        }
+
+        private class SlideChevron : PoolableDrawable
         {
             public SlideChevron()
             {
                 Anchor = Anchor.Centre;
                 Origin = Anchor.Centre;
             }
+
             [BackgroundDependencyLoader]
             private void load(TextureStore textures)
             {
-                Texture = textures.Get("slide");
+                AddInternal(new Sprite
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Texture = textures.Get("slide")
+                });
             }
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideBody.cs
@@ -35,10 +35,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                 if (path == value)
                     return;
                 path = value;
-                foreach (var segment in segments)
-                    segment.ClearChevrons();
-                segments.Clear(false);
-                createVisuals();
+                updateVisuals();
                 updateProgress(progress);
             }
         }
@@ -59,8 +56,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         }
 
         private double chevronInterval;
-        private void createVisuals()
+        private void updateVisuals()
         {
+            foreach (var segment in segments)
+                segment.ClearChevrons();
+            segments.Clear(false);
+
             var distance = Path.Distance;
             int chevrons = (int)Math.Ceiling(distance / SlideBody.SLIDE_CHEVRON_DISTANCE);
             chevronInterval = 1.0 / chevrons;


### PR DESCRIPTION
Many `SlideSegments` and `SlideChevrons` are created and disposed every time a new path is assigned, even if the path is the same.

This pools the segments and chevrons for each `DrawableSlideBody` ahead of time within the `SlideBody` piece. Each piece will pool 15 segments and 74 chevrons, which are the amount needed by the longest slide pattern. The side effect is that a whopping **240 segments and 1184 chevrons in total** are pooled ahead of time. I may consider pooling them in a parent somewhere (maybe Playfield), since they don't particularly have a strong dependence on their host...

Another minor adjustment is an equality comparison within the `Path` property to ensure the visuals aren't recreated when the same pattern is used. The reference equality is valid since the `SlidePath` property of the HitObject is fetched from a static list, and is shared among all HitObjects.
