### PR TITLE
Change how break sample is loaded

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiLanedHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiLanedHitObject.cs
@@ -1,10 +1,5 @@
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using osu.Framework.Bindables;
-using osu.Game.Audio;
-using osu.Game.Beatmaps;
-using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Rulesets.Sentakki.Objects
@@ -12,18 +7,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
     public abstract class SentakkiLanedHitObject : SentakkiHitObject
     {
         protected virtual bool NeedBreakSample => true;
-
-        private List<HitSampleInfo> originalSamples { get; set; } = new List<HitSampleInfo>();
-
-        public new IList<HitSampleInfo> Samples
-        {
-            get => originalSamples;
-            set
-            {
-                originalSamples.Clear();
-                originalSamples.AddRange(value);
-            }
-        }
 
         public readonly BindableBool BreakBindable = new BindableBool();
 
@@ -45,18 +28,17 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             base.CreateNestedHitObjects(cancellationToken);
 
             if (Break)
+            {
                 for (int i = 0; i < 4; ++i)
-                    AddNested(new ScorePaddingObject() { StartTime = this.GetEndTime() });
-        }
+                {
+                    var nestedObject = new ScorePaddingObject() { StartTime = this.GetEndTime() };
 
-        protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, IBeatmapDifficultyInfo difficulty)
-        {
-            base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
+                    if (i == 0 && NeedBreakSample)
+                        nestedObject.Samples.Add(new SentakkiHitSampleInfo("Break"));
 
-            // Add break sample
-            var sampleList = originalSamples.ToList();
-            if (Break && NeedBreakSample) sampleList.Add(new SentakkiHitSampleInfo("Break"));
-            base.Samples = sampleList;
+                    AddNested(nestedObject);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The previous way of adding the break sample utilizes member hiding in `SentakkiLanedHitObject`, and the assumption that samples will only be adjusted by sentakki code (which always uses the specific type). This caused problems with the editor placement tools/selection handlers, which always uses the generic HitObject interface to read/modify samples...  The member hiding hack is now removed.

I could move the break sample to the `DrawableHitObject.LoadSample`, instead of turning it into a sample within the `ScorePaddingObject`, but that means that the volume of break notes will need to be manually set to be in line with regular hit samples, and playback needs to be manually performed on hit. I'd rather use the provided flow as that performs everything I need already, with less potential for breaking changes to affect it.