### PR TITLE
Avoid drawing/updating visualisation when it is not really visible

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
@@ -137,9 +137,10 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             timeDelta += Math.Abs(Time.Elapsed);
             if (timeDelta >= time_between_updates)
             {
+                timeDelta %= time_between_updates;
+
                 if (!updateAmplitudes() && !ShouldDraw)
                     return;
-                timeDelta %= time_between_updates;
             }
 
             float decayFactor = Math.Abs((float)Time.Elapsed) * decay_per_milisecond;

--- a/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
@@ -67,7 +67,6 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
         private IShader shader;
         private readonly Texture texture;
 
-
         public PlayfieldVisualisation()
         {
             FillAspectRatio = 1;
@@ -104,13 +103,13 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
         }
 
         // Returns true if amplitude have been updated
-        private bool updateAmplitudes()
+        private void updateAmplitudes()
         {
             var track = beatmap.Value.TrackLoaded ? beatmap.Value.Track : null;
             var effect = beatmap.Value.BeatmapLoaded ? beatmap.Value.Beatmap?.ControlPointInfo.EffectPointAt(track?.CurrentTime ?? Time.Current) : null;
 
             if (!effect?.KiaiMode ?? false)
-                return false;
+                return;
 
             ReadOnlySpan<float> temporalAmplitudes = (track?.CurrentAmplitudes ?? ChannelAmplitudes.Empty).FrequencyAmplitudes.Span;
 
@@ -123,7 +122,8 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
 
             indexOffset = (indexOffset + index_change) % bars_per_visualiser;
 
-            return true;
+            // It's kiai time, turn on the visualisation
+            ShouldDraw = true;
         }
 
         private double timeDelta;
@@ -138,10 +138,12 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             if (timeDelta >= time_between_updates)
             {
                 timeDelta %= time_between_updates;
-
-                if (!updateAmplitudes() && !ShouldDraw)
-                    return;
+                updateAmplitudes();
             }
+
+            // We don't have to update further if we don't need to draw
+            if (!ShouldDraw)
+                return;
 
             float decayFactor = Math.Abs((float)Time.Elapsed) * decay_per_milisecond;
             ShouldDraw = false;
@@ -157,6 +159,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                     ShouldDraw = true;
             }
 
+            // Don't invalidate the draw node if we don't plan to draw
             if (!ShouldDraw)
                 return;
 

--- a/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/PlayfieldVisualization.cs
@@ -161,7 +161,6 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                 return;
 
             Invalidate(Invalidation.DrawNode);
-            Console.WriteLine("Vis node fully invalidated");
         }
 
         protected override DrawNode CreateDrawNode() => new VisualisationDrawNode(this);
@@ -252,7 +251,6 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                 }
 
                 shader.Unbind();
-                Console.WriteLine("Vis draw occured");
             }
 
             protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Contrary to Tau's version of the playfield visualisation, sentakki doesn't FadeOut/FadeIn its visualisation based on the current effect point's kiai flag, and instead allows the visualisation to update normally, with the exception that `updateAmplitudes()` will early return when not in kiai. This allows the visualisation bars to slowly shorten back to 0 when not in kiai, instead of fading out before that point. 

However, since sentakki's visualisation never has an alpha of 0, it is considered present, which means a full update and draw routine takes place every frame. 

To prevent that, a `ShouldDraw` field is used to determine whether updates/draws should occur. This field will be set to true as long as all the bars have a length > 0. As long as it is false, draws will never happen, and updates will early return.