### PR TITLE
Prioritize twin colors on `HitObjectLine`s

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/Components/HitObjectLine/LineLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/HitObjectLine/LineLifetimeEntry.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components.HitObjectLine
                 bool allBreaks = HitObjects.All(h => h.Break);
 
                 Type = getLineTypeForDistance(Math.Abs(delta));
-                Colour = allBreaks ? Color4.OrangeRed : Color4.Gold;
+                Colour = Color4.Gold;
                 Rotation = anchor.Lane.GetRotationForLane() + (delta * 22.5f);
             }
 


### PR DESCRIPTION
Resolves #375.

`HitObjectLine`s used to prioritize colours in the same way as HitObjects, being `Break -> Twin -> Normal`.

This changes it so that the priority is now `Twin -> Break -> Normal`. This is in fact the same priority that maimai(DX/Finale) uses as well, players coming from those games will probably be pleased.