### PR TITLE
Add more checkpoints to SlideFans

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
@@ -28,13 +28,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         // All hits can only be done after the parent StartTime
         public bool IsHittable => Time.Current > ParentHitObject.HitObject.StartTime && isPreviousNodeHit();
 
-        private bool isPreviousNodeHit()
-        {
-            if (HitObject.StrictCompletionOrder)
-                return ThisIndex < 1 || parentSlide.SlideCheckpoints[ThisIndex - 1].IsHit;
-
-            return ThisIndex < 2 || parentSlide.SlideCheckpoints[ThisIndex - 2].IsHit;
-        }
+        private bool isPreviousNodeHit() => ThisIndex < 2 || parentSlide.SlideCheckpoints[ThisIndex - 2].IsHit;
 
         private Container<DrawableSlideCheckpointNode> nodes;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
@@ -44,11 +44,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
         protected virtual void CreateSlideCheckpoints()
         {
-            var distance = SlideInfo.SlidePath.TotalDistance;
-            var nodeCount = (int)Math.Floor(distance / 100);
+            double distance = SlideInfo.SlidePath.TotalDistance;
+            int nodeCount = (int)Math.Floor(distance / 100);
             for (int i = 0; i < nodeCount; i++)
             {
-                var progress = (double)(i + 1) / nodeCount;
+                double progress = (double)(i + 1) / nodeCount;
                 SlideCheckpoint checkpoint = new SlideCheckpoint()
                 {
                     Progress = (float)progress,

--- a/osu.Game.Rulesets.Sentakki/Objects/SlideCheckpoint.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlideCheckpoint.cs
@@ -8,11 +8,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 {
     public class SlideCheckpoint : SentakkiHitObject
     {
-        public SlideCheckpoint(bool strictMode = false)
-        {
-            StrictCompletionOrder = strictMode;
-        }
-
         // Used to update slides visuals
         public float Progress { get; set; }
 
@@ -20,10 +15,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         public List<Vector2> NodePositions { get; set; } = new List<Vector2>();
 
         public int NodesToPass { get; set; } = 1;
-
-        // If this is true, then all previous checkpoints must be completed to hit this one
-        // This is in contrast to non-strict, where you can hit it if the n-2 checkpoint is hit
-        public bool StrictCompletionOrder { get; }
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
         {

--- a/osu.Game.Rulesets.Sentakki/Objects/SlideFan.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlideFan.cs
@@ -9,10 +9,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         {
             // Add body nodes (should be two major sets)
             Vector2 originpoint = new Vector2(0, -SentakkiPlayfield.INTERSECTDISTANCE);
-            for (int i = 1; i < 3; ++i)
+            for (int i = 1; i < 5; ++i)
             {
-                float progress = 0.5f * i;
-                SlideCheckpoint checkpoint = new SlideCheckpoint(true)
+                float progress = 0.25f * i;
+                SlideCheckpoint checkpoint = new SlideCheckpoint()
                 {
                     Progress = progress,
                     StartTime = StartTime + ShootDelay + ((Duration - ShootDelay) * progress),


### PR DESCRIPTION
This is mainly to make the slide disappear less jarringly, with `SlideFan`s being composed by more, but smaller segments.

`SlideCheckpoint.StrictCompletionOrder` has been removed, since with double the checkpoints, `SlideFan`s can use the same logic to achieve roughly the same intention as before this change.