### PR TITLE
Improve slide visuals

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneAllSlides.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneAllSlides.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -49,9 +50,9 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
 
         protected void RefreshSlide()
         {
-            slide.Path = CreatePattern().Path;
+            slide.Path = CreatePattern();
             nodes.Clear();
-            foreach (var node in slide.Path.ControlPoints)
+            foreach (var node in slide.Path.SlideSegments.SelectMany(s => s.ControlPoints))
             {
                 nodes.Add(new CircularContainer
                 {

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneSlide.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
             });
             AddSliderStep("Progress", 0.0f, 1.0f, 0.0f, p =>
             {
-                slide.CompletedSegments = (int)(slide.SegmentCount * p);
+                slide.Progress = p;
             });
 
             Add(nodes = new Container()

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneSlide.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -59,9 +60,9 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
 
         protected void RefreshSlide()
         {
-            slide.Path = CreatePattern().Path;
+            slide.Path = CreatePattern();
             nodes.Clear();
-            foreach (var node in slide.Path.ControlPoints)
+            foreach (var node in slide.Path.SlideSegments.SelectMany(s => s.ControlPoints))
             {
                 nodes.Add(new CircularContainer
                 {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -119,7 +119,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         private void updatePathProgress()
         {
             var target = SlideNodes.LastOrDefault(x => x.Result.IsHit);
-            if ( target == null )
+            if (target == null)
                 Slidepath.Progress = 0;
             else
                 Slidepath.Progress = target.HitObject.Progress;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void OnApply()
         {
             base.OnApply();
-            Slidepath.Path = HitObject.SlideInfo.SlidePath.Path;
+            Slidepath.Path = HitObject.SlideInfo.SlidePath;
             updatePathProgress();
             StarProgress = 0;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -119,10 +119,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         private void updatePathProgress()
         {
             var target = SlideNodes.LastOrDefault(x => x.Result.IsHit);
-            if (target == null)
-                Slidepath.CompletedSegments = 0;
+            if ( target == null )
+                Slidepath.Progress = 0;
             else
-                Slidepath.CompletedSegments = target.ThisIndex + 1;
+                Slidepath.Progress = target.HitObject.Progress;
 
             pendingProgressUpdate = false;
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideNode.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideNode.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void OnApply()
         {
             base.OnApply();
-            Position = parentSlide.HitObject.SlideInfo.SlidePath.Path.PositionAt(HitObject.Progress);
+            Position = parentSlide.HitObject.SlideInfo.SlidePath.PositionAt(HitObject.Progress);
 
             // Nodes are applied before being added to the parent playfield, so this node isn't in SlideNodes yet
             // Since we know that the node isn't in the container yet, and that the count is always one higher than the topmost element, we can use that as the predicted index

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
@@ -133,7 +133,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                 SlideSegment currentSegment = segmentPool.Get();
                 reverseSegments.Add(currentSegment);
 
-                float lastAngle = path.PositionAt(0).GetDegreesFromPosition(path.PositionAt(0.1 / totalDistance));
                 var previousPosition = path.PositionAt(0);
                 for (int i = 0; i < chevronCount; i++)
                 {
@@ -155,7 +154,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                         reverseSegments.Add(currentSegment);
                     }
 
-                    lastAngle = angle;
                     previousPosition = position;
                 }
             }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
@@ -126,7 +126,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 
         public void PerformEntryAnimation(double duration)
         {
-            updateProgress(); // transforms are reset so we need to reapply them
             if (snakingIn.Value)
             {
                 double fadeDuration = duration / chevrons.Count;
@@ -134,19 +133,18 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                 for (int j = chevrons.Count - 1; j >= 0; j--)
                 {
                     var chevron = chevrons[j];
-                    chevron.FadeOut().Delay(currentOffset).FadeInFromZero(fadeDuration * 2);
+                    chevron.FadeOut().Delay(currentOffset).FadeIn(fadeDuration * 2).Finally(c => c.UpdateProgress(progress));
                     currentOffset += fadeDuration / 2;
                 }
             }
             else
             {
-                this.FadeOut().Delay(duration / 2).FadeIn(duration / 2);
+                this.FadeOut().Delay(duration / 2).FadeIn(duration / 2).Finally(c => c.updateProgress());
             }
         }
 
         public void PerformExitAnimation(double duration)
         {
-            updateProgress();
             int chevronsLeft = chevrons.Count(c => c.Alpha != 0);
             double fadeDuration = duration / chevronsLeft;
             double currentOffset = 0;
@@ -185,7 +183,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 
             public void UpdateProgress(double progress)
             {
-                this.FadeTo(progress >= Progress ? 0 : 1);
+                Alpha = progress >= Progress ? 0 : 1;
             }
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
@@ -134,7 +134,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             return (int)Math.Ceiling((path.Distance - (2 * endpoint_distance)) * chevrons_per_distance);
         }
 
-
         private void updateVisuals()
         {
             foreach (var segment in segments)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
@@ -21,14 +21,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         // This will be proxied, so a must.
         public override bool RemoveWhenNotAlive => false;
 
-        private int completedSegments;
-        public int CompletedSegments
+        private double progress;
+        public double Progress
         {
-            get => completedSegments;
+            get => progress;
             set
             {
-                completedSegments = value;
-                updateProgress(completedSegments);
+                progress = value;
+                updateProgress();
             }
         }
         private SliderPath path;
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                     return;
                 path = value;
                 updateVisuals();
-                updateProgress(CompletedSegments);
+                updateProgress();
             }
         }
 
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             sentakkiConfig?.BindWith(SentakkiRulesetSettings.SnakingSlideBody, snakingIn);
 
             AddRangeInternal(new Drawable[]{
-                segmentPool = new DrawablePool<SlideSegment>(20),
+                segmentPool = new DrawablePool<SlideSegment>(5),
                 chevronPool = new DrawablePool<SlideChevron>(61),
                 segments = new Container<SlideSegment>(),
             });
@@ -79,10 +79,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         private const double endpoint_distance = /*r*/34;
 
         /// <returns>A rented array which needs to be returned to <see cref="ArrayPool&lt;SliderPath&gt;.Shared"/></returns>
-        private static (SliderPath[] array, int count) splitIntoContinuousPaths(SliderPath path)
+        private static (SliderPath[] autosmoothedarray, SliderPath[] originalarray, int count) splitIntoContinuousPaths(SliderPath path)
         {
-            // upperbound, might rent a bit more than needed but it usually returns batches of 16 anyway
             var paths = ArrayPool<SliderPath>.Shared.Rent(path.ControlPoints.Skip(1).SkipLast(1).Count(c => c.Type.Value == null || c.Type.Value == PathType.Linear));
+            var originalPaths = ArrayPool<SliderPath>.Shared.Rent(path.ControlPoints.Skip(1).SkipLast(1).Count(c => c.Type.Value == null || c.Type.Value == PathType.Linear));
             const double auto_smooth_angle = 60;
 
             PathType context = path.ControlPoints[0].Type.Value ?? PathType.Linear;
@@ -91,11 +91,15 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             if (paths[0] is null) paths[0] = new SliderPath();
             paths[0].ControlPoints.Clear();
             paths[0].ControlPoints.Add(path.ControlPoints[0]);
+            if (originalPaths[0] is null) originalPaths[0] = new SliderPath();
+            originalPaths[0].ControlPoints.Clear();
+            originalPaths[0].ControlPoints.Add(path.ControlPoints[0]);
 
             for (int i = 1; i < path.ControlPoints.Count; i++)
             {
                 var controlPoint = path.ControlPoints[i];
                 paths[pathIndex].ControlPoints.Add(controlPoint);
+                originalPaths[pathIndex].ControlPoints.Add(controlPoint);
                 context = controlPoint.Type.Value ?? context;
                 if (context == PathType.Linear && i + 1 != path.ControlPoints.Count)
                 {
@@ -117,9 +121,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                     if (paths[pathIndex] == null) paths[pathIndex] = new SliderPath();
                     paths[pathIndex].ControlPoints.Clear();
                     paths[pathIndex].ControlPoints.Add(controlPoint);
+                    if (originalPaths[pathIndex] == null) originalPaths[pathIndex] = new SliderPath();
+                    originalPaths[pathIndex].ControlPoints.Clear();
+                    originalPaths[pathIndex].ControlPoints.Add(controlPoint);
                 }
             }
-            return (paths, pathIndex + 1);
+            return (paths, originalPaths, pathIndex + 1);
         }
 
         private static int chevronsInContinuousPath(SliderPath path)
@@ -127,13 +134,16 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             return (int)Math.Ceiling((path.Distance - (2 * endpoint_distance)) * chevrons_per_distance);
         }
 
-        /// <summary>
-        /// Creates a list of segments consisting of evenly spaced out points and their directions
-        /// </summary>
-        public static IEnumerable<(IEnumerable<(Vector2 positon, float rotation)> segment, double startProgress, double endProgress)> CreateSegmentsFor(SliderPath path)
+
+        private void updateVisuals()
         {
-            static IEnumerable<(Vector2 positon, float rotation)> createSegment(SliderPath path)
+            foreach (var segment in segments)
+                segment.ClearChevrons();
+            segments.Clear(false);
+
+            SlideSegment createSegment(SliderPath path)
             {
+                SlideSegment currentSegment = segmentPool.Get();
                 var chevronCount = chevronsInContinuousPath(path);
                 var totalDistance = path.Distance;
                 var safeDistance = totalDistance - (endpoint_distance * 2);
@@ -142,74 +152,47 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                 for (int i = 0; i < chevronCount; i++)
                 {
                     var progress = (double)i / (chevronCount - 1); // from 0 to 1, both inclusive
-
                     var position = path.PositionAt(((progress * safeDistance) + endpoint_distance) / totalDistance);
                     var angle = previousPosition.GetDegreesFromPosition(position);
 
-                    yield return (position, angle);
+                    var chevron = chevronPool.Get();
+                    chevron.Position = position;
+                    chevron.Rotation = angle;
+                    chevron.Depth = i;
+                    currentSegment.Add(chevron);
 
                     previousPosition = position;
                 }
+                return currentSegment;
             }
 
-            var (paths, count) = splitIntoContinuousPaths(path);
+            var (paths, originalPaths, count) = splitIntoContinuousPaths(path);
             double totalDistance = 0;
-            for (int i = 0; i < count; i++)
+            for ( int i = 0; i < count; i++ )
             {
-                yield return (createSegment(paths[i]), (totalDistance + endpoint_distance) / path.Distance, (totalDistance + paths[i].Distance - endpoint_distance) / path.Distance);
-                totalDistance += paths[i].Distance;
-            }
-            ArrayPool<SliderPath>.Shared.Return(paths);
-        }
-
-        private int chevronCount;
-        private void updateVisuals()
-        {
-            foreach (var segment in segments)
-                segment.ClearChevrons();
-            segments.Clear(false);
-
-            chevronCount = 0;
-            foreach (var (segment,_,_) in CreateSegmentsFor(path))
-            {
-                SlideSegment currentSegment = segmentPool.Get();
-                currentSegment.Depth = segments.Count;
-                segments.Add(currentSegment);
-
-                var left = segment.Count();
-                chevronCount += left;
-                foreach (var (pos, rot) in segment)
-                {
-                    currentSegment.Add(chevronPool.Get().With(c => {
-                        c.Position = pos;
-                        c.Rotation = rot;
-                        c.Depth = currentSegment.Children.Count;
-                    }));
-
-                    if (currentSegment.Children.Count >= 3 && left >= 3)
-                    {
-                        currentSegment = segmentPool.Get();
-                        currentSegment.Depth = segments.Count;
-                        segments.Add(currentSegment);
-                    }
-                    left--;
-                }
+                var segment = createSegment(paths[i]);
+                segment.StartProgress = (totalDistance + endpoint_distance) / path.Distance;
+                segment.EndProgress = (totalDistance + originalPaths[i].Distance - endpoint_distance) / path.Distance;
+                segment.Depth = segments.Count;
+                totalDistance += originalPaths[i].Distance;
+                segments.Add(segment);
             }
         }
 
-        private void updateProgress(int completedNodes)
+        private void updateProgress()
         {
-            for (int i = 1; i <= segments.Count; ++i)
+            for (int i = 0; i < segments.Count; i++)
             {
-                segments[^i].Alpha = i <= completedNodes ? 0 : 1;
+                segments[i].UpdateProgress(progress);
             }
         }
 
         public void PerformEntryAnimation(double duration)
         {
+            updateProgress(); // transforms are reset so we need to reapply them
             if (snakingIn.Value)
             {
-                double fadeDuration = duration / chevronCount;
+                double fadeDuration = duration / segments.Sum(s => s.ChevronCount);
                 double currentOffset = duration / 2;
                 for (int i = segments.Count - 1; i >= 0; i--)
                 {
@@ -230,23 +213,19 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 
         public void PerformExitAnimation(double duration)
         {
-            int chevronsLeft = chevronCount;
+            updateProgress();
+            int chevronsLeft = segments.Sum(s => s.ChevronCount);
             double fadeDuration() => duration / chevronsLeft;
             double currentOffset = 0;
             for (int i = segments.Count - 1; i >= 0; i--)
             {
                 var segment = segments[i];
-                if (segment.Alpha == 0)
-                {
-                    chevronsLeft -= segment.ChevronCount;
-                    continue;
-                }
-
                 for (int j = segment.Children.Count - 1; j >= 0; j--)
                 {
                     var chevron = segment.Children[j] as SlideChevron;
                     chevron.Delay(currentOffset).FadeOut(fadeDuration() * 2);
                     currentOffset += fadeDuration() / 2;
+                    chevronsLeft--;
                 }
             }
         }
@@ -258,6 +237,26 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             public int ChevronCount => InternalChildren.Count;
 
             public IReadOnlyList<Drawable> Children => InternalChildren;
+            public double StartProgress;
+            public double EndProgress;
+            public void UpdateProgress(double progress)
+            {
+                for (int i = 0; i < Children.Count; i++)
+                {
+                    var progressHere = (double)i / (Children.Count - 1);
+                    progressHere = StartProgress + (progressHere * (EndProgress - StartProgress));
+
+                    if (progressHere > progress)
+                        Children[^(i+1)].FadeIn();
+                    else
+                        Children[^(i+1)].FadeOut();
+                }
+
+                if (progress >= EndProgress)
+                    this.FadeOut();
+                else
+                    this.FadeIn();
+            }
         }
 
         private class SlideChevron : PoolableDrawable

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Buffers;
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -10,9 +8,7 @@ using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Sentakki.Configuration;
-using osuTK;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 {
@@ -71,7 +67,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         private const int chevrons_per_eith = 8;
         private const double ring_radius = 297;
         private const double chevrons_per_distance = (chevrons_per_eith * 8) / (2 * Math.PI * ring_radius);
-        private const double endpoint_distance = /*r*/34;
+        private const double endpoint_distance = 34; // margin for each end
 
         private static int chevronsInContinuousPath(SliderPath path)
         {
@@ -83,7 +79,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             chevrons.Clear(false);
 
             double runningDistance = 0;
-            void createSegment(SliderPath path)
+            foreach (var path in path.SlideSegments)
             {
                 var chevronCount = chevronsInContinuousPath(path);
                 var totalDistance = path.Distance;
@@ -108,11 +104,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                     previousPosition = position;
                 }
                 runningDistance += totalDistance;
-            }
-
-            foreach (var i in path.SlideSegments)
-            {
-                createSegment(i);
             }
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
@@ -218,7 +218,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 
             public void UpdateProgress(double progress)
             {
-                Alpha = progress >= Progress ? 0 : 1;
+                this.FadeTo(progress >= Progress ? 0 : 1);
             }
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             sentakkiConfig?.BindWith(SentakkiRulesetSettings.SnakingSlideBody, snakingIn);
 
             AddRangeInternal(new Drawable[]{
-                chevronPool = new DrawablePool<SlideChevron>(61),
+                chevronPool = new DrawablePool<SlideChevron>(62),
                 chevrons = new Container<SlideChevron>(),
             });
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
@@ -156,7 +156,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             double totalDistance = 0;
             for (int i = 0; i < count; i++)
             {
-                yield return (createSegment(paths[i]), totalDistance / path.Distance, (totalDistance + paths[i].Distance) / path.Distance);
+                yield return (createSegment(paths[i]), (totalDistance + endpoint_distance) / path.Distance, (totalDistance + paths[i].Distance - endpoint_distance) / path.Distance);
                 totalDistance += paths[i].Distance;
             }
             ArrayPool<SliderPath>.Shared.Return(paths);

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiSlidePath.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiSlidePath.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using osu.Game.Rulesets.Objects;
+using osuTK;
 
 namespace osu.Game.Rulesets.Sentakki.Objects
 {
@@ -7,8 +8,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
     {
         // The ending lane of the path, without considering the lane offset of the main body
         public readonly int EndLane;
-
-        public readonly SliderPath Path;
 
         // The minimum duration that this pattern can have, used in converts
         public double MinDuration => TotalDistance / 2;
@@ -33,6 +32,22 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             SlideSegments = segments;
             TotalDistance = SlideSegments.Sum(p => p.Distance);
             EndLane = endLane;
+        }
+
+        public Vector2 PositionAt(double progress)
+        {
+            if (progress <= 0) return SlideSegments[0].PositionAt(0);
+            if (progress >= 1) return SlideSegments[^1].PositionAt(1);
+
+            double distanceLeft = TotalDistance * progress;
+            int i = 0;
+            while ( distanceLeft > SlideSegments[i].Distance )
+            {
+                distanceLeft -= SlideSegments[i].Distance;
+                i++;
+            }
+
+            return SlideSegments[i].PositionAt(distanceLeft / SlideSegments[i].Distance);
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiSlidePath.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiSlidePath.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Rulesets.Sentakki.Objects
@@ -10,16 +11,27 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         public readonly SliderPath Path;
 
         // The minimum duration that this pattern can have, used in converts
-        public readonly double MinDuration;
+        public double MinDuration => TotalDistance / 2;
 
         // The maximum duration that this pattern can have, used in converts.
         // While it is completely playable even beyond this value, it would look awkward for shorter slides
         public double MaxDuration => MinDuration * 10;
 
-        public SentakkiSlidePath(PathControlPoint[] pathControlPoints, int endLane)
+        public double TotalDistance;
+
+        public readonly SliderPath[] SlideSegments;
+
+        public SentakkiSlidePath(SliderPath segment, int endLane)
         {
-            Path = new SliderPath(pathControlPoints);
-            MinDuration = Path.Distance / 2;
+            SlideSegments = new SliderPath[] { segment };
+            TotalDistance = SlideSegments.Sum(p => p.Distance);
+            EndLane = endLane;
+        }
+
+        public SentakkiSlidePath(SliderPath[] segments, int endLane)
+        {
+            SlideSegments = segments;
+            TotalDistance = SlideSegments.Sum(p => p.Distance);
             EndLane = endLane;
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiSlidePath.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiSlidePath.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
             double distanceLeft = TotalDistance * progress;
             int i = 0;
-            while ( distanceLeft > SlideSegments[i].Distance )
+            while (distanceLeft > SlideSegments[i].Distance)
             {
                 distanceLeft -= SlideSegments[i].Distance;
                 i++;

--- a/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading;
 using Newtonsoft.Json;
 using osu.Game.Beatmaps;
@@ -7,6 +6,7 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.Judgements;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Sentakki.Scoring;
 using osuTK.Graphics;
 
@@ -15,7 +15,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
     public class SlideBody : SentakkiLanedHitObject, IHasDuration
     {
         protected override Color4 DefaultNoteColour => Color4.Aqua;
-        public static readonly float SLIDE_CHEVRON_DISTANCE = 30f;
 
         public double EndTime
         {
@@ -35,8 +34,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         {
             base.CreateNestedHitObjects(cancellationToken);
 
-            var distance = SlideInfo.SlidePath.Path.Distance;
-            int chevrons = (int)Math.Round(distance / SLIDE_CHEVRON_DISTANCE);
+            int chevrons = SlideVisual.ChevronsInPath(SlideInfo.SlidePath.Path);
             double chevronInterval = 1.0 / chevrons;
 
             for (int i = 4; i < chevrons - 3; i += 3)

--- a/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading;
 using Newtonsoft.Json;
@@ -40,32 +41,32 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             {
                 var count = segment.Count();
                 var left = count;
-                int i = 0;
-                foreach (var (pos, rot) in segment)
+
+                for ( int i = 0; left > 0; i = left >= 6 ? (i + 3) : (count - 1) )
                 {
-                    // skip first node, insert each third chevron unless there are less than 2 left (if so, insert one at the end)
-                    if(i != 0 && ((i % 3 == 0 && left >= 3) || left == 1))
+                    var progress = (double)i / ( count - 1 );
+                    progress = start + ( progress * ( end - start ) );
+
+                    SlideNode node;
+                    AddNested(node = new SlideNode
                     {
-                        var progress = (double)i / (count - 1);
-                        progress = start + (progress * (end - start));
+                        StartTime = StartTime + ShootDelay + ( ( Duration - ShootDelay ) * progress ),
+                        Progress = (float)progress
+                    });
 
-                        SlideNode node;
-                        AddNested(node = new SlideNode {
-                            StartTime = StartTime + ShootDelay + ((Duration - ShootDelay) * progress),
-                            Progress = (float)progress
-                        });
-
-                        if (!isSampleAdded)
-                        {
-                            isSampleAdded = true;
-                            node.Samples.Add(new SentakkiHitSampleInfo("slide"));
-                        }
+                    if ( !isSampleAdded )
+                    {
+                        isSampleAdded = true;
+                        node.Samples.Add(new SentakkiHitSampleInfo("slide"));
                     }
 
-                    i++;
-                    left--;
+                    left = count - i - 1;
                 }
             }
+            AddNested(new SlideNode {
+                StartTime = EndTime,
+                Progress = 1
+            });
         }
 
         [JsonIgnore]

--- a/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
             bool isSampleAdded = false;
             var distance = SlideInfo.SlidePath.Path.Distance;
-            var nodeCount = (int)Math.Floor(distance / 80);
+            var nodeCount = (int)Math.Floor(distance / 100);
             for (int i = 0; i < nodeCount; i++)
             {
                 var progress = (double)(i + 1) / nodeCount;
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                     Progress = (float)progress
                 });
 
-                if ( !isSampleAdded )
+                if (!isSampleAdded)
                 {
                     isSampleAdded = true;
                     node.Samples.Add(new SentakkiHitSampleInfo("slide"));

--- a/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
@@ -37,36 +37,24 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             base.CreateNestedHitObjects(cancellationToken);
 
             bool isSampleAdded = false;
-            foreach (var (segment,start,end) in SlideVisual.CreateSegmentsFor(SlideInfo.SlidePath.Path))
+            var distance = SlideInfo.SlidePath.Path.Distance;
+            var nodeCount = (int)Math.Floor(distance / 80);
+            for (int i = 0; i < nodeCount; i++)
             {
-                var count = segment.Count();
-                var left = count;
-
-                for ( int i = 0; left > 0; i = left >= 6 ? (i + 3) : (count - 1) )
+                var progress = (double)(i + 1) / nodeCount;
+                SlideNode node;
+                AddNested(node = new SlideNode
                 {
-                    var progress = (double)i / ( count - 1 );
-                    progress = start + ( progress * ( end - start ) );
+                    StartTime = StartTime + ShootDelay + ((Duration - ShootDelay) * progress),
+                    Progress = (float)progress
+                });
 
-                    SlideNode node;
-                    AddNested(node = new SlideNode
-                    {
-                        StartTime = StartTime + ShootDelay + ( ( Duration - ShootDelay ) * progress ),
-                        Progress = (float)progress
-                    });
-
-                    if ( !isSampleAdded )
-                    {
-                        isSampleAdded = true;
-                        node.Samples.Add(new SentakkiHitSampleInfo("slide"));
-                    }
-
-                    left = count - i - 1;
+                if ( !isSampleAdded )
+                {
+                    isSampleAdded = true;
+                    node.Samples.Add(new SentakkiHitSampleInfo("slide"));
                 }
             }
-            AddNested(new SlideNode {
-                StartTime = EndTime,
-                Progress = 1
-            });
         }
 
         [JsonIgnore]

--- a/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             base.CreateNestedHitObjects(cancellationToken);
 
             bool isSampleAdded = false;
-            var distance = SlideInfo.SlidePath.Path.Distance;
+            var distance = SlideInfo.SlidePath.TotalDistance;
             var nodeCount = (int)Math.Floor(distance / 100);
             for (int i = 0; i < nodeCount; i++)
             {

--- a/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
@@ -144,7 +144,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             Vector2 Node1Pos = Vector2.Zero;
             Vector2 Node2Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end);
 
-            if (end >= 3 || end <= 5)
+            if (end >= 3 && end <= 5)
             {
                 var path = new SliderPath(new PathControlPoint[]{
                     new PathControlPoint(Node0Pos, PathType.Linear),

--- a/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
@@ -135,9 +135,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             Vector2 Node1Pos = Vector2.Zero;
             Vector2 Node2Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end);
 
+            // This is used to determine whether a break is needed
+            bool continuous = end >= 3 && end <= 5;
+            PathType? Node1Type = null;
+            if (!continuous) Node1Type = PathType.Linear;
+
             var controlPoints = new List<PathControlPoint>{
                 new PathControlPoint(Node0Pos, PathType.Linear),
-                new PathControlPoint(Node1Pos, PathType.Linear),
+                new PathControlPoint(Node1Pos, Node1Type),
                 new PathControlPoint(Node2Pos, PathType.Linear)
             }.ToArray();
 

--- a/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
@@ -86,7 +86,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         {
             var path = new SliderPath(new PathControlPoint[] {
                 new PathControlPoint(SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, 0), PathType.Linear),
-                new PathControlPoint(getPositionInBetween(SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, 0),SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end)), PathType.Linear),
                 new PathControlPoint(SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end), PathType.Linear),
             });
 

--- a/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
@@ -84,13 +84,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         // Covers DX Straight 3-7
         public static SentakkiSlidePath GenerateStraightPattern(int end)
         {
-            var controlPoints = new List<PathControlPoint>{
+            var path = new SliderPath(new PathControlPoint[] {
                 new PathControlPoint(SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, 0), PathType.Linear),
                 new PathControlPoint(getPositionInBetween(SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, 0),SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end)), PathType.Linear),
                 new PathControlPoint(SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end), PathType.Linear),
-            }.ToArray();
+            });
 
-            return new SentakkiSlidePath(controlPoints, end);
+            return new SentakkiSlidePath(path, end);
         }
 
         private static Vector2 getIntesectPoint(Vector2 A1, Vector2 A2, Vector2 B1, Vector2 B2)
@@ -111,6 +111,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             int lane2 = mirrored ? 2 : 6;
             int lane3 = mirrored ? 6 : 2;
             int lane4 = mirrored ? 7 : 1;
+
             static Vector2 lanestart(int x) => SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, x);
             Vector2 Node0Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, 0);
             Vector2 Node1Pos = getIntesectPoint(lanestart(0), lanestart(lane1), lanestart(lane2), lanestart(lane3));
@@ -118,14 +119,22 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             Vector2 Node2Pos = getIntesectPoint(lanestart(lane2), lanestart(lane3), lanestart(lane4), lanestart(4));
             Vector2 Node3Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, 4);
 
-            var controlPoints = new List<PathControlPoint>{
-                new PathControlPoint(Node0Pos, PathType.Linear),
-                new PathControlPoint(Node1Pos, PathType.Linear),
-                new PathControlPoint(Node2Pos, PathType.Linear),
-                new PathControlPoint(Node3Pos, PathType.Linear)
+            SliderPath[] segments = new SliderPath[]{
+                new SliderPath(new PathControlPoint[]{
+                    new PathControlPoint(Node0Pos, PathType.Linear),
+                    new PathControlPoint(Node1Pos, PathType.Linear),
+                }),
+                new SliderPath(new PathControlPoint[]{
+                    new PathControlPoint(Node1Pos, PathType.Linear),
+                    new PathControlPoint(Node2Pos, PathType.Linear),
+                }),
+                new SliderPath(new PathControlPoint[]{
+                    new PathControlPoint(Node2Pos, PathType.Linear),
+                    new PathControlPoint(Node3Pos, PathType.Linear),
+                })
             };
 
-            return new SentakkiSlidePath(controlPoints.ToArray(), 4);
+            return new SentakkiSlidePath(segments, 4);
         }
 
         // Covers DX V pattern 1-8
@@ -135,18 +144,30 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             Vector2 Node1Pos = Vector2.Zero;
             Vector2 Node2Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end);
 
-            // This is used to determine whether a break is needed
-            bool continuous = end >= 3 && end <= 5;
-            PathType? Node1Type = null;
-            if (!continuous) Node1Type = PathType.Linear;
+            if (end >= 3 || end <= 5)
+            {
+                var path = new SliderPath(new PathControlPoint[]{
+                    new PathControlPoint(Node0Pos, PathType.Linear),
+                    new PathControlPoint(Node1Pos, PathType.Linear),
+                    new PathControlPoint(Node2Pos, PathType.Linear)
+                });
+                return new SentakkiSlidePath(path, end);
+            }
+            else
+            {
+                SliderPath[] segments = new SliderPath[]{
+                    new SliderPath(new PathControlPoint[]{
+                        new PathControlPoint(Node0Pos, PathType.Linear),
+                        new PathControlPoint(Node1Pos, PathType.Linear),
+                    }),
+                    new SliderPath(new PathControlPoint[]{
+                        new PathControlPoint(Node1Pos, PathType.Linear),
+                        new PathControlPoint(Node2Pos, PathType.Linear),
+                    })
+                };
 
-            var controlPoints = new List<PathControlPoint>{
-                new PathControlPoint(Node0Pos, PathType.Linear),
-                new PathControlPoint(Node1Pos, Node1Type),
-                new PathControlPoint(Node2Pos, PathType.Linear)
-            }.ToArray();
-
-            return new SentakkiSlidePath(controlPoints, end);
+                return new SentakkiSlidePath(segments, end);
+            }
         }
 
         // Covers DX L pattern 2-5
@@ -156,13 +177,18 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             Vector2 Node1Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, mirrored ? 2 : 6);
             Vector2 Node2Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end);
 
-            var controlPoints = new List<PathControlPoint>{
-                new PathControlPoint(Node0Pos, PathType.Linear),
-                new PathControlPoint(Node1Pos, PathType.Linear),
-                new PathControlPoint(Node2Pos, PathType.Linear)
-            }.ToArray();
+            var segments = new SliderPath[]{
+                new SliderPath(new PathControlPoint[]{
+                    new PathControlPoint(Node0Pos, PathType.Linear),
+                    new PathControlPoint(Node1Pos, PathType.Linear),
+                }),
+                new SliderPath(new PathControlPoint[]{
+                    new PathControlPoint(Node1Pos, PathType.Linear),
+                    new PathControlPoint(Node2Pos, PathType.Linear),
+                }),
+            };
 
-            return new SentakkiSlidePath(controlPoints, end);
+            return new SentakkiSlidePath(segments, end);
         }
 
         // DX Circle Pattern
@@ -171,13 +197,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             float centre = ((0.GetRotationForLane() + end.GetRotationForLane()) / 2) + (direction == RotationDirection.CounterClockwise ? 180 : 0);
             Vector2 centreNode = SentakkiExtensions.GetCircularPosition(SentakkiPlayfield.INTERSECTDISTANCE, centre == 0.GetRotationForLane() ? centre + 180 : centre);
 
-            List<PathControlPoint> SlidePath = new List<PathControlPoint> {
+            var path = new SliderPath(new PathControlPoint[]{
                 new PathControlPoint(SentakkiExtensions.GetCircularPosition(SentakkiPlayfield.INTERSECTDISTANCE, 0.GetRotationForLane() + (direction == RotationDirection.CounterClockwise ? -.5f : .5f)), PathType.PerfectCurve),
                 new PathControlPoint(centreNode),
                 new PathControlPoint(SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end), PathType.PerfectCurve)
-            };
+            });
 
-            return new SentakkiSlidePath(SlidePath.ToArray(), end);
+            return new SentakkiSlidePath(path, end);
         }
 
         public static SentakkiSlidePath GenerateUPattern(int end, bool reversed = false)
@@ -191,15 +217,15 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             Vector2 Node4Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end);
             Vector2 Node3Pos = getPositionInBetween(Node4Pos, SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end + (reversed ? -3 : 3)), .51f);
 
-            var controlPoints = new List<PathControlPoint>{
+
+            var path = new SliderPath(new PathControlPoint[]{
                 new PathControlPoint(Node0Pos,PathType.Linear),
                 new PathControlPoint(Node1Pos, PathType.PerfectCurve),
                 new PathControlPoint(Node2Pos),
                 new PathControlPoint(Node3Pos, PathType.PerfectCurve),
                 new PathControlPoint(Node4Pos,PathType.Linear)
-            };
-
-            return new SentakkiSlidePath(controlPoints.ToArray(), end);
+            });
+            return new SentakkiSlidePath(path, end);
         }
 
         public static SentakkiSlidePath GenerateCupPattern(int end, bool mirrored = false)
@@ -243,17 +269,17 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             Vector2 Node5Pos = loopOrigin + SentakkiExtensions.GetCircularPosition(r, loopEndAngle);
             Vector2 Node6Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end);
 
-            var controlPoints = new List<PathControlPoint>{
+            var path = new SliderPath(new PathControlPoint[]{
                 new PathControlPoint(Node0Pos, PathType.Linear),
                 new PathControlPoint(Node1Pos, PathType.PerfectCurve),
                 new PathControlPoint(Node2Pos),
                 new PathControlPoint(Node3Pos, PathType.PerfectCurve),
                 new PathControlPoint(Node4Pos),
                 new PathControlPoint(Node5Pos,PathType.PerfectCurve),
-                new PathControlPoint(Node6Pos, PathType.Linear),
-            };
+                new PathControlPoint(Node6Pos, PathType.Linear)
+            });
 
-            return new SentakkiSlidePath(controlPoints.ToArray(), end);
+            return new SentakkiSlidePath(path, end);
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
@@ -217,7 +217,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             Vector2 Node4Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end);
             Vector2 Node3Pos = getPositionInBetween(Node4Pos, SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end + (reversed ? -3 : 3)), .51f);
 
-
             var path = new SliderPath(new PathControlPoint[]{
                 new PathControlPoint(Node0Pos,PathType.Linear),
                 new PathControlPoint(Node1Pos, PathType.PerfectCurve),

--- a/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             GenerateStraightPattern(5),
             GenerateStraightPattern(6),
             GenerateThunderPattern(),
+            GenerateThunderPattern(true),
             GenerateUPattern(0),
             GenerateUPattern(1),
             GenerateUPattern(2),

--- a/osu.Game.Rulesets.Sentakki/UI/Lane.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Lane.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
             RegisterPool<Slide, DrawableSlide>(2);
             RegisterPool<SlideTap, DrawableSlideTap>(2);
             RegisterPool<SlideBody, DrawableSlideBody>(2);
-            RegisterPool<SlideBody.SlideNode, DrawableSlideNode>(10);
+            RegisterPool<SlideBody.SlideNode, DrawableSlideNode>(18);
 
             RegisterPool<ScorePaddingObject, DrawableScorePaddingObject>(20);
         }


### PR DESCRIPTION
⚠️ This PR will lightly affect map generation, potentially causing desyncs in replays recorded before this change if slide notes are present. ⚠️

To sum up:
* The distance from endpoints is now constant
* Slides on the ring are way less squishy
* Slides can now be split into segments
* Perfect overlap on roundabout patterns
* Remove `ShouldHide` from `SlideChevron`
* Remove `SlideSegment`
* Separate visuals from hitobject logic
* Add mirrored thunder slide