### PR TITLE
Move break sample from tail to head in holds

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
@@ -12,6 +12,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 {
     public class Hold : SentakkiLanedHitObject, IHasDuration
     {
+        protected override bool NeedBreakSample => false;
+
         private List<IList<HitSampleInfo>> nodeSamples = new List<IList<HitSampleInfo>>();
 
         public List<IList<HitSampleInfo>> NodeSamples
@@ -50,8 +52,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
         public class HoldHead : SentakkiLanedHitObject
         {
-            protected override bool NeedBreakSample => false;
-
             public override Judgement CreateJudgement() => new SentakkiJudgement();
             protected override HitWindows CreateHitWindows() => new SentakkiHitWindows();
         }


### PR DESCRIPTION
Most osu! sliders are built with the emphasis at the hitcircle, rather than the tail. Having the break sample be at the tail doesn't really play nice with that.

This changes things so that the head plays the break sample rather than the tail.