### PR TITLE
Reduce per-update allocation amounts in several drawables

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -82,12 +82,21 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.Update();
             int count = 0;
-            var touchInput = SentakkiActionInputManager.CurrentState.Touch;
 
-            if (touchInput.ActiveSources.Any())
-                count = touchInput.ActiveSources.Where(x => ReceivePositionalInputAt(touchInput.GetTouchPosition(x) ?? new Vector2(float.MinValue))).Count();
-            else if (IsHovered)
-                count = SentakkiActionInputManager.PressedActions.Where(x => x < SentakkiAction.Key1).Count();
+            if (!AllJudged)
+            {
+                var touchInput = SentakkiActionInputManager.CurrentState.Touch;
+                if (touchInput.ActiveSources.Any())
+                {
+                    foreach (var t in touchInput.ActiveSources)
+                        if (ReceivePositionalInputAt(touchInput.GetTouchPosition(t).Value)) ++count;
+                }
+                else if (IsHovered)
+                {
+                    foreach (var a in SentakkiActionInputManager.PressedActions)
+                        if (a < SentakkiAction.Key1) ++count;
+                }
+            }
 
             trackedKeys.Value = count;
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -100,11 +100,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.Update();
 
-            var touchInput = SentakkiActionInputManager.CurrentState.Touch;
-            bool isTouched = touchInput.ActiveSources.Any(s => ReceivePositionalInputAt(touchInput.GetTouchPosition(s) ?? new Vector2(float.MinValue)));
             isHitting.Value = Time.Current >= HitObject.StartTime
                             && Time.Current <= (HitObject as IHasDuration)?.EndTime
-                            && (Auto || isTouched || ((SentakkiActionInputManager?.PressedActions.Any() ?? false) && IsHovered));
+                            && (Auto || checkForTouchInput() || ((SentakkiActionInputManager?.PressedActions.Any() ?? false) && IsHovered));
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
@@ -143,6 +141,18 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     this.ScaleTo(.0f, time_fade_miss).FadeOut(time_fade_miss).Expire();
                     break;
             }
+        }
+
+        private bool checkForTouchInput()
+        {
+            var touchInput = SentakkiActionInputManager.CurrentState.Touch;
+
+            // Avoiding Linq to minimize allocations, since this would be called every update of this node
+            foreach (var t in touchInput.ActiveSources)
+                if (ReceivePositionalInputAt(touchInput.GetTouchPosition(t).Value))
+                    return true;
+
+            return false;
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/Lane.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Lane.cs
@@ -96,9 +96,15 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 var touchInput = SentakkiActionInputManager.CurrentState.Touch;
 
                 if (touchInput.ActiveSources.Any())
-                    count = touchInput.ActiveSources.Where(x => ReceivePositionalInputAt(touchInput.GetTouchPosition(x) ?? new Vector2(float.MinValue))).Count();
+                {
+                    foreach (var t in touchInput.ActiveSources)
+                        if (ReceivePositionalInputAt(touchInput.GetTouchPosition(t).Value)) ++count;
+                }
                 else if (IsHovered && laneInputMode.Value == LaneInputMode.Sensor)
-                    count = SentakkiActionInputManager.PressedActions.Where(x => x < SentakkiAction.Key1).Count();
+                {
+                    foreach (var a in SentakkiActionInputManager.PressedActions)
+                        if (a < SentakkiAction.Key1) ++count;
+                }
 
                 currentKeys.Value = count;
             }


### PR DESCRIPTION
I'm gonna pretend I know what I'm talking about, even if I'm likely pulling shit out of my arse.

These adjustments drastically reduce allocations during gameplay which happen every update, leading to less GC stress, alongside with slightly improving update rate (maybe placebo).

