### PR TITLE
Fix replays

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Replays/SentakkiFramedReplayInputHandler.cs
+++ b/osu.Game.Rulesets.Sentakki/Replays/SentakkiFramedReplayInputHandler.cs
@@ -16,6 +16,7 @@ namespace osu.Game.Rulesets.Sentakki.Replays
         }
 
         protected override bool IsImportant(SentakkiReplayFrame frame) => true;
+        public bool UsingSensorMode => CurrentFrame.UsingSensorMode;
 
         protected Vector2 Position
         {

--- a/osu.Game.Rulesets.Sentakki/Replays/SentakkiReplayFrame.cs
+++ b/osu.Game.Rulesets.Sentakki/Replays/SentakkiReplayFrame.cs
@@ -12,15 +12,18 @@ namespace osu.Game.Rulesets.Sentakki.Replays
         public Vector2 Position;
         public List<SentakkiAction> Actions = new List<SentakkiAction>();
 
+        public bool UsingSensorMode;
+
         public SentakkiReplayFrame()
         {
         }
 
-        public SentakkiReplayFrame(double time, Vector2 position, params SentakkiAction[] actions)
+        public SentakkiReplayFrame(double time, Vector2 position, bool usingSensorMode, params SentakkiAction[] actions)
             : base(time)
         {
             Position = position;
             Actions.AddRange(actions);
+            UsingSensorMode = usingSensorMode;
         }
 
         public void FromLegacy(LegacyReplayFrame currentFrame, IBeatmap beatmap, ReplayFrame lastFrame = null)
@@ -29,6 +32,8 @@ namespace osu.Game.Rulesets.Sentakki.Replays
 
             if (currentFrame.MouseLeft) Actions.Add(SentakkiAction.Button1);
             if (currentFrame.MouseRight) Actions.Add(SentakkiAction.Button2);
+
+            UsingSensorMode = currentFrame.ButtonState.HasFlag(ReplayButtonState.Smoke);
         }
 
         public LegacyReplayFrame ToLegacy(IBeatmap beatmap)
@@ -37,6 +42,7 @@ namespace osu.Game.Rulesets.Sentakki.Replays
 
             if (Actions.Contains(SentakkiAction.Button1)) state |= ReplayButtonState.Left1;
             if (Actions.Contains(SentakkiAction.Button2)) state |= ReplayButtonState.Right1;
+            if (UsingSensorMode) state |= ReplayButtonState.Smoke;
 
             return new LegacyReplayFrame(Time, Position.X, Position.Y, state);
         }

--- a/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
@@ -10,7 +10,6 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects;
-using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.Replays;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
@@ -27,6 +26,10 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 mod.ApplyToTrack(speedAdjustmentTrack);
         }
 
+        protected override void LoadComplete()
+        {
+            (Config as SentakkiRulesetConfigManager)?.BindWith(SentakkiRulesetSettings.LaneInputMode, laneInputMode);
+        }
 
         // Input specifics (sensor/button) for replay and gameplay
         private readonly Bindable<LaneInputMode> laneInputMode = new Bindable<LaneInputMode>();
@@ -37,15 +40,12 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
         public bool UseSensorMode => hasReplay ? sentakkiFramedReplayInput.UsingSensorMode : laneInputMode.Value == LaneInputMode.Sensor;
 
-        protected override void LoadComplete()
-        {
-            (Config as SentakkiRulesetConfigManager)?.BindWith(SentakkiRulesetSettings.LaneInputMode, laneInputMode);
-        }
-
+        // Gameplay speed specifics
         private readonly Track speedAdjustmentTrack = new TrackVirtual(0);
 
         public double GameplaySpeed => speedAdjustmentTrack.Rate;
 
+        // Default stuff
         protected override Playfield CreatePlayfield() => new SentakkiPlayfield();
 
         protected override ReplayInputHandler CreateReplayInputHandler(Replay replay) => new SentakkiFramedReplayInputHandler(replay);

--- a/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
@@ -2,11 +2,13 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Input.Handlers;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.Replays;
@@ -25,6 +27,21 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 mod.ApplyToTrack(speedAdjustmentTrack);
         }
 
+
+        // Input specifics (sensor/button) for replay and gameplay
+        private readonly Bindable<LaneInputMode> laneInputMode = new Bindable<LaneInputMode>();
+
+        private bool hasReplay => ((SentakkiInputManager)KeyBindingInputManager).ReplayInputHandler != null;
+
+        private SentakkiFramedReplayInputHandler sentakkiFramedReplayInput => (SentakkiFramedReplayInputHandler)((SentakkiInputManager)KeyBindingInputManager).ReplayInputHandler;
+
+        public bool UseSensorMode => hasReplay ? sentakkiFramedReplayInput.UsingSensorMode : laneInputMode.Value == LaneInputMode.Sensor;
+
+        protected override void LoadComplete()
+        {
+            (Config as SentakkiRulesetConfigManager)?.BindWith(SentakkiRulesetSettings.LaneInputMode, laneInputMode);
+        }
+
         private readonly Track speedAdjustmentTrack = new TrackVirtual(0);
 
         public double GameplaySpeed => speedAdjustmentTrack.Rate;
@@ -33,7 +50,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
         protected override ReplayInputHandler CreateReplayInputHandler(Replay replay) => new SentakkiFramedReplayInputHandler(replay);
 
-        protected override ReplayRecorder CreateReplayRecorder(Replay replay) => new SentakkiReplayRecorder(replay);
+        protected override ReplayRecorder CreateReplayRecorder(Replay replay) => new SentakkiReplayRecorder(replay, this);
 
         public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new SentakkiPlayfieldAdjustmentContainer();
 

--- a/osu.Game.Rulesets.Sentakki/UI/Lane.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Lane.cs
@@ -4,7 +4,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Pooling;
 using osu.Framework.Input.Bindings;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -82,9 +81,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
             }
 
             private DrawableSentakkiRuleset drawableSentakkiRuleset;
-
             private bool usingSensor => drawableSentakkiRuleset.UseSensorMode;
-
 
             [BackgroundDependencyLoader(true)]
             private void load(DrawableSentakkiRuleset drawableRuleset)

--- a/osu.Game.Rulesets.Sentakki/UI/LanedPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/LanedPlayfield.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 using osu.Game.Rulesets.UI;

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiReplayRecorder.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiReplayRecorder.cs
@@ -9,12 +9,15 @@ namespace osu.Game.Rulesets.Sentakki.UI
 {
     public class SentakkiReplayRecorder : ReplayRecorder<SentakkiAction>
     {
-        public SentakkiReplayRecorder(Replay replay)
+        private DrawableSentakkiRuleset drawableRuleset;
+
+        public SentakkiReplayRecorder(Replay replay, DrawableSentakkiRuleset ruleset)
             : base(replay)
         {
+            drawableRuleset = ruleset;
         }
 
         protected override ReplayFrame HandleFrame(Vector2 mousePosition, List<SentakkiAction> actions, ReplayFrame previousFrame)
-            => new SentakkiReplayFrame(Time.Current, mousePosition, actions.ToArray());
+            => new SentakkiReplayFrame(Time.Current, mousePosition, drawableRuleset.UseSensorMode, actions.ToArray());
     }
 }


### PR DESCRIPTION
This PR resolves a crash that occurs when the lane input mode is set to `Button`.

Alongside that, I also made it so that the ReplayRecorder will record the setting state. The DrawableRuleset will be in charge of determining the mode used by the lanes which DI's it. If a replay is being played, then the lanes will use the mode recorded in the replay, otherwise it'll use the user setting as usual.

Now lane input is now spread across two different classes, which I'm not a fan of, just for the sake of supporting the current replay system I have, **which isn't even supposed to be used in non-legacy rulesets in the first place**. The legacy replay format is completely inadequate for sentakki's use case as well, and straight up doesn't even handle multi-touch input. So I'm considering straight up nuking the replay functionality of sen.