### PR TITLE
Avoid differentiating assembly name for dev builds

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Build with .NET
-      run: dotnet build --configuration Development
+      run: dotnet build
     - name: Unit Tests
       run: dotnet test --no-build --no-restore
     - name: Upload Artifact

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -22,4 +22,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: Sentakki (Dev build)
-        path: osu.Game.Rulesets.Sentakki/bin/Debug/netstandard2.1/osu.Game.Rulesets.Sentakki-dev.dll
+        path: osu.Game.Rulesets.Sentakki/bin/Debug/netstandard2.1/osu.Game.Rulesets.Sentakki.dll

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -17,9 +17,9 @@ jobs:
     - name: Build with .NET
       run: dotnet build --configuration Development
     - name: Unit Tests
-      run: dotnet test --no-build --no-restore --configuration Development
+      run: dotnet test --no-build --no-restore
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:
         name: Sentakki (Dev build)
-        path: osu.Game.Rulesets.Sentakki/bin/Development/netstandard2.1/osu.Game.Rulesets.Sentakki-dev.dll
+        path: osu.Game.Rulesets.Sentakki/bin/Debug/netstandard2.1/osu.Game.Rulesets.Sentakki-dev.dll

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,18 +14,6 @@
             "console": "internalConsole"
         },
         {
-            "name": "sentakki for osu! (Development)",
-            "type": "coreclr",
-            "request": "launch",
-            "program": "dotnet",
-            "args": [
-                "${workspaceRoot}/osu.Game.Rulesets.Sentakki.Tests/bin/Development/net5.0/osu.Game.Rulesets.Sentakki.Tests.dll"
-            ],
-            "cwd": "${workspaceRoot}",
-            "preLaunchTask": "Build (Development)",
-            "console": "internalConsole"
-        },
-        {
             "name": "sentakki for osu! (Release)",
             "type": "coreclr",
             "request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,20 +16,6 @@
             "problemMatcher": "$msCompile"
         },
         {
-            "label": "Build (Development)",
-            "type": "shell",
-            "command": "dotnet",
-            "args": [
-                "build",
-                "osu.Game.Rulesets.Sentakki.Tests",
-                "/p:Configuration=Development",
-                "/m",
-                "/verbosity:m"
-            ],
-            "group": "build",
-            "problemMatcher": "$msCompile"
-        },
-        {
             "label": "Build (Release)",
             "type": "shell",
             "command": "dotnet",
@@ -51,17 +37,6 @@
             "args": [
                 "test",
                 "/p:Configuration=Debug",
-            ],
-            "group": "test",
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "Run tests (Development)",
-            "type": "shell",
-            "command": "dotnet",
-            "args": [
-                "test",
-                "/p:Configuration=Development",
             ],
             "group": "test",
             "problemMatcher": "$msCompile"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,6 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
-        <Configurations>Debug;Release</Configurations>
 
         <Authors>Derrick Timmermans</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,24 +1,18 @@
 <Project>
-  <PropertyGroup Label="C#">
-    <LangVersion>8.0</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <Configurations>Debug;Release;Development</Configurations>
+    <PropertyGroup Label="C#">
+        <LangVersion>8.0</LangVersion>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <Configurations>Debug;Release</Configurations>
 
-    <Authors>Derrick Timmermans</Authors>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/LumpBloom7/sentakki</RepositoryUrl>
-    <Copyright>Copyright (c) 2021 Derrick Timmermans</Copyright>
-  </PropertyGroup>
-  <ItemGroup>
-    <!-- The automated version of this (<EmbeddedResource Include="xyz\**" />) would prepend the RootNamespace to name,
-         that will not work well with DllResourceStore as it can only determine the root namespace via AssemblyName,
-         and we change that based on the build configuration for separation purposes.
-         Therefore prepend the AssemblyName to embedded resources names instead. -->
-    <EmbeddedResource Include="Resources\**\*">
-      <LogicalName>$(AssemblyName).$([System.String]::Copy(%(Identity)).Replace($([System.IO.Path]::DirectorySeparatorChar.ToString()), '.'))</LogicalName>
-    </EmbeddedResource>
-  </ItemGroup>
+        <Authors>Derrick Timmermans</Authors>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <RepositoryUrl>https://github.com/LumpBloom7/sentakki</RepositoryUrl>
+        <Copyright>Copyright (c) 2021 Derrick Timmermans</Copyright>
+    </PropertyGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Resources\**\*"/>
+    </ItemGroup>
 </Project>

--- a/osu.Game.Rulesets.Sentakki.sln
+++ b/osu.Game.Rulesets.Sentakki.sln
@@ -16,14 +16,10 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Development|Any CPU.ActiveCfg = Development|Any CPU
-		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Development|Any CPU.Build.0 = Development|Any CPU
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Development|Any CPU.ActiveCfg = Development|Any CPU
-		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Development|Any CPU.Build.0 = Development|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Release|Any CPU.Build.0 = Release|Any CPU
 

--- a/osu.Game.Rulesets.Sentakki.sln
+++ b/osu.Game.Rulesets.Sentakki.sln
@@ -11,7 +11,6 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		Development|Any CPU = Development|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -37,12 +38,13 @@ namespace osu.Game.Rulesets.Sentakki
 {
     public class SentakkiRuleset : Ruleset
     {
-        private static readonly Lazy<bool> is_development_build = new Lazy<bool>(() => typeof(SentakkiRuleset).Assembly.GetName().Name.EndsWith("-dev"));
+        private static readonly Lazy<bool> is_development_build
+            = new Lazy<bool>(() => typeof(SentakkiRuleset).Assembly.GetCustomAttributes(false).OfType<DebuggableAttribute>().Any(da => da.IsJITTrackingEnabled));
         public static bool IsDevelopmentBuild => is_development_build.Value;
 
         public override string Description => IsDevelopmentBuild ? "sentakki (Dev build)" : "sentakki";
         public override string PlayingVerb => "Washing laundry";
-        public override string ShortName => IsDevelopmentBuild ? "Sentakki-dev" : "Sentakki";
+        public override string ShortName => "Sentakki";
 
         public override ScoreProcessor CreateScoreProcessor() => new SentakkiScoreProcessor();
 

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
@@ -9,11 +9,14 @@ namespace osu.Game.Rulesets.Sentakki.UI
 {
     public class SentakkiSettingsSubsection : RulesetSettingsSubsection
     {
-        protected override LocalisableString Header => SentakkiRuleset.IsDevelopmentBuild ? "sentakki (Dev build)" : "sentakki";
+        private readonly Ruleset ruleset;
+
+        protected override LocalisableString Header => ruleset.Description;
 
         public SentakkiSettingsSubsection(Ruleset ruleset)
             : base(ruleset)
         {
+            this.ruleset = ruleset;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Sentakki/osu.Game.Rulesets.Sentakki.csproj
+++ b/osu.Game.Rulesets.Sentakki/osu.Game.Rulesets.Sentakki.csproj
@@ -11,4 +11,9 @@
     <ItemGroup>
         <PackageReference Include="ppy.osu.Game" Version="2021.916.0"/>
     </ItemGroup>
+
+    <!--Since we aren't changing the assembly name, we use the assembly title to indicate whether it is a dev build-->
+    <PropertyGroup Condition="!('$(Configuration)' == 'Release')">
+        <AssemblyTitle>sentakki for osu!lazer (dev build)</AssemblyTitle>
+    </PropertyGroup>
 </Project>

--- a/osu.Game.Rulesets.Sentakki/osu.Game.Rulesets.Sentakki.csproj
+++ b/osu.Game.Rulesets.Sentakki/osu.Game.Rulesets.Sentakki.csproj
@@ -1,28 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Label="Project">
-    <AssemblyTitle>sentakki for osu!lazer</AssemblyTitle>
-    <Description>TAP, HOLD and SLIDE to the beat.</Description>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <OutputType>Library</OutputType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <RootNamespace>osu.Game.Rulesets.Sentakki</RootNamespace>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Development' ">
-    <Optimize>true</Optimize>
-  </PropertyGroup>
-  <Choose>
-    <When Condition=" '$(Configuration)' == 'Release' ">
-      <PropertyGroup>
+    <PropertyGroup Label="Project">
+        <AssemblyTitle>sentakki for osu!lazer</AssemblyTitle>
+        <Description>TAP, HOLD and SLIDE to the beat.</Description>
+        <TargetFramework>netstandard2.1</TargetFramework>
+        <OutputType>Library</OutputType>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <RootNamespace>osu.Game.Rulesets.Sentakki</RootNamespace>
         <AssemblyName>osu.Game.Rulesets.Sentakki</AssemblyName>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <AssemblyName>osu.Game.Rulesets.Sentakki-dev</AssemblyName>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2021.916.0"/>
-  </ItemGroup>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="ppy.osu.Game" Version="2021.916.0"/>
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
While it was nice and convenient to run the release and dev builds side by side in osu, it was causing problems elsewhere, such as shortname problems, and debug and dynComp incompatibilities(multiple assemblies with same object). It was essentially trading one convenience for the loss of others.

This shouldn't affect end-users much, as ideally they'd only run release builds. 
<sub>Big RIP for those who intentionally download dev builds just to fill the ruleset bar</sub> 

Build artifacts will instead use the Debug builds.