### PR TITLE
Allow dev builds to run side-by-side with release builds

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -14,9 +14,12 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-    - name: Install dependencies
-      run: dotnet restore
     - name: Build with .NET
-      run: dotnet build --no-restore --configuration Release
+      run: dotnet build --configuration Development
     - name: Unit Tests
       run: dotnet test --no-build --no-restore --configuration Release
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Sentakki (Dev build)
+        path: osu.Game.Rulesets.Sentakki/bin/Development/netstandard2.1/osu.Game.Rulesets.Sentakki-dev.dll

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Build with .NET
       run: dotnet build --configuration Development
     - name: Unit Tests
-      run: dotnet test --no-build --no-restore --configuration Release
+      run: dotnet test --no-build --no-restore --configuration Development
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "sentakki for osu! (Tests, Debug)",
+            "name": "sentakki for osu! (Debug)",
             "type": "coreclr",
             "request": "launch",
             "program": "dotnet",
@@ -10,11 +10,23 @@
                 "${workspaceRoot}/osu.Game.Rulesets.Sentakki.Tests/bin/Debug/net5.0/osu.Game.Rulesets.Sentakki.Tests.dll"
             ],
             "cwd": "${workspaceRoot}",
-            "preLaunchTask": "Build tests (Debug)",
+            "preLaunchTask": "Build (Debug)",
             "console": "internalConsole"
         },
         {
-            "name": "sentakki for osu! (Tests, Release)",
+            "name": "sentakki for osu! (Development)",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "dotnet",
+            "args": [
+                "${workspaceRoot}/osu.Game.Rulesets.Sentakki.Tests/bin/Development/net5.0/osu.Game.Rulesets.Sentakki.Tests.dll"
+            ],
+            "cwd": "${workspaceRoot}",
+            "preLaunchTask": "Build (Development)",
+            "console": "internalConsole"
+        },
+        {
+            "name": "sentakki for osu! (Release)",
             "type": "coreclr",
             "request": "launch",
             "program": "dotnet",
@@ -22,7 +34,7 @@
                 "${workspaceRoot}/osu.Game.Rulesets.Sentakki.Tests/bin/Release/net5.0/osu.Game.Rulesets.Sentakki.Tests.dll"
             ],
             "cwd": "${workspaceRoot}",
-            "preLaunchTask": "Build tests (Release)",
+            "preLaunchTask": "Build (Release)",
             "console": "internalConsole"
         },
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,6 +8,7 @@
             "args": [
                 "build",
                 "osu.Game.Rulesets.Sentakki.Tests",
+                "/p:Configuration=Debug",
                 "/m",
                 "/verbosity:m"
             ],
@@ -21,7 +22,7 @@
             "args": [
                 "build",
                 "osu.Game.Rulesets.Sentakki.Tests",
-                "-c Development",
+                "/p:Configuration=Development",
                 "/m",
                 "/verbosity:m"
             ],
@@ -35,7 +36,7 @@
             "args": [
                 "build",
                 "osu.Game.Rulesets.Sentakki.Tests",
-                "-c Release",
+                "/p:Configuration=Release",
                 "/m",
                 "/verbosity:m"
             ],
@@ -49,7 +50,7 @@
             "command": "dotnet",
             "args": [
                 "test",
-                "-c Debug",
+                "/p:Configuration=Debug",
             ],
             "group": "test",
             "problemMatcher": "$msCompile"
@@ -60,7 +61,7 @@
             "command": "dotnet",
             "args": [
                 "test",
-                "-c Development",
+                "/p:Configuration=Development",
             ],
             "group": "test",
             "problemMatcher": "$msCompile"
@@ -71,7 +72,7 @@
             "command": "dotnet",
             "args": [
                 "test",
-                "-c Release",
+                "/c Release",
             ],
             "group": "test",
             "problemMatcher": "$msCompile"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,14 +2,12 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Build tests (Debug)",
+            "label": "Build (Debug)",
             "type": "shell",
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Rulesets.Sentakki.Tests",
-                "/p:GenerateFullPaths=true",
                 "/m",
                 "/verbosity:m"
             ],
@@ -17,15 +15,27 @@
             "problemMatcher": "$msCompile"
         },
         {
-            "label": "Build tests (Release)",
+            "label": "Build (Development)",
             "type": "shell",
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Rulesets.Sentakki.Tests",
-                "/p:Configuration=Release",
-                "/p:GenerateFullPaths=true",
+                "-c Development",
+                "/m",
+                "/verbosity:m"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build (Release)",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "osu.Game.Rulesets.Sentakki.Tests",
+                "-c Release",
                 "/m",
                 "/verbosity:m"
             ],
@@ -39,7 +49,18 @@
             "command": "dotnet",
             "args": [
                 "test",
-                "/p:Configuration=Debug",
+                "-c Debug",
+            ],
+            "group": "test",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Run tests (Development)",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "test",
+                "-c Development",
             ],
             "group": "test",
             "problemMatcher": "$msCompile"
@@ -50,7 +71,7 @@
             "command": "dotnet",
             "args": [
                 "test",
-                "/p:Configuration=Release",
+                "-c Release",
             ],
             "group": "test",
             "problemMatcher": "$msCompile"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,20 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <Configurations>Debug;Release;Development</Configurations>
+
+    <Authors>Derrick Timmermans</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/LumpBloom7/sentakki</RepositoryUrl>
+    <Copyright>Copyright (c) 2021 Derrick Timmermans</Copyright>
   </PropertyGroup>
-  <ItemGroup Label="Resources">
-    <EmbeddedResource Include="Resources\**\*.*" />
+  <ItemGroup>
+    <!-- The automated version of this (<EmbeddedResource Include="xyz\**" />) would prepend the RootNamespace to name,
+         that will not work well with DllResourceStore as it can only determine the root namespace via AssemblyName,
+         and we change that based on the build configuration for separation purposes.
+         Therefore prepend the AssemblyName to embedded resources names instead. -->
+    <EmbeddedResource Include="Resources\**\*">
+      <LogicalName>$(AssemblyName).$([System.String]::Copy(%(Identity)).Replace($([System.IO.Path]::DirectorySeparatorChar.ToString()), '.'))</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/osu.Game.Rulesets.Sentakki.sln
+++ b/osu.Game.Rulesets.Sentakki.sln
@@ -11,21 +11,22 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		VisualTests|Any CPU = VisualTests|Any CPU
+		Development|Any CPU = Development|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Development|Any CPU.ActiveCfg = Development|Any CPU
+		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Development|Any CPU.Build.0 = Development|Any CPU
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.VisualTests|Any CPU.ActiveCfg = Release|Any CPU
-		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.VisualTests|Any CPU.Build.0 = Release|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Development|Any CPU.ActiveCfg = Development|Any CPU
+		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Development|Any CPU.Build.0 = Development|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.VisualTests|Any CPU.ActiveCfg = Debug|Any CPU
-		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.VisualTests|Any CPU.Build.0 = Debug|Any CPU
+
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -12,8 +12,6 @@ using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Difficulty;
@@ -175,13 +173,17 @@ namespace osu.Game.Rulesets.Sentakki
             };
         }
 
-        private class SentakkiIcon : DrawSizePreservingFillContainer
+        public class SentakkiIcon : CompositeDrawable
         {
             private readonly Ruleset ruleset;
+
             public SentakkiIcon(Ruleset ruleset)
             {
+                Anchor = Origin = Anchor.Centre;
                 this.ruleset = ruleset;
-                RelativeSizeAxes = Axes.Both;
+                FillAspectRatio = 1;
+                FillMode = FillMode.Fit;
+                Size = new Vector2(100, 100);
             }
 
             [BackgroundDependencyLoader]
@@ -202,28 +204,30 @@ namespace osu.Game.Rulesets.Sentakki
                 {
                     AddInternal(new Container
                     {
-                        Masking = true,
-                        CornerExponent = 2.5f,
-                        CornerRadius = 2.5f,
                         Anchor = Anchor.BottomRight,
                         Origin = Anchor.BottomRight,
-                        RelativeSizeAxes = Axes.Both,
-                        Size = new Vector2(.6f, 0.35f),
+                        Size = new Vector2(60, 35),
                         Children = new Drawable[]{
-                            new Box
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                            },
-                            new DrawSizePreservingFillContainer{
-                                TargetDrawSize = new Vector2(16,9),
-                                Child = new OsuSpriteText
+                            // Used to offset the fonts being misaligned
+                            new Container{
+                                Anchor = Anchor.BottomCentre,
+                                Origin = Anchor.BottomCentre,
+                                Size = new Vector2(60,32),
+                                CornerRadius = 8f,
+                                CornerExponent = 2.5f,
+                                Masking = true,
+                                Child = new Box
                                 {
-                                    Text = "DEV",
-                                    Colour = Color4.Gray,
-                                    Font = OsuFont.Torus.With(size: 8, weight: FontWeight.SemiBold),
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                }
+                                    RelativeSizeAxes = Axes.Both,
+                                },
+                            },
+                            new SpriteText
+                            {
+                                Text = "DEV",
+                                Colour = Color4.Gray,
+                                Font = OsuFont.Torus.With(size: 32,weight: FontWeight.Bold),
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
                             }
                         }
                     });

--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -3,12 +3,16 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Difficulty;
@@ -28,13 +32,18 @@ using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking.Statistics;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki
 {
     public class SentakkiRuleset : Ruleset
     {
-        public override string Description => "sentakki";
+        private static readonly Lazy<bool> is_development_build = new Lazy<bool>(() => typeof(SentakkiRuleset).Assembly.GetName().Name.EndsWith("-dev"));
+        public static bool IsDevelopmentBuild => is_development_build.Value;
+
+        public override string Description => IsDevelopmentBuild ? "sentakki (Dev build)" : "sentakki";
         public override string PlayingVerb => "Washing laundry";
+        public override string ShortName => IsDevelopmentBuild ? "Sentakki-dev" : "Sentakki";
 
         public override ScoreProcessor CreateScoreProcessor() => new SentakkiScoreProcessor();
 
@@ -96,8 +105,6 @@ namespace osu.Game.Rulesets.Sentakki
                     return Array.Empty<Mod>();
             }
         }
-
-        public override string ShortName => "Sentakki";
 
         public override RulesetSettingsSubsection CreateSettings() => new SentakkiSettingsSubsection(this);
 
@@ -167,12 +174,13 @@ namespace osu.Game.Rulesets.Sentakki
             };
         }
 
-        private class SentakkiIcon : Sprite
+        private class SentakkiIcon : CompositeDrawable
         {
             private readonly Ruleset ruleset;
             public SentakkiIcon(Ruleset ruleset)
             {
                 this.ruleset = ruleset;
+                RelativeSizeAxes = Axes.Both;
             }
 
             [BackgroundDependencyLoader]
@@ -181,7 +189,40 @@ namespace osu.Game.Rulesets.Sentakki
                 if (!textures.GetAvailableResources().Contains("Textures/SentakkiIcon.png"))
                     textures.AddStore(host.CreateTextureLoaderStore(ruleset.CreateResourceStore()));
 
-                Texture = textures.Get("Textures/SentakkiIcon.png");
+                AddInternal(new Sprite
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    Texture = textures.Get("Textures/SentakkiIcon.png"),
+                });
+
+                if (IsDevelopmentBuild)
+                {
+                    AddInternal(new Container
+                    {
+                        Masking = true,
+                        CornerExponent = 2.5f,
+                        CornerRadius = 2.5f,
+                        Anchor = Anchor.BottomRight,
+                        Origin = Anchor.BottomRight,
+                        RelativeSizeAxes = Axes.Both,
+                        Size = new Vector2(.6f, 0.35f),
+                        Children = new Drawable[]{
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                            },
+                            new OsuSpriteText{
+                                Text = "DEV",
+                                Colour = Color4.Gray,
+                                Font = OsuFont.Torus.With(size: 8, weight: FontWeight.SemiBold),
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                            }
+                        }
+                    });
+                }
             }
         }
     }

--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -12,6 +12,7 @@ using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Configuration;
@@ -174,7 +175,7 @@ namespace osu.Game.Rulesets.Sentakki
             };
         }
 
-        private class SentakkiIcon : CompositeDrawable
+        private class SentakkiIcon : DrawSizePreservingFillContainer
         {
             private readonly Ruleset ruleset;
             public SentakkiIcon(Ruleset ruleset)
@@ -213,12 +214,16 @@ namespace osu.Game.Rulesets.Sentakki
                             {
                                 RelativeSizeAxes = Axes.Both,
                             },
-                            new OsuSpriteText{
-                                Text = "DEV",
-                                Colour = Color4.Gray,
-                                Font = OsuFont.Torus.With(size: 8, weight: FontWeight.SemiBold),
-                                Anchor = Anchor.Centre,
-                                Origin = Anchor.Centre,
+                            new DrawSizePreservingFillContainer{
+                                TargetDrawSize = new Vector2(16,9),
+                                Child = new OsuSpriteText
+                                {
+                                    Text = "DEV",
+                                    Colour = Color4.Gray,
+                                    Font = OsuFont.Torus.With(size: 8, weight: FontWeight.SemiBold),
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                }
                             }
                         }
                     });

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
 {
     public class SentakkiSettingsSubsection : RulesetSettingsSubsection
     {
-        protected override string Header => "sentakki";
+        protected override string Header => SentakkiRuleset.IsDevelopmentBuild ? "sentakki (Dev build)" : "sentakki";
 
         public SentakkiSettingsSubsection(Ruleset ruleset)
             : base(ruleset)

--- a/osu.Game.Rulesets.Sentakki/osu.Game.Rulesets.Sentakki.csproj
+++ b/osu.Game.Rulesets.Sentakki/osu.Game.Rulesets.Sentakki.csproj
@@ -1,14 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
+    <AssemblyTitle>sentakki for osu!lazer</AssemblyTitle>
+    <Description>TAP, HOLD and SLIDE to the beat.</Description>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <AssemblyTitle>osu.Game.Rulesets.Sentakki</AssemblyTitle>
     <OutputType>Library</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <RootNamespace>osu.Game.Rulesets.Sentakki</RootNamespace>
   </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyName>osu.Game.Rulesets.Sentakki</AssemblyName>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Development' ">
+    <Optimize>true</Optimize>
   </PropertyGroup>
+  <Choose>
+    <When Condition=" '$(Configuration)' == 'Release' ">
+      <PropertyGroup>
+        <AssemblyName>osu.Game.Rulesets.Sentakki</AssemblyName>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <AssemblyName>osu.Game.Rulesets.Sentakki-dev</AssemblyName>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game" Version="2021.407.1"/>
   </ItemGroup>


### PR DESCRIPTION
Thanks to the efforts made by @frenzibyte in https://github.com/Beamographic/rush/pull/127, we are now able to better differentiate dev builds and official releases.

Most things copied verbatim from his work. I also changed the "insider" branding to "dev" because it fits better in the icon label.
![image](https://user-images.githubusercontent.com/12001167/114023571-57679800-9873-11eb-9b37-03cc10a28225.png)
