### PR TITLE
Implement Challenge mod

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/UI/TestSceneLiveCounter.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/UI/TestSceneLiveCounter.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Sentakki.UI.Components;
 using osu.Game.Tests.Visual;
@@ -9,6 +10,11 @@ namespace osu.Game.Rulesets.Sentakki.Tests.UI
     public class TestSceneLiveCounter : OsuTestScene
     {
         private LiveCounter counter;
+        private BindableInt lives = new BindableInt
+        {
+            MaxValue = 10,
+            Value = 10
+        };
 
         public TestSceneLiveCounter()
         {
@@ -17,7 +23,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.UI
                 Clear();
             });
 
-            AddStep("Create Ring", () => Add(counter = new LiveCounter()));
+            AddStep("Create Ring", () => Add(counter = new LiveCounter(lives)));
             AddUntilStep("Ring loaded", () => counter.IsLoaded);
             AddStep("Lose a live", () => counter.LivesLeft.Value--);
         }

--- a/osu.Game.Rulesets.Sentakki.Tests/UI/TestSceneLiveCounter.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/UI/TestSceneLiveCounter.cs
@@ -12,8 +12,8 @@ namespace osu.Game.Rulesets.Sentakki.Tests.UI
         private LiveCounter counter;
         private BindableInt lives = new BindableInt
         {
-            MaxValue = 10,
-            Value = 10
+            MaxValue = 500,
+            Value = 500
         };
 
         public TestSceneLiveCounter()
@@ -23,9 +23,11 @@ namespace osu.Game.Rulesets.Sentakki.Tests.UI
                 Clear();
             });
 
-            AddStep("Create Ring", () => Add(counter = new LiveCounter(lives)));
-            AddUntilStep("Ring loaded", () => counter.IsLoaded);
-            AddStep("Lose a live", () => counter.LivesLeft.Value--);
+            AddStep("Create counter", () => Add(counter = new LiveCounter(lives)));
+            AddUntilStep("Counter loaded", () => counter.IsLoaded);
+            AddStep("Lose a live", () => counter.LivesLeft.Value -= 1);
+            AddStep("Lose two lives", () => counter.LivesLeft.Value -= 2);
+            AddStep("Lose five lives", () => counter.LivesLeft.Value -= 5);
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/UI/TestSceneLiveCounter.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/UI/TestSceneLiveCounter.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Sentakki.UI.Components;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Sentakki.Tests.UI
+{
+    [TestFixture]
+    public class TestSceneLiveCounter : OsuTestScene
+    {
+        private LiveCounter counter;
+
+        public TestSceneLiveCounter()
+        {
+            AddStep("Clear test", () =>
+            {
+                Clear();
+            });
+
+            AddStep("Create Ring", () => Add(counter = new LiveCounter()));
+            AddUntilStep("Ring loaded", () => counter.IsLoaded);
+            AddStep("Lose a live", () => counter.LivesLeft.Value--);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModAutoplay.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModAutoplay.cs
@@ -32,7 +32,6 @@ namespace osu.Game.Rulesets.Sentakki.Mods
             typeof(SentakkiModChallenge)
         };
 
-
         public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
         {
             foreach (var d in drawables.OfType<DrawableSentakkiHitObject>())

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModAutoplay.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModAutoplay.cs
@@ -29,7 +29,15 @@ namespace osu.Game.Rulesets.Sentakki.Mods
             };
         }
 
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(SentakkiModAutoTouch)).ToArray();
+        public override Type[] IncompatibleMods => new Type[5]
+        {
+            typeof(ModRelax),
+            typeof(ModSuddenDeath),
+            typeof(ModNoFail),
+            typeof(SentakkiModAutoTouch),
+            typeof(SentakkiModChallenge)
+        };
+
 
         public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
         {

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
@@ -44,7 +44,6 @@ namespace osu.Game.Rulesets.Sentakki.Mods
 
         public enum Lives
         {
-            [Description("1")] One,
             [Description("5")] Five,
             [Description("10")] Ten,
             [Description("20")] Twenty,

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
@@ -55,8 +55,8 @@ namespace osu.Game.Rulesets.Sentakki.Mods
         [SettingSource("Number of Lives", "The number of lives you start with.")]
         public Bindable<Lives> LiveSetting { get; } = new Bindable<Lives>
         {
-            Default = Lives.Ten,
-            Value = Lives.Ten,
+            Default = Lives.Fifty,
+            Value = Lives.Fifty,
         };
 
         public BindableInt LivesLeft;

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
@@ -1,0 +1,92 @@
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Sentakki.Judgements;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.UI;
+using osu.Game.Rulesets.Sentakki.UI.Components;
+using osu.Game.Rulesets.UI;
+using System.ComponentModel;
+
+namespace osu.Game.Rulesets.Sentakki.Mods
+{
+    public class SentakkiModChallenge : Mod, IApplicableToDrawableRuleset<SentakkiHitObject>, IApplicableToHealthProcessor
+    {
+        public override string Name => "Challenge";
+        public override string Description => "You only get a small margin for errors.";
+        public override string Acronym => "C";
+
+        public override IconUsage? Icon => FontAwesome.Solid.HeartBroken;
+        public override ModType Type => ModType.DifficultyIncrease;
+
+        public override bool Ranked => false;
+
+        public override double ScoreMultiplier => 1.00;
+
+        public bool RestartOnFail => false;
+        public bool PerformFail() => true;
+
+        public enum Lives
+        {
+            [Description("1")] One,
+            [Description("5")] Five,
+            [Description("10")] Ten,
+            [Description("20")] Twenty,
+            [Description("50")] Fifty,
+            [Description("100")] Hundred,
+            [Description("200")] TwoHundred,
+            [Description("300")] ThreeHundred,
+        }
+
+        [SettingSource("Number of Lives", "The number of lives you start with.")]
+        public Bindable<Lives> LiveSetting { get; } = new Bindable<Lives>
+        {
+            Default = Lives.Ten,
+            Value = Lives.Ten,
+        };
+
+        public BindableInt LivesLeft = new BindableInt();
+
+        public void ApplyToDrawableRuleset(DrawableRuleset<SentakkiHitObject> drawableRuleset)
+        {
+            LivesLeft.Value = int.Parse(LiveSetting.Value.GetDescription());
+            (drawableRuleset.Playfield as SentakkiPlayfield).AddDrawable(new LiveCounter().With(d => d.LivesLeft.BindTo(LivesLeft)));
+        }
+
+        public void ApplyToHealthProcessor(HealthProcessor healthProcessor)
+        {
+            healthProcessor.FailConditions += FailCondition;
+        }
+
+        protected bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
+        {
+            if (!(result.Judgement is SentakkiJudgement) || result.HitObject is ScorePaddingObject)
+                return false;
+
+            int newValue = LivesLeft.Value;
+
+            switch (result.Type)
+            {
+                case HitResult.Great:
+                    newValue -= 1;
+                    break;
+                case HitResult.Good:
+                    newValue -= 2;
+                    break;
+                case HitResult.Miss:
+                    newValue -= 5;
+                    break;
+            }
+            if (newValue < 0) newValue = 0;
+            LivesLeft.Value = newValue;
+
+            return LivesLeft.Value <= 0;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
@@ -60,6 +61,7 @@ namespace osu.Game.Rulesets.Sentakki.Mods
             Value = Lives.Fifty,
         };
 
+        [JsonIgnore]
         public BindableInt LivesLeft;
 
         public void ApplyToDrawableRuleset(DrawableRuleset<SentakkiHitObject> drawableRuleset)

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
@@ -1,3 +1,5 @@
+using System;
+using System.ComponentModel;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
@@ -5,15 +7,12 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.Judgements;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.UI;
 using osu.Game.Rulesets.Sentakki.UI.Components;
 using osu.Game.Rulesets.UI;
-using System;
-using System.ComponentModel;
 
 namespace osu.Game.Rulesets.Sentakki.Mods
 {

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Rulesets.Sentakki.Mods
 
         public override bool Ranked => false;
 
+        public override bool RequiresConfiguration => true;
+
         public override double ScoreMultiplier => 1.00;
 
         public bool RestartOnFail => false;

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
@@ -59,12 +59,18 @@ namespace osu.Game.Rulesets.Sentakki.Mods
             Value = Lives.Ten,
         };
 
-        public BindableInt LivesLeft = new BindableInt();
+        public BindableInt LivesLeft;
 
         public void ApplyToDrawableRuleset(DrawableRuleset<SentakkiHitObject> drawableRuleset)
         {
-            LivesLeft.Value = int.Parse(LiveSetting.Value.GetDescription());
-            (drawableRuleset.Playfield as SentakkiPlayfield).Ring.Add(new LiveCounter().With(d => d.LivesLeft.BindTo(LivesLeft)));
+            int maxLives = int.Parse(LiveSetting.Value.GetDescription());
+            LivesLeft = new BindableInt()
+            {
+                Value = maxLives,
+                MaxValue = maxLives,
+            };
+
+            (drawableRuleset.Playfield as SentakkiPlayfield).Ring.Add(new LiveCounter(LivesLeft));
         }
 
         public void ApplyToHealthProcessor(HealthProcessor healthProcessor)
@@ -96,7 +102,5 @@ namespace osu.Game.Rulesets.Sentakki.Mods
 
             return LivesLeft.Value <= 0;
         }
-
-
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.UI;
 using osu.Game.Rulesets.Sentakki.UI.Components;
 using osu.Game.Rulesets.UI;
+using System;
 using System.ComponentModel;
 
 namespace osu.Game.Rulesets.Sentakki.Mods
@@ -31,6 +32,14 @@ namespace osu.Game.Rulesets.Sentakki.Mods
 
         public bool RestartOnFail => false;
         public bool PerformFail() => true;
+
+        public override Type[] IncompatibleMods => new Type[4]
+        {
+            typeof(ModRelax),
+            typeof(ModSuddenDeath),
+            typeof(ModAutoplay),
+            typeof(ModNoFail),
+        };
 
         public enum Lives
         {
@@ -56,7 +65,7 @@ namespace osu.Game.Rulesets.Sentakki.Mods
         public void ApplyToDrawableRuleset(DrawableRuleset<SentakkiHitObject> drawableRuleset)
         {
             LivesLeft.Value = int.Parse(LiveSetting.Value.GetDescription());
-            (drawableRuleset.Playfield as SentakkiPlayfield).AddDrawable(new LiveCounter().With(d => d.LivesLeft.BindTo(LivesLeft)));
+            (drawableRuleset.Playfield as SentakkiPlayfield).Ring.Add(new LiveCounter().With(d => d.LivesLeft.BindTo(LivesLeft)));
         }
 
         public void ApplyToHealthProcessor(HealthProcessor healthProcessor)
@@ -88,5 +97,7 @@ namespace osu.Game.Rulesets.Sentakki.Mods
 
             return LivesLeft.Value <= 0;
         }
+
+
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
@@ -44,13 +44,13 @@ namespace osu.Game.Rulesets.Sentakki.Mods
 
         public enum Lives
         {
-            [Description("5")] Five,
-            [Description("10")] Ten,
-            [Description("20")] Twenty,
-            [Description("50")] Fifty,
-            [Description("100")] Hundred,
-            [Description("200")] TwoHundred,
-            [Description("300")] ThreeHundred,
+            [Description("5")] Five = 5,
+            [Description("10")] Ten = 10,
+            [Description("20")] Twenty = 20,
+            [Description("50")] Fifty = 50,
+            [Description("100")] Hundred = 100,
+            [Description("200")] TwoHundred = 200,
+            [Description("300")] ThreeHundred = 300,
         }
 
         [SettingSource("Number of Lives", "The number of lives you start with.")]
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Sentakki.Mods
 
         public void ApplyToDrawableRuleset(DrawableRuleset<SentakkiHitObject> drawableRuleset)
         {
-            int maxLives = int.Parse(LiveSetting.Value.GetDescription());
+            int maxLives = (int)LiveSetting.Value;
             LivesLeft = new BindableInt()
             {
                 Value = maxLives,

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModNoFail.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModNoFail.cs
@@ -1,8 +1,11 @@
-﻿using osu.Game.Rulesets.Mods;
+﻿using System;
+using System.Linq;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Sentakki.Mods
 {
     public class SentakkiModNoFail : ModNoFail
     {
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(SentakkiModChallenge)).ToArray();
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModPerfect.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModPerfect.cs
@@ -4,7 +4,7 @@ using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Sentakki.Mods
 {
-    public class SentakkiModPerfect : ModPerfect
+    public class SentakkiModPerfect : SentakkiModSuddenDeath
     {
         protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
             => !(result.Judgement is IgnoreJudgement)

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModSuddenDeath.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModSuddenDeath.cs
@@ -1,8 +1,16 @@
-﻿using osu.Game.Rulesets.Mods;
+﻿using System;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Sentakki.Mods
 {
     public class SentakkiModSuddenDeath : ModSuddenDeath
     {
+        public override Type[] IncompatibleMods => new Type[4]
+        {
+            typeof(ModNoFail),
+            typeof(ModRelax),
+            typeof(ModAutoplay),
+            typeof(SentakkiModChallenge)
+        };
     }
 }

--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -68,6 +68,7 @@ namespace osu.Game.Rulesets.Sentakki
                     {
                         new SentakkiModHardRock(),
                         new MultiMod(new SentakkiModSuddenDeath(), new SentakkiModPerfect()),
+                        new SentakkiModChallenge(),
                         new MultiMod(new SentakkiModDoubleTime(), new SentakkiModNightcore()),
                     };
 

--- a/osu.Game.Rulesets.Sentakki/UI/Components/LiveCounter.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/LiveCounter.cs
@@ -1,5 +1,8 @@
+using System;
+using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -7,7 +10,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.UI.Components
 {
-    public class LiveCounter : ShakeContainer
+    public class LiveCounter : BeatSyncedContainer
     {
         public BindableInt LivesLeft = new BindableInt(300);
 
@@ -17,7 +20,6 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
-            ShakeMagnitude = 4;
 
             InternalChildren = new Drawable[]{
 
@@ -36,6 +38,35 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                 this.FadeColour(Color4.Red, 160).Then().FadeColour(Color4.White, 320);
                 Shake();
             }, true);
+        }
+
+        public void Shake(double? maximumLength = null)
+        {
+            const float shake_amount = 8;
+            const double shake_duration = 80;
+
+            // if we don't have enough time, don't bother shaking.
+            if (maximumLength < shake_duration * 2)
+                return;
+
+            var sequence = this.MoveToX(shake_amount, shake_duration / 2, Easing.OutSine).Then()
+                               .MoveToX(-shake_amount, shake_duration, Easing.InOutSine).Then();
+
+            // if we don't have enough time for the second shake, skip it.
+            if (!maximumLength.HasValue || maximumLength >= shake_duration * 4)
+            {
+                sequence = sequence
+                           .MoveToX(shake_amount, shake_duration, Easing.InOutSine).Then()
+                           .MoveToX(-shake_amount, shake_duration, Easing.InOutSine).Then();
+            }
+
+            sequence.MoveToX(0, shake_duration / 2, Easing.InSine);
+        }
+
+        protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
+        {
+            if (beatIndex % (int)timingPoint.TimeSignature == 0)
+                this.ScaleTo(1.1f, 200).Then().ScaleTo(1, 120).Then().ScaleTo(1.1f, 160).Then().ScaleTo(1, 320);
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/Components/LiveCounter.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/LiveCounter.cs
@@ -28,17 +28,15 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Text = "",
                     Font = OsuFont.Torus.With(size: 40, weight: FontWeight.SemiBold),
-                    Shadow = true,
-                    ShadowColour = Color4.Black,
+                    ShadowColour = Color4.Gray,
                 },
             };
 
             LivesLeft.BindValueChanged(v =>
             {
                 livesText.Text = v.NewValue.ToString();
-                livesText.FadeColour(Color4.Red, 160).Then().FadeColour(Color4.White, 320);
+                this.FadeColour(Color4.Red, 160).Then().FadeColour(Color4.White, 320);
                 Shake();
             }, true);
         }

--- a/osu.Game.Rulesets.Sentakki/UI/Components/LiveCounter.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/LiveCounter.cs
@@ -1,0 +1,46 @@
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics;
+using osu.Framework.Bindables;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics;
+using osuTK.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+using osu.Game.Graphics.Containers;
+
+namespace osu.Game.Rulesets.Sentakki.UI.Components
+{
+    public class LiveCounter : ShakeContainer
+    {
+        public BindableInt LivesLeft = new BindableInt(300);
+
+        private OsuSpriteText livesText;
+
+        public LiveCounter()
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            ShakeMagnitude = 4;
+
+            InternalChildren = new Drawable[]{
+
+                livesText = new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Text = "",
+                    Font = OsuFont.Torus.With(size: 40, weight: FontWeight.SemiBold),
+                    Shadow = true,
+                    ShadowColour = Color4.Black,
+                },
+            };
+
+            LivesLeft.BindValueChanged(v =>
+            {
+                livesText.Text = v.NewValue.ToString();
+                livesText.FadeColour(Color4.Red, 160).Then().FadeColour(Color4.White, 320);
+                Shake();
+            }, true);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/UI/Components/LiveCounter.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/LiveCounter.cs
@@ -1,12 +1,9 @@
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics;
 using osu.Framework.Bindables;
-using osu.Game.Graphics.Sprites;
+using osu.Framework.Graphics;
 using osu.Game.Graphics;
-using osuTK.Graphics;
-using osu.Framework.Graphics.Sprites;
-using osuTK;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.UI.Components
 {

--- a/osu.Game.Rulesets.Sentakki/UI/Components/LiveCounter.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/LiveCounter.cs
@@ -6,6 +6,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.UI.Components
@@ -14,7 +15,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
     {
         public BindableInt LivesLeft = new BindableInt();
 
-        private OsuSpriteText livesText;
+        private LiveRollingCounter livesText;
 
         public LiveCounter(BindableInt livesBindable)
         {
@@ -22,23 +23,18 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
-            InternalChildren = new Drawable[]{
-
-                livesText = new OsuSpriteText
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Font = OsuFont.Torus.With(size: 40, weight: FontWeight.SemiBold),
-                    ShadowColour = Color4.Gray,
-                },
-            };
+            InternalChild = livesText = new LiveRollingCounter();
 
             LivesLeft.BindValueChanged(v =>
             {
-                livesText.Text = v.NewValue.ToString();
                 this.FadeColour(Color4.Red, 160).Then().FadeColour(Color4.White, 320);
                 Shake();
             }, true);
+        }
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            livesText.Current.BindTo(LivesLeft);
         }
 
         public void Shake(double? maximumLength = null)
@@ -83,6 +79,28 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                     .Then().ScaleTo(1, 120 * panicDurationMultiplier)
                     .Then().ScaleTo(1 + beatMagnitude, 160 * panicDurationMultiplier)
                     .Then().ScaleTo(1, 320 * panicDurationMultiplier);
+        }
+
+        private class LiveRollingCounter : RollingCounter<int>
+        {
+            protected override double RollingDuration => 1000;
+
+            public LiveRollingCounter()
+            {
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+            }
+
+            protected override OsuSpriteText CreateSpriteText()
+            {
+                return new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Font = OsuFont.Torus.With(size: 40, weight: FontWeight.SemiBold),
+                    ShadowColour = Color4.Gray,
+                };
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/Components/SentakkiRing.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/SentakkiRing.cs
@@ -16,7 +16,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.UI.Components
 {
-    public class SentakkiRing : CompositeDrawable
+    public class SentakkiRing : Container
     {
         private readonly Container spawnIndicator;
 

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
         private readonly Container<DrawableSentakkiJudgement> judgementLayer;
         private readonly DrawablePool<DrawableSentakkiJudgement> judgementPool;
 
-        private readonly SentakkiRing ring;
+        public readonly SentakkiRing Ring;
         public BindableNumber<int> RevolutionDuration = new BindableNumber<int>(0);
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
             {
                 judgementPool = new DrawablePool<DrawableSentakkiJudgement>(8),
                 new PlayfieldVisualisation(),
-                ring = new SentakkiRing(),
+                Ring = new SentakkiRing(),
                 lanedPlayfield = new LanedPlayfield(),
                 HitObjectContainer, // This only contains Touch and TouchHolds, which should appear above others note types. Might consider separating to another playfield.
                 judgementLayer = new Container<DrawableSentakkiJudgement>
@@ -68,8 +68,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
             AddNested(lanedPlayfield);
             NewResult += onNewResult;
         }
-
-        public void AddDrawable(Drawable drawable) => AddInternal(drawable);
 
         private DrawableSentakkiRuleset drawableSentakkiRuleset;
         private SentakkiRulesetConfigManager sentakkiRulesetConfig;
@@ -121,7 +119,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
             judgementLayer.Add(judgementPool.Get(j => j.Apply(result, judgedObject)));
 
             if (result.IsHit && judgedObject.HitObject.Kiai)
-                ring.KiaiBeat();
+                Ring.KiaiBeat();
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -69,6 +69,8 @@ namespace osu.Game.Rulesets.Sentakki.UI
             NewResult += onNewResult;
         }
 
+        public void AddDrawable(Drawable drawable) => AddInternal(drawable);
+
         private DrawableSentakkiRuleset drawableSentakkiRuleset;
         private SentakkiRulesetConfigManager sentakkiRulesetConfig;
 


### PR DESCRIPTION
This mod adds a live counter to the middle of the playfield. Lives will be lost for every non-perfect judgement, the lives lost are shown below.

The lives counter forces players to make fewer mistakes instead of going below a certain acc. and the difficulty also scales with track length. (50 lives on a 7 min map is harder than 50 on a 1 min map, and the error rate must be lower to complete the map)

```
Perfect: -0
Great  : -1
Good   : -2
Miss   : -5
```

The number of lives can be configured in the mod configuration menu, and players can select from a preset list of values.

If sequential playlists(https://github.com/ppy/osu/issues/5757) is ever added osu-side, and mod persistence is possible, this mod can be further extended enable carrying lives over from the previous track, which maybe some degree of regeneration, like adding a certain amount of lives for every passed map. This could open up new multiplayer opportunities as well (realtime playlist elimination, timeshift playlists that takes the total score acquired at the end of a run by dying or finishing)
