### PR TITLE
Reimplement HR mod

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
@@ -36,6 +36,19 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             patternGen.Experiments.BindTo(EnabledExperiments);
         }
 
+        protected override Beatmap<SentakkiHitObject> ConvertBeatmap(IBeatmap original, CancellationToken cancellationToken)
+        {
+            var convertedBeatmap = base.ConvertBeatmap(original, cancellationToken);
+
+            // We don't use any of the standard difficulty values
+            // But we initialize to defaults so HR can adjust HitWindows in a controlled manner
+            // We clone beforehand to avoid altering the original (it really should be readonly :P)
+            convertedBeatmap.BeatmapInfo = convertedBeatmap.BeatmapInfo.Clone();
+            convertedBeatmap.BeatmapInfo.BaseDifficulty = new BeatmapDifficulty();
+
+            return convertedBeatmap;
+        }
+
         protected override IEnumerable<SentakkiHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap, CancellationToken cancellationToken)
         {
             if ((original as IHasCombo).NewCombo)

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModHardRock.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModHardRock.cs
@@ -1,33 +1,16 @@
-using System.Collections.Generic;
-using System.Linq;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Sentakki.Mods
 {
-    public class SentakkiModHardRock : ModHardRock, IApplicableToDrawableHitObjects
+    public class SentakkiModHardRock : ModHardRock
     {
         public override double ScoreMultiplier => 1.06;
         public override bool Ranked => true;
 
-        public override bool HasImplementation => false;
-
-        public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
+        public override void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
-            foreach (var d in drawables.OfType<DrawableSentakkiHitObject>())
-            {
-                switch (d)
-                {
-                    case DrawableHold _:
-                        //hold.HitArea.Size = new Vector2(160);
-                        break;
-
-                    case DrawableTap _:
-                        //tap.HitArea.Size = new Vector2(160);
-                        break;
-                }
-            }
+            difficulty.OverallDifficulty = 10f;
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Scoring/SentakkiHitWindows.cs
+++ b/osu.Game.Rulesets.Sentakki/Scoring/SentakkiHitWindows.cs
@@ -19,10 +19,10 @@ namespace osu.Game.Rulesets.Sentakki.Scoring
         }
 
         protected override DifficultyRange[] GetRanges() => new DifficultyRange[]{
-            new DifficultyRange(HitResult.Miss, 144, 144, 144),
-            new DifficultyRange(HitResult.Good, 144, 144, 144),
-            new DifficultyRange(HitResult.Great, 96, 96, 96),
-            new DifficultyRange(HitResult.Perfect, 48, 48, 48),
+            new DifficultyRange(HitResult.Miss, 144, 144, 72),
+            new DifficultyRange(HitResult.Good, 144, 144, 72),
+            new DifficultyRange(HitResult.Great, 96, 96, 48),
+            new DifficultyRange(HitResult.Perfect, 48, 48, 24),
         };
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Scoring/SentakkiSlideHitWindows.cs
+++ b/osu.Game.Rulesets.Sentakki/Scoring/SentakkiSlideHitWindows.cs
@@ -5,10 +5,10 @@ namespace osu.Game.Rulesets.Sentakki.Scoring
     public class SentakkiSlideHitWindows : SentakkiHitWindows
     {
         protected override DifficultyRange[] GetRanges() => new DifficultyRange[]{
-            new DifficultyRange(HitResult.Miss, 576, 576, 576),
-            new DifficultyRange(HitResult.Good, 576, 576, 576),
-            new DifficultyRange(HitResult.Great, 416, 416, 416),
-            new DifficultyRange(HitResult.Perfect, 288, 288, 288)
+            new DifficultyRange(HitResult.Miss, 576, 576, 288),
+            new DifficultyRange(HitResult.Good, 576, 576, 288),
+            new DifficultyRange(HitResult.Great, 416, 416, 208),
+            new DifficultyRange(HitResult.Perfect, 288, 288, 144)
         };
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Scoring/SentakkiTouchHitWindows.cs
+++ b/osu.Game.Rulesets.Sentakki/Scoring/SentakkiTouchHitWindows.cs
@@ -5,10 +5,10 @@ namespace osu.Game.Rulesets.Sentakki.Scoring
     public class SentakkiTouchHitWindows : SentakkiHitWindows
     {
         protected override DifficultyRange[] GetRanges() => new DifficultyRange[]{
-            new DifficultyRange(HitResult.Miss, 288, 288, 288),
-            new DifficultyRange(HitResult.Good, 288, 288, 288),
-            new DifficultyRange(HitResult.Great, 240, 240, 240),
-            new DifficultyRange(HitResult.Perfect, 192, 192, 192),
+            new DifficultyRange(HitResult.Miss, 288, 288, 144),
+            new DifficultyRange(HitResult.Good, 288, 288, 144),
+            new DifficultyRange(HitResult.Great, 240, 240, 120),
+            new DifficultyRange(HitResult.Perfect, 192, 192, 96),
         };
     }
 }


### PR DESCRIPTION
Resolves #81

This reimplements HR so that difficulty is actually affected. 

Sentakki HitObjects don't use any of the standard beatmap difficulties, and HitWindows is completely fixed, removing the effect of OD. This PR makes it so that the HitWindow ranges have a max value, and only used during HR. In any other circumstances, the ranges remain the same as their mid values, by reinitializing converted beatmaps' difficulty values back to the defaults.

Perhaps it is worth considering using OD for more than just HR, similar to the standard rulesets. 🤔