### PR TITLE
Propagate input events to DrawableTouch from a parent, rather than to let them actively poll for it

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -22,6 +23,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         // This HitObject uses a completely different offset
         protected override double InitialLifetimeOffset => base.InitialLifetimeOffset + HitObject.HitWindows.WindowFor(HitResult.Ok);
+
+        public bool[] IsPointOver = new bool[11];
 
         private TouchFlashPiece flash;
         private ExplodePiece explode;
@@ -76,9 +79,16 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             Position = HitObject.Position;
         }
 
+        protected override void OnFree()
+        {
+            base.OnFree();
+            for (int i = 0; i < 11; ++i)
+                IsPointOver[i] = false;
+        }
+
         private BindableInt trackedKeys = new BindableInt(0);
 
-        protected override void Update()
+        /* protected override void Update()
         {
             base.Update();
             int count = 0;
@@ -100,7 +110,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             trackedKeys.Value = count;
         }
-
+ */
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();
@@ -172,5 +182,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     break;
             }
         }
+
+        public bool OnNewHeldPointDetected() => UpdateResult(true);
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -24,7 +24,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         // This HitObject uses a completely different offset
         protected override double InitialLifetimeOffset => base.InitialLifetimeOffset + HitObject.HitWindows.WindowFor(HitResult.Ok);
 
-        public bool[] IsPointOver = new bool[11];
+        // Similar to IsHovered for mouse, this tracks whether a pointer (touch or mouse) is interacting with this drawable
+        // Interaction == (IsHovered && ActionPressed) || (OnTouch && TouchPointerInBounds)
+        public bool[] PointInteractionState = new bool[11];
 
         private TouchFlashPiece flash;
         private ExplodePiece explode;
@@ -83,34 +85,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.OnFree();
             for (int i = 0; i < 11; ++i)
-                IsPointOver[i] = false;
+                PointInteractionState[i] = false;
         }
 
         private BindableInt trackedKeys = new BindableInt(0);
 
-        /* protected override void Update()
-        {
-            base.Update();
-            int count = 0;
-
-            if (!AllJudged)
-            {
-                var touchInput = SentakkiActionInputManager.CurrentState.Touch;
-                if (touchInput.ActiveSources.Any())
-                {
-                    foreach (var t in touchInput.ActiveSources)
-                        if (ReceivePositionalInputAt(touchInput.GetTouchPosition(t).Value)) ++count;
-                }
-                else if (IsHovered)
-                {
-                    foreach (var a in SentakkiActionInputManager.PressedActions)
-                        if (a < SentakkiAction.Key1) ++count;
-                }
-            }
-
-            trackedKeys.Value = count;
-        }
- */
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();
@@ -183,6 +162,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             }
         }
 
-        public bool OnNewHeldPointDetected() => UpdateResult(true);
+        public bool OnNewPointInteraction() => UpdateResult(true);
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -82,7 +82,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
             sentakkiRulesetConfig = sentakkiRulesetConfigManager;
 
             RegisterPool<TouchHold, DrawableTouchHold>(2);
-            RegisterPool<Objects.Touch, DrawableTouch>(8);
         }
 
         protected override HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject) => new SentakkiHitObjectLifetimeEntry(hitObject, sentakkiRulesetConfig, drawableSentakkiRuleset);

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -33,6 +33,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
         public static readonly float NOTESTARTDISTANCE = 66f;
 
         private readonly LanedPlayfield lanedPlayfield;
+        private readonly TouchPlayfield touchPlayfield;
 
         public static readonly float[] LANEANGLES =
         {
@@ -60,12 +61,14 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 Ring = new SentakkiRing(),
                 lanedPlayfield = new LanedPlayfield(),
                 HitObjectContainer, // This only contains Touch and TouchHolds, which should appear above others note types. Might consider separating to another playfield.
+                touchPlayfield = new TouchPlayfield(),
                 judgementLayer = new Container<DrawableSentakkiJudgement>
                 {
                     RelativeSizeAxes = Axes.Both,
                 }
             });
             AddNested(lanedPlayfield);
+            AddNested(touchPlayfield);
             NewResult += onNewResult;
         }
 
@@ -104,7 +107,9 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 case SentakkiLanedHitObject _:
                     lanedPlayfield.Add(h);
                     break;
-
+                case Objects.Touch _:
+                    touchPlayfield.Add(h);
+                    break;
                 default:
                     base.Add(h);
                     break;

--- a/osu.Game.Rulesets.Sentakki/UI/TouchPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/TouchPlayfield.cs
@@ -1,7 +1,11 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 using osu.Game.Rulesets.UI;
@@ -41,6 +45,8 @@ namespace osu.Game.Rulesets.Sentakki.UI
         {
             base.Update();
 
+            var aliveObjects = HitObjectContainer.AliveObjects.ToList();
+
             // Handle mouse input
             var mousePosition = SentakkiActionInputManager.CurrentState.Mouse.Position;
             bool actionPressed = false;
@@ -53,20 +59,20 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 }
             }
 
-            handlePointInput(0, actionPressed, mousePosition);
+            handlePointInput(0, actionPressed, mousePosition, aliveObjects);
 
             // Handle touch
             for (int i = 0; i < 10; ++i)
             {
                 var currentTouchPosition = SentakkiActionInputManager.CurrentState.Touch.GetTouchPosition((TouchSource)i);
-                handlePointInput(i + 1, currentTouchPosition.HasValue, currentTouchPosition);
+                handlePointInput(i + 1, currentTouchPosition.HasValue, currentTouchPosition, aliveObjects);
             }
         }
 
-        private void handlePointInput(int pointID, bool hasAction, Vector2? pointerPosition)
+        private void handlePointInput(int pointID, bool hasAction, Vector2? pointerPosition, IEnumerable<DrawableHitObject> aliveObjects)
         {
             bool continueEventPropogation = true;
-            foreach (DrawableTouch touch in HitObjectContainer.AliveObjects)
+            foreach (DrawableTouch touch in aliveObjects)
             {
                 if (hasAction && touch.ReceivePositionalInputAt(pointerPosition.Value))
                 {

--- a/osu.Game.Rulesets.Sentakki/UI/TouchPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/TouchPlayfield.cs
@@ -1,14 +1,100 @@
+using System.Buffers;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Input;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Sentakki.Configuration;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 using osu.Game.Rulesets.UI;
+using osuTK;
 
 namespace osu.Game.Rulesets.Sentakki.UI
 {
     public class TouchPlayfield : Playfield
     {
+        private SentakkiInputManager sentakkiActionInputManager;
+        internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= GetContainingInputManager() as SentakkiInputManager;
+
+        public override bool HandlePositionalInput => true;
+
         public TouchPlayfield()
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        private DrawableSentakkiRuleset drawableSentakkiRuleset;
+        private SentakkiRulesetConfigManager sentakkiRulesetConfig;
+
+        [BackgroundDependencyLoader(true)]
+        private void load(DrawableSentakkiRuleset drawableRuleset, SentakkiRulesetConfigManager sentakkiRulesetConfigManager)
+        {
+            drawableSentakkiRuleset = drawableRuleset;
+            sentakkiRulesetConfig = sentakkiRulesetConfigManager;
+
+            RegisterPool<Objects.Touch, DrawableTouch>(8);
+        }
+
+        protected override HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject) => new SentakkiHitObjectLifetimeEntry(hitObject, sentakkiRulesetConfig, drawableSentakkiRuleset);
+
+        protected override void Update()
+        {
+            base.Update();
+
+            // Handle mouse input
+            bool continueMouseEventPropogation = true;
+            var mousePosition = SentakkiActionInputManager.CurrentState.Mouse.Position;
+            var actionPressed = false;
+            foreach (var action in SentakkiActionInputManager.PressedActions)
+            {
+                if (action < SentakkiAction.Key1)
+                {
+                    actionPressed = true;
+                    break;
+                }
+            }
+
+            foreach (DrawableTouch touch in HitObjectContainer.AliveObjects)
+            {
+                if (actionPressed && touch.ReceivePositionalInputAt(mousePosition))
+                {
+                    if (!touch.IsPointOver[0])
+                    {
+                        touch.IsPointOver[0] = true;
+                        if (continueMouseEventPropogation)
+                            continueMouseEventPropogation = !touch.OnNewHeldPointDetected();
+                    }
+                }
+                else
+                {
+                    touch.IsPointOver[0] = false;
+                }
+            }
+
+            // Handle touch
+            for (int i = 0; i < 10; ++i)
+            {
+                bool continueTouchEventPropogation = true;
+                Vector2? currentTouchPosition = SentakkiActionInputManager.CurrentState.Touch.GetTouchPosition((TouchSource)i);
+
+                foreach (DrawableTouch touch in HitObjectContainer.AliveObjects)
+                {
+                    if (currentTouchPosition.HasValue && touch.ReceivePositionalInputAt(currentTouchPosition.Value))
+                    {
+                        if (!touch.IsPointOver[i + 1])
+                        {
+                            touch.IsPointOver[i + 1] = true;
+                            if (continueTouchEventPropogation)
+                                continueTouchEventPropogation = !touch.OnNewHeldPointDetected();
+                        }
+                    }
+                    else
+                    {
+                        touch.IsPointOver[i + 1] = false;
+                    }
+                }
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/TouchPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/TouchPlayfield.cs
@@ -9,15 +9,12 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Sentakki.UI
 {
-
     // A special playfield specifically made for TouchNotes
     // Contains extra functionality to better propogate touch input to Touch notes, and avoids some double hit weirdness
     public class TouchPlayfield : Playfield
     {
         private SentakkiInputManager sentakkiActionInputManager;
         internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= GetContainingInputManager() as SentakkiInputManager;
-
-        public override bool HandlePositionalInput => true;
 
         public TouchPlayfield()
         {

--- a/osu.Game.Rulesets.Sentakki/UI/TouchPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/TouchPlayfield.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
             {
                 if (hasAction && touch.ReceivePositionalInputAt(pointerPosition.Value))
                 {
-                    if (touch.PointInteractionState[pointID])
+                    if (!touch.PointInteractionState[pointID])
                     {
                         touch.PointInteractionState[pointID] = true;
                         if (continueEventPropogation)


### PR DESCRIPTION
`DrawableTouch` have several methods of being hit. Either a direct click/touch on it, or entering their hitbox with a previously clicked pointer, or a finger dragging into it. Both are valid, and to make it straight forward, I'll be using the term "Interaction" to cover both cases. And the term "pointer" to refer to cursor and fingers.

Previously, `DrawableTouch` would poll for the current state of inputs within their update method. This was problematic as each individual drawable will have no knowledge of their siblings, so they are unable to block other Drawables from receiving the same interaction, unlike regular events that could be blocked (Ex. OnClick, OnMove, etc). This would cause issues where two Touch notes with overlapping boundaries could be hit at the same frame, regardless of player intention.

This PR separates out the Touch HitObjects into their own playfield (using the previously unused `TouchPlayfield`). The `TouchPlayfield` has the capability to poll the current state of Mouse and Touch inputs, and checks that the position of each of the points is within the boundaries of the DrawableTouch (Similar to IsHovered). Unlike IsHovered, all points are tracked separately, and all of the drawables will have the current interaction states updated regardless of whether another drawable is sharing the same space. An `OnTouchNoteInteraction` event will be fired if a new interaction is established with a drawable, this can be blocked in a similar fashion to `OnX` events fired by the `InputManager`s, returning true on this event will not prevent the interaction states of other drawables from being updated. 

