### PR TITLE
Make ResumeOverlay ticks follow the current BPM

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiResumeOverlay.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiResumeOverlay.cs
@@ -70,6 +70,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
                     Colour = colours.Yellow,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
+                    ShadowColour = new Color4(0f, 0f, 0f, 0.25f)
                 },
                 new FillFlowContainer
                 {

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiResumeOverlay.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiResumeOverlay.cs
@@ -47,6 +47,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
         private double remainingTime = 3500;
 
         private Bindable<int> beatsLeft = new Bindable<int>(4);
+        private int barLength;
 
         private OsuSpriteText supporterText;
 
@@ -126,11 +127,11 @@ namespace osu.Game.Rulesets.Sentakki.UI
             messageText.Text = "Get ready!";
 
             var currentTimingPoint = beatmap.Value.Beatmap.ControlPointInfo.TimingPointAt(beatmap.Value.Track.CurrentTime);
-            int maxTicks = (int)currentTimingPoint.TimeSignature;
+            barLength = (int)currentTimingPoint.TimeSignature;
             beatlength = currentTimingPoint.BeatLength;
 
-            // Reset the countdown
-            remainingTime = maxTicks * beatlength;
+            // Reset the countdown, plus a second for preparation
+            remainingTime = (barLength * beatlength) + 1000;
 
             GameplayCursor.ActiveCursor.Hide();
 
@@ -161,7 +162,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
         private void onCountUpdated(ValueChangedEvent<int> beatsLeft)
         {
-            if (beatsLeft.NewValue < beatsLeft.OldValue)
+            if (beatsLeft.NewValue < barLength && beatsLeft.NewValue < beatsLeft.OldValue)
             {
                 countSound?.Play();
 

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiResumeOverlay.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiResumeOverlay.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -12,11 +11,9 @@ using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Screens.Play;
 using osu.Game.Skinning;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.UI
@@ -27,18 +24,16 @@ namespace osu.Game.Rulesets.Sentakki.UI
         private IBindable<WorkingBeatmap> beatmap { get; set; }
 
         private readonly string[] supporter_list = new string[]{
-            "Ayato_K ♥",
-            "Bosch ♥",
-            "Dubita ♥",
-            "Ezz ♥ (iOS helper)",
-            "Mae ♥♥",
-            "Nutchapol ♥",
-            "Shiuannie (Artist)",
-            "Smoogipoo ♥♥♥",
+            "Ayato_K",
+            "Bosch",
+            "Dubita",
+            "Ezz",
+            "Mae",
+            "Nutchapol",
+            "Shiuannie",
+            "Smoogipoo",
             "Flutterish",
-            "Slipsy (Discord moderator)",
-            "Nooraldeen (Discord moderator, feedback machine)",
-            "lazer developers"
+            "Nooraldeen",
         }.OrderBy(t => RNG.Next()).ToArray();
 
         private static int currentSupporterIndex;
@@ -84,7 +79,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
                         new OsuSpriteText
                         {
                             Text = "Sentakki is made with the support of ",
-                            Font = OsuFont.Torus.With(size: 15),
+                            Font = OsuFont.Torus.With(size: 20),
                             Colour = Color4.White,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
@@ -94,7 +89,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
                         supporterText = new OsuSpriteText
                         {
                             Text = "Marisa Kirisame",
-                            Font = OsuFont.Torus.With(size: 18, weight: FontWeight.SemiBold),
+                            Font = OsuFont.Torus.With(size: 20, weight: FontWeight.SemiBold),
                             Colour = Color4Extensions.FromHex("ff0064"),
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,


### PR DESCRIPTION
Previously, `SentakkiResumeOverlay` had a constant countdown of 3 seconds. 

This PR changes it so that the countdown matches the BPM of beatmap track at current time. The only problem that could arise is that the overlay may take a long time to disappear on absurdly low BPMs, but I'm fine with that. (Anyone who listens to 1BPM music deserves the wait imo.)


https://user-images.githubusercontent.com/12001167/127750900-c82c3406-2651-46c2-bc87-bb3dcf3014f9.mp4



