### PR TITLE
Slightly tweak slide endpoint margin

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         private const int chevrons_per_eith = 8;
         private const double ring_radius = 297;
         private const double chevrons_per_distance = (chevrons_per_eith * 8) / (2 * Math.PI * ring_radius);
-        private const double endpoint_distance = 34; // margin for each end
+        private const double endpoint_distance = 30; // margin for each end
 
         private static int chevronsInContinuousPath(SliderPath path)
         {


### PR DESCRIPTION
The current margins were chosen because we preferred the clean overlaps on the U shape loops. However, this came at the cost of the V slides suffering some major spacing inconsistencies when the path is segmented (At around the 90 degree bends).

Looking at it, the U slide loops don't have the perfect overlap either, so I feel justified in sacrificing the perfect overlaps of the Cup slide loops, in favor of having a less noticable spacing difference in V slides. (The overlap is now off slightly)

## Comparisons

https://user-images.githubusercontent.com/12001167/124366504-a47bc000-dc50-11eb-8188-a4c46a48adc2.mp4


https://user-images.githubusercontent.com/12001167/124366506-a776b080-dc50-11eb-8f0b-99038c542512.mp4
