### PR TITLE
Fix shader error causing potential crashes

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_PlayfieldMask.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_PlayfieldMask.fs
@@ -17,5 +17,5 @@ lowp vec4 getColourAt(highp vec2 diff, highp vec2 size, lowp vec4 originalColour
 
 void main(void)
 {
-    gl_FragColor = mix(getColourAt(maskPosition - v_Position, maskRadius, v_Colour), vec4(0, 0.0, 0, 1.0), 0);
+    gl_FragColor = mix(getColourAt(maskPosition - v_Position, maskRadius, v_Colour), vec4(0.0, 0.0, 0.0, 1.0), 0.0);
 }

--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_PlayfieldMask.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_PlayfieldMask.fs
@@ -4,7 +4,7 @@ varying lowp vec4 v_Colour;
 uniform highp vec2 maskPosition;
 uniform highp vec2 maskRadius;
 
-const mediump float smoothness = 2;
+const mediump float smoothness = 2.0;
 
 // highp precision is necessary for vertex positions to prevent catastrophic failure on GL_ES platforms
 lowp vec4 getColourAt(highp vec2 diff, highp vec2 size, lowp vec4 originalColour)


### PR DESCRIPTION
This fixes shader related crash in MacOS and Linux, Android ios untested.

The `mix` function in glsl doesn't officially support using `GenIType` as the third parameter. Weirdly it seems to work on Windows, maybe something specific to the OpenGL implementation in drivers...