### PR TITLE
Fix resume overlay cursor being offset

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -2,7 +2,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
-using osu.Framework.Input;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -16,7 +15,7 @@ using osuTK;
 namespace osu.Game.Rulesets.Sentakki.UI
 {
     [Cached]
-    public class SentakkiPlayfield : Playfield, IRequireHighFrequencyMousePosition
+    public class SentakkiPlayfield : Playfield
     {
         private readonly Container<DrawableSentakkiJudgement> judgementLayer;
         private readonly DrawablePool<DrawableSentakkiJudgement> judgementPool;

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiResumeOverlay.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiResumeOverlay.cs
@@ -54,7 +54,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
             Origin = Anchor.Centre;
             Anchor = Anchor.Centre;
             RelativeSizeAxes = Axes.Both;
-            FillMode = FillMode.Fill;
             Children = new Drawable[]{
                 counterText = new OsuSpriteText
                 {
@@ -128,7 +127,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
             if (localCursorContainer == null)
             {
                 Add(localCursorContainer = new SentakkiCursorContainer());
-                localCursorContainer.MoveTo(GameplayCursor.ActiveCursor.Position);
             }
         }
 
@@ -137,7 +135,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
             base.PopOut();
 
             if (localCursorContainer != null && GameplayCursor?.ActiveCursor != null)
-                GameplayCursor.ActiveCursor.Position = localCursorContainer.Position;
+                GameplayCursor.ActiveCursor.Position = localCursorContainer.ActiveCursor.Position;
 
             localCursorContainer?.Expire();
             localCursorContainer = null;

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiResumeOverlay.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiResumeOverlay.cs
@@ -11,7 +11,6 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Screens.Play;
 using osu.Game.Skinning;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.UI


### PR DESCRIPTION
This was an error caused by a change introduced in fcac7d7512f5561cf649a740bc2ff0806658a9f2... And would've been caught had I tested properly.

