### PR TITLE
Fix ResumeOverlay countdown intervals not accounting for DT

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiResumeOverlay.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiResumeOverlay.cs
@@ -22,6 +22,9 @@ namespace osu.Game.Rulesets.Sentakki.UI
         [Resolved]
         private IBindable<WorkingBeatmap> beatmap { get; set; }
 
+        [Resolved]
+        private DrawableSentakkiRuleset drawableSentakkiRuleset { get; set; }
+
         private readonly string[] supporter_list = new string[]{
             "Ayato_K",
             "Bosch",
@@ -128,7 +131,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
             var currentTimingPoint = beatmap.Value.Beatmap.ControlPointInfo.TimingPointAt(beatmap.Value.Track.CurrentTime);
             barLength = currentTimingPoint.TimeSignature.Numerator;
-            beatlength = currentTimingPoint.BeatLength;
+            beatlength = currentTimingPoint.BeatLength / drawableSentakkiRuleset.GameplaySpeed;
 
             // Reset the countdown, plus a second for preparation
             remainingTime = (barLength * beatlength) + 1000;

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiResumeOverlay.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiResumeOverlay.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
         [Resolved]
         private IBindable<WorkingBeatmap> beatmap { get; set; }
 
-        [Resolved]
+        [Resolved(canBeNull: true)]
         private DrawableSentakkiRuleset drawableSentakkiRuleset { get; set; }
 
         private readonly string[] supporter_list = new string[]{
@@ -131,7 +131,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
             var currentTimingPoint = beatmap.Value.Beatmap.ControlPointInfo.TimingPointAt(beatmap.Value.Track.CurrentTime);
             barLength = currentTimingPoint.TimeSignature.Numerator;
-            beatlength = currentTimingPoint.BeatLength / drawableSentakkiRuleset.GameplaySpeed;
+            beatlength = currentTimingPoint.BeatLength / (drawableSentakkiRuleset?.GameplaySpeed ?? 1);
 
             // Reset the countdown, plus a second for preparation
             remainingTime = (barLength * beatlength) + 1000;


### PR DESCRIPTION
The countdown interval in ResumeOverlay isn't affected by the gameplay clock, causing a mismatch between the countdown and the actual BPM.

The beatlength is now divided by the `GameplaySpeed` defined in `DrawableSentakkiRuleset` in the same way that hitobject animations do. It isn't 1:1, but it is better than the current behavior.