### PR TITLE
Share touch object explosions with laned objects

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -6,7 +6,6 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
-using osu.Game.Rulesets.Sentakki.UI.Components;
 using osuTK;
 using osuTK.Graphics;
 
@@ -25,8 +24,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         // Similar to IsHovered for mouse, this tracks whether a pointer (touch or mouse) is interacting with this drawable
         // Interaction == (IsHovered && ActionPressed) || (OnTouch && TouchPointerInBounds)
         public bool[] PointInteractionState = new bool[11];
-
-        private HitExplosion explosion;
         public TouchBody TouchBody;
 
         private SentakkiInputManager sentakkiActionInputManager;
@@ -46,7 +43,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             Anchor = Anchor.Centre;
             AddRangeInternal(new Drawable[]{
                 TouchBody = new TouchBody(),
-                explosion = new HitExplosion()
             });
 
             trackedKeys.BindValueChanged(x =>
@@ -56,11 +52,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
                 UpdateResult(true);
             });
-
-            AccentColour.BindValueChanged(c =>
-            {
-                explosion.Colour = c.NewValue;
-            }, true);
         }
 
         protected override void OnApply()
@@ -127,7 +118,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             switch (state)
             {
                 case ArmedState.Hit:
-                    explosion.Explode();
                     TouchBody.FadeOut();
                     this.Delay(time_fade_hit).Expire();
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHoldBody.cs
@@ -3,7 +3,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Sentakki.UI.Components;
 using osuTK;
 using osuTK.Graphics;
 
@@ -13,8 +12,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
     {
         public readonly TouchHoldProgressPiece ProgressPiece;
         private readonly TouchHoldCentrePiece centrePiece;
-
-        private readonly HitExplosion explosion;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => centrePiece.ReceivePositionalInputAt(screenSpacePos);
 
@@ -26,9 +23,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             InternalChildren = new Drawable[]{
                 ProgressPiece = new TouchHoldProgressPiece(),
                 centrePiece = new TouchHoldCentrePiece(),
-                explosion = new HitExplosion(){
-                    Size = new Vector2(110)
-                },
             };
         }
 
@@ -37,12 +31,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         [BackgroundDependencyLoader]
         private void load(DrawableHitObject drawableObject)
         {
-            accentColour.BindTo(drawableObject.AccentColour);
-            accentColour.BindValueChanged(colour =>
-            {
-                explosion.Colour = colour.NewValue;
-            }, true);
-
             drawableObject.ApplyCustomUpdateState += updateState;
         }
 
@@ -53,9 +41,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                 switch (state)
                 {
                     case ArmedState.Hit:
-                        explosion.Explode();
-
-                        //after the flash, we can hide some elements that were behind it
                         ProgressPiece.FadeOut();
                         centrePiece.FadeOut();
                         break;

--- a/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
@@ -5,6 +5,7 @@ using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Transforms;
 using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 using osuTK;
 using osuTK.Graphics;
 
@@ -16,11 +17,14 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
 
         private readonly CircularContainer circle;
 
+        private const float default_explosion_size = 75;
+        private const float touch_hold_explosion_size = 110;
+
         public HitExplosion()
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
-            Size = new Vector2(75);
+            Size = new Vector2(default_explosion_size);
             Colour = Color4.Cyan;
             Alpha = 0;
             InternalChildren = new Drawable[]{
@@ -38,8 +42,10 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                     }
                 },
             };
+
             borderRatio.BindValueChanged(_ => setBorderThiccness(), true);
         }
+
         private void setBorderThiccness()
         {
             circle.BorderThickness = Size.X / 2 * borderRatio.Value;
@@ -47,10 +53,27 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
 
         private readonly BindableFloat borderRatio = new BindableFloat(1);
 
-        public void Apply(SentakkiLanedHitObject lanedHitObject)
+        public void Apply(DrawableSentakkiHitObject drawableSentakkiHitObject)
         {
-            Position = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, lanedHitObject.Lane);
-            Colour = lanedHitObject.NoteColour;
+            Colour = drawableSentakkiHitObject.AccentColour.Value;
+            switch (drawableSentakkiHitObject.HitObject)
+            {
+                case SentakkiLanedHitObject lanedObject:
+                    Position = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, lanedObject.Lane);
+                    Size = new Vector2(default_explosion_size);
+                    break;
+
+                case Touch touchObject:
+                    Position = touchObject.Position;
+                    Size = new Vector2(default_explosion_size);
+                    break;
+
+                case TouchHold _:
+                default:
+                    Position = Vector2.Zero;
+                    Size = new Vector2(touch_hold_explosion_size);
+                    break;
+            }
         }
 
         protected override void PrepareForUse()

--- a/osu.Game.Rulesets.Sentakki/UI/LanedPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/LanedPlayfield.cs
@@ -3,13 +3,10 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
-using osu.Game.Rulesets.Sentakki.UI.Components;
 using osu.Game.Rulesets.Sentakki.UI.Components.HitObjectLine;
 using osu.Game.Rulesets.UI;
 
@@ -26,10 +23,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
         [Cached]
         private readonly DrawablePool<SlideVisual.SlideChevron> chevronPool;
-
-        private readonly DrawablePool<HitExplosion> explosionPool;
-
-        private readonly Container<HitExplosion> explosionLayer;
 
         public readonly Container LanedHitObjectArea;
 
@@ -52,10 +45,8 @@ namespace osu.Game.Rulesets.Sentakki.UI
             }
 
             AddRangeInternal(new Drawable[]{
-                explosionPool = new DrawablePool<HitExplosion>(8),
                 chevronPool = new DrawablePool<SlideVisual.SlideChevron>(100),
                 HitObjectLineRenderer = new LineRenderer(),
-                explosionLayer = new Container<HitExplosion>() { RelativeSizeAxes = Axes.Both },
                 slideBodyProxyContainer = new SortedDrawableProxyContainer(),
                 LanedHitObjectArea = new Container
                 {
@@ -63,8 +54,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
                     Child = lanedNoteProxyContainer = new SortedDrawableProxyContainer(),
                 }
             });
-
-            NewResult += onNewResult;
         }
 
         public override void Add(HitObject h)
@@ -106,19 +95,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
                     lanedNoteProxyContainer.Add(h.NoteBody.CreateProxy(), h);
                     break;
             }
-        }
-
-        private void onNewResult(DrawableHitObject judgedObject, JudgementResult result)
-        {
-            if (!judgedObject.DisplayResult || !DisplayJudgements.Value || !(judgedObject is DrawableSentakkiLanedHitObject laned))
-                return;
-
-            if (!result.IsHit) return;
-
-            if (judgedObject is DrawableSlideBody) return;
-
-            var explosion = explosionPool.Get(e => e.Apply(laned.HitObject));
-            explosionLayer.Add(explosion);
         }
     }
 }


### PR DESCRIPTION
Previously, touch objects had their explosions bound to their drawable representations, while the laned objects have their hitExplosions handled by the playfield. 

I've extracted the hitExplosions out of the touch objects, and let SentakkiPlayfield handle them as well as the hitExplosions for laned objects.