### PR TITLE
Improve positioning of Touch notes in converted maps

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneTouchNote.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneTouchNote.cs
@@ -4,8 +4,10 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Sentakki.Beatmaps;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
+using osu.Game.Rulesets.Sentakki.UI.Components;
 using osu.Game.Tests.Visual;
 using osuTK;
 
@@ -22,30 +24,35 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
         public TestSceneTouchNote()
         {
             base.Content.Add(content = new SentakkiInputManager(new SentakkiRuleset().RulesetInfo));
+            base.Content.Add(new SentakkiRing());
 
-            AddStep("Miss Single", () => testSingle());
-            AddStep("Hit Single", () => testSingle(true));
+            AddStep("Miss Single", () => testAllPositions());
+            AddStep("Hit Single", () => testAllPositions(true));
             AddUntilStep("Wait for object despawn", () => !Children.Any(h => (h is DrawableSentakkiHitObject) && (h as DrawableSentakkiHitObject).AllJudged == false));
         }
 
-        private void testSingle(bool auto = false)
+        private void testAllPositions(bool auto = false)
         {
-            var circle = new Touch
+            foreach (var position in SentakkiPatternGenerator.VALID_TOUCH_POSITIONS)
             {
-                StartTime = Time.Current + 1000,
-                Position = new Vector2(0, -1),
-            };
+                var circle = new Touch
+                {
+                    StartTime = Time.Current + 1000,
+                    Position = position,
+                };
 
-            circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });
+                circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });
 
-            Add(new DrawableTouch(circle)
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Depth = depthIndex++,
-                Auto = auto
-            });
+                Add(new DrawableTouch(circle)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Depth = depthIndex++,
+                    Auto = auto
+                });
+            }
         }
+
         protected override Ruleset CreateRuleset() => new SentakkiRuleset();
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         none = 0,
         twinNotes = 1,
         twinSlides = 2,
-        touch = 4,
     }
 
     public class SentakkiBeatmapConverter : BeatmapConverter<SentakkiHitObject>

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
@@ -11,6 +11,8 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.UI;
+using osuTK;
 
 namespace osu.Game.Rulesets.Sentakki.Beatmaps
 {
@@ -235,13 +237,27 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             };
         }
 
+        public static readonly Vector2[] VALID_TOUCH_POSITIONS;
+        static SentakkiPatternGenerator()
+        {
+            var tmp = new List<Vector2>(){
+                Vector2.Zero
+            };
+            foreach (var angle in SentakkiPlayfield.LANEANGLES)
+            {
+                tmp.Add(SentakkiExtensions.GetCircularPosition(190, angle - 22.5f));
+                tmp.Add(SentakkiExtensions.GetCircularPosition(130, angle));
+            }
+            VALID_TOUCH_POSITIONS = tmp.ToArray();
+        }
+
         private SentakkiHitObject createTouchNote(HitObject original)
         {
             return new Touch
             {
                 Samples = original.Samples,
                 StartTime = original.StartTime,
-                Position = SentakkiExtensions.GetCircularPosition(rng.Next(200), rng.Next(360))
+                Position = VALID_TOUCH_POSITIONS[rng.Next(0, VALID_TOUCH_POSITIONS.Length)]
             };
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 
                 default:
                     breakNote = original.Samples.Any(s => s.Name == HitSampleInfo.HIT_FINISH);
-                    if (!breakNote && Experiments.Value.HasFlagFast(ConversionExperiments.touch) && original.Samples.Any(s => s.Name == HitSampleInfo.HIT_WHISTLE))
+                    if (!breakNote && original.Samples.Any(s => s.Name == HitSampleInfo.HIT_WHISTLE))
                     {
                         yield return createTouchNote(original);
                     }

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
@@ -35,13 +35,6 @@ namespace osu.Game.Rulesets.Sentakki.Mods
             Value = false
         };
 
-        [SettingSource("Touch notes", "Allow TOUCHs to appear")]
-        public BindableBool EnableTouch { get; } = new BindableBool
-        {
-            Default = false,
-            Value = false
-        };
-
         public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)
         {
             if (EnableTwinNotes.Value)
@@ -49,9 +42,6 @@ namespace osu.Game.Rulesets.Sentakki.Mods
 
             if (EnableTwinSlides.Value)
                 (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments.Value |= ConversionExperiments.twinSlides;
-
-            if (EnableTouch.Value)
-                (beatmapConverter as SentakkiBeatmapConverter).EnabledExperiments.Value |= ConversionExperiments.touch;
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             sentakkiConfigs?.BindWith(SentakkiRulesetSettings.TouchAnimationDuration, AnimationDuration);
 
-            Size = new Vector2(130);
+            Size = new Vector2(105);
             Origin = Anchor.Centre;
             Anchor = Anchor.Centre;
             Alpha = 0;


### PR DESCRIPTION
Previously, the position of Touch notes were chosen randomly, this resulted in some odd positioning, making them less fun.

Instead of full random, Touch notes will randomly pick a position from a preset list. Each "slot" has a cooldown of 500ms, to avoid multiple notes occupying the same slot. Touch notes will pick the slot that will be available the soonest in the event that there aren't any available slots.

With this, I feel confident in moving Touch notes into the official conversion possibilities.