### PR TITLE
Fix dedicated lane button overriding lane receptor

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/Lane.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Lane.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
         private void handleKeyPress(ValueChangedEvent<int> keys)
         {
-            if (keys.NewValue > keys.OldValue || keys.NewValue == 0)
+            if (keys.NewValue < keys.OldValue)
                 SentakkiActionInputManager.TriggerReleased(SentakkiAction.Key1 + LaneNumber);
 
             if (keys.NewValue > keys.OldValue)

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiCursorContainer.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiCursorContainer.cs
@@ -2,7 +2,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
-using osu.Framework.Input.Events;
 using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Sentakki.UI
@@ -25,20 +24,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
             if (cursorSprite != null)
                 cursorSprite.Texture = cursorTexture;
-        }
-
-        protected override bool Handle(UIEvent e)
-        {
-            switch (e)
-            {
-                case MouseEvent _:
-                    Show();
-                    break;
-                case TouchEvent _:
-                    Hide();
-                    break;
-            }
-            return base.Handle(e);
         }
     }
 }


### PR DESCRIPTION
This makes it so that multiple input sources can trigger a press event, while only the last source to be release will trigger the release event. 

This allows playstyles that use multiple input methods to work seamlessly together as a typical maimai player would expect. (using the physical and touch inputs at the same time to perform trills on the same lane)