### PR TITLE
Fix visualizer colour not being consistent with SentakkiRing

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Sentakki.Mods
                 MaxValue = maxLives,
             };
 
-            (drawableRuleset.Playfield as SentakkiPlayfield).Ring.Add(new LiveCounter(LivesLeft));
+            (drawableRuleset.Playfield as SentakkiPlayfield).AccentContainer.Add(new LiveCounter(LivesLeft));
         }
 
         public void ApplyToHealthProcessor(HealthProcessor healthProcessor)

--- a/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
@@ -14,7 +14,6 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Sentakki.Configuration;
-using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
 
@@ -61,13 +60,12 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
 
         private int indexOffset;
 
-        public Color4 AccentColour { get; set; }
+        public Color4 AccentColour { get; set; } = Color4.White.Opacity(0.2f);
 
         private readonly float[] frequencyAmplitudes = new float[256];
 
         private IShader shader;
         private readonly Texture texture;
-        private Bindable<Skin> skin;
 
         public PlayfieldVisualisation()
         {
@@ -81,17 +79,13 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             Blending = BlendingParameters.Additive;
         }
 
-        private readonly Bindable<ColorOption> colorOption = new Bindable<ColorOption>(ColorOption.Default);
-
         private readonly Bindable<bool> kiaiEffect = new Bindable<bool>(true);
+
         [BackgroundDependencyLoader(true)]
-        private void load(ShaderManager shaders, IBindable<WorkingBeatmap> beatmap, SkinManager skinManager, SentakkiRulesetConfigManager settings, OsuColour colours, DrawableSentakkiRuleset ruleset)
+        private void load(ShaderManager shaders, IBindable<WorkingBeatmap> beatmap, SentakkiRulesetConfigManager settings)
         {
             this.beatmap.BindTo(beatmap);
             shader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
-
-            skin = skinManager.CurrentSkin.GetBoundCopy();
-            skin.BindValueChanged(_ => colorOption.TriggerChange());
 
             settings?.BindWith(SentakkiRulesetSettings.KiaiEffects, kiaiEffect);
             kiaiEffect.BindValueChanged(k =>
@@ -101,24 +95,10 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                 else
                     this.FadeOut(500);
             });
-
-            settings?.BindWith(SentakkiRulesetSettings.RingColor, colorOption);
-            colorOption.BindValueChanged(c =>
-            {
-                AccentColour = Color4.White.Opacity(0.2f);
-
-                if (c.NewValue == ColorOption.Default)
-                    this.FadeColour(Color4.White, 200);
-                else if (c.NewValue == ColorOption.Difficulty)
-                    this.FadeColour(colours.ForDifficultyRating(ruleset?.Beatmap.BeatmapInfo.DifficultyRating ?? DifficultyRating.Normal, true), 200);
-                else if (c.NewValue == ColorOption.Skin)
-                    this.FadeColour(skin.Value.GetConfig<GlobalSkinColours, Color4>(GlobalSkinColours.MenuGlow)?.Value ?? Color4.White, 200);
-            });
         }
 
         protected override void LoadComplete()
         {
-            colorOption.TriggerChange();
             kiaiEffect.TriggerChange();
         }
 

--- a/osu.Game.Rulesets.Sentakki/UI/Components/SentakkiRing.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/SentakkiRing.cs
@@ -3,13 +3,9 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Beatmaps;
-using osu.Game.Graphics;
 using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
-using osu.Game.Skinning;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.UI.Components
 {
@@ -55,36 +51,17 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
 
         public readonly Bindable<float> RingOpacity = new Bindable<float>(1);
         public readonly Bindable<bool> NoteStartIndicators = new Bindable<bool>(false);
-        private readonly Bindable<ColorOption> colorOption = new Bindable<ColorOption>(ColorOption.Default);
         private readonly Bindable<bool> kiaiEffect = new Bindable<bool>(true);
-        private IBindable<StarDifficulty?> beatmapDifficulty;
 
-        private Bindable<Skin> skin;
+
         [BackgroundDependencyLoader(true)]
-        private void load(SentakkiRulesetConfigManager settings, OsuColour colours, SkinManager skinManager, IBeatmap beatmap, BeatmapDifficultyCache difficultyCache)
+        private void load(SentakkiRulesetConfigManager settings)
         {
-            if (beatmap != null)
-                beatmapDifficulty = difficultyCache.GetBindableDifficulty(beatmap.BeatmapInfo);
-
             settings?.BindWith(SentakkiRulesetSettings.RingOpacity, RingOpacity);
             RingOpacity.BindValueChanged(opacity => Alpha = opacity.NewValue);
 
             settings?.BindWith(SentakkiRulesetSettings.ShowNoteStartIndicators, NoteStartIndicators);
             NoteStartIndicators.BindValueChanged(opacity => spawnIndicator.FadeTo(Convert.ToSingle(opacity.NewValue), 200));
-
-            skin = skinManager.CurrentSkin.GetBoundCopy();
-            skin.BindValueChanged(_ => colorOption.TriggerChange(), true);
-
-            settings?.BindWith(SentakkiRulesetSettings.RingColor, colorOption);
-            colorOption.BindValueChanged(option =>
-            {
-                if (option.NewValue == ColorOption.Default)
-                    this.FadeColour(Color4.White, 200);
-                else if (option.NewValue == ColorOption.Difficulty)
-                    this.FadeColour(colours.ForDifficultyRating(beatmapDifficulty?.Value.Value.DifficultyRating ?? DifficultyRating.Normal, true), 200);
-                else if (option.NewValue == ColorOption.Skin)
-                    this.FadeColour(skin.Value.GetConfig<GlobalSkinColours, Color4>(GlobalSkinColours.MenuGlow)?.Value ?? Color4.White, 200);
-            });
 
             settings?.BindWith(SentakkiRulesetSettings.KiaiEffects, kiaiEffect);
         }
@@ -93,7 +70,6 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
         {
             NoteStartIndicators.TriggerChange();
             this.FadeTo(RingOpacity.Value, 1000, Easing.OutElasticQuarter).ScaleTo(1, 1000, Easing.OutElasticQuarter);
-            colorOption.TriggerChange();
         }
 
         public void KiaiBeat()

--- a/osu.Game.Rulesets.Sentakki/UI/Components/SentakkiRing.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/SentakkiRing.cs
@@ -53,7 +53,6 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
         public readonly Bindable<bool> NoteStartIndicators = new Bindable<bool>(false);
         private readonly Bindable<bool> kiaiEffect = new Bindable<bool>(true);
 
-
         [BackgroundDependencyLoader(true)]
         private void load(SentakkiRulesetConfigManager settings)
         {

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -86,11 +86,11 @@ namespace osu.Game.Rulesets.Sentakki.UI
         [Resolved]
         private DrawableSentakkiRuleset drawableSentakkiRuleset { get; set; }
 
-        [Resolved]
+        [Resolved(canBeNull: true)]
         private SentakkiRulesetConfigManager sentakkiRulesetConfig { get; set; }
 
         private IBindable<Skin> skin;
-        private IBindable<ColorOption> ringColor;
+        private Bindable<ColorOption> ringColor = new Bindable<ColorOption>();
 
         private IBindable<StarDifficulty?> beatmapDifficulty;
 
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
             beatmapDifficulty = difficultyCache.GetBindableDifficulty(beatmap.BeatmapInfo);
 
             skin = skinManager.CurrentSkin.GetBoundCopy();
-            ringColor = sentakkiRulesetConfig?.GetBindable<ColorOption>(SentakkiRulesetSettings.RingColor);
+            sentakkiRulesetConfig?.BindWith(SentakkiRulesetSettings.RingColor, ringColor);
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
In #230, my goal was to make the "Difficulty-based colour" option in sentakki use the inflated SR values we use, instead of dumbly using the SR values embedded in the beatmaps. In that PR, I made `SentakkiRing` use the correct SR values to determine its colour, but totally forgot about `PlayfieldVisualizer`.

Instead of adjusting the visualizer colours separate from the ring, I've chosen to apply the colour to a container that holds both of them, and let the playfield be responsible for changing the colour of that container. 