### PR TITLE
Improve testing

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -9,7 +9,10 @@ on:
 jobs:
   build:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This is an attempt to improve test coverage, so that regressions/bugs are caught during PRs. Asserts should be used where feasable, and visual only testing in other cases.

This originally was a response to try and catch shader compilation errors during the CI process (perhaps due to non-compliant shader file), but it doesn't seem to work as headless tests lack GL contexts.