### PR TITLE
Add "Classic" mod

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
     {
         // Conversion flags
         public ConversionExperiments EnabledExperiments;
+        public bool ClassicMode;
 
         public static readonly List<Vector2> VALID_TOUCH_POSITIONS;
         static SentakkiBeatmapConverter()
@@ -93,7 +94,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             bool special = original.Samples.Any(s => s.Name == HitSampleInfo.HIT_WHISTLE);
             bool twin = original.Samples.Any(s => s.Name == HitSampleInfo.HIT_CLAP);
 
-            if (!breakNote && special)
+            if (!breakNote && !ClassicMode && special)
                 yield return createTouchNote(original);
             else
             {
@@ -109,7 +110,11 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             IHasDuration spinner = (IHasDuration)original;
             if (spinner.Duration >= 100)
             {
-                yield return createTouchHold(original);
+                if (!ClassicMode)
+                    yield return createTouchHold(original);
+                else
+                    foreach (var ho in convertSlider(original))
+                        yield return ho;
             }
             else
             {

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModClassic.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModClassic.cs
@@ -1,0 +1,19 @@
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Sentakki.Beatmaps;
+
+namespace osu.Game.Rulesets.Sentakki.Mods
+{
+    public class SentakkiModClassic : ModClassic, IApplicableToBeatmapConverter
+    {
+        public override string Description => "Remove gameplay elements introduced in maimaiDX, for the Finale purists.";
+
+        public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)
+        {
+            ((SentakkiBeatmapConverter)beatmapConverter).ClassicMode = true;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModPerfect.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModPerfect.cs
@@ -11,12 +11,13 @@ namespace osu.Game.Rulesets.Sentakki.Mods
             => !(result.Judgement is IgnoreJudgement)
                && result.Type < result.Judgement.MaxResult;
 
-        public override Type[] IncompatibleMods => new Type[4]
+        public override Type[] IncompatibleMods => new Type[5]
         {
                 typeof(ModNoFail),
                 typeof(ModRelax),
                 typeof(ModAutoplay),
-                typeof(SentakkiModChallenge)
+                typeof(SentakkiModChallenge),
+                typeof(ModSuddenDeath)
         };
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModSuddenDeath.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModSuddenDeath.cs
@@ -5,12 +5,13 @@ namespace osu.Game.Rulesets.Sentakki.Mods
 {
     public class SentakkiModSuddenDeath : ModSuddenDeath
     {
-        public override Type[] IncompatibleMods => new Type[4]
+        public override Type[] IncompatibleMods => new Type[5]
         {
             typeof(ModNoFail),
             typeof(ModRelax),
             typeof(ModAutoplay),
-            typeof(SentakkiModChallenge)
+            typeof(SentakkiModChallenge),
+            typeof(ModPerfect)
         };
     }
 }

--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -95,6 +95,7 @@ namespace osu.Game.Rulesets.Sentakki
                 case ModType.Conversion:
                     return new Mod[]{
                         new SentakkiModExperimental(),
+                        new SentakkiModClassic(),
                         new SentakkiModMirror(),
                     };
 


### PR DESCRIPTION
Classic mod allows players to remove gameplay features introduced in maimaiDX, like Touch notes and TouchHolds.

This doesn't change anything else during gameplay.  For example, Holds will still behave like how they do in DX, rather than pre-DX.