### PR TITLE
Fix non-snaking slide transforms not resetting before entry animation

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
@@ -129,7 +129,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             }
             else
             {
-                this.FadeOut().Delay(duration / 2).FadeIn(duration / 2).Finally(c => c.updateProgress());
+                updateProgress();
+                this.FadeOut().Delay(duration / 2).FadeIn(duration / 2);
             }
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
@@ -129,7 +129,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             }
             else
             {
-                updateProgress();
                 this.FadeOut().Delay(duration / 2).FadeIn(duration / 2);
             }
         }
@@ -175,6 +174,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                     Origin = Anchor.Centre,
                     Texture = textures.Get("slide"),
                 });
+            }
+
+            protected override void FreeAfterUse()
+            {
+                base.FreeAfterUse();
+                ClearTransforms();
             }
 
             public void UpdateProgress(double progress)


### PR DESCRIPTION
The chevrons could be either visible or invisible depending on whether the previous slide has been completed or not. The transforms used during the non-snaking transforms resets the chevrons back to full alpha at the end, instead of at the front. The original transforms were due to me trying to rush things, and copied the same thing from the snaking transforms, without realizing that it was not helping anything.