### PR TITLE
Adjust twin slide body colouring rules

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapProcessor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Sentakki.Objects;
@@ -16,32 +17,40 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         {
             base.PostProcess();
 
+            Color4 twinColor = Color4.Gold;
+            Color4 breakColor = Color4.OrangeRed;
+
             var hitObjectGroups = Beatmap.HitObjects.GroupBy(h => h.StartTime).ToList();
 
             foreach (var group in hitObjectGroups)
             {
                 bool isTwin = group.Count() > 1; // This determines whether the twin colour should be used
 
+                List<SlideBody> slideBodiesInGroup = new List<SlideBody>();
+
                 foreach (SentakkiHitObject hitObject in group)
                 {
                     Color4 noteColor = hitObject.DefaultNoteColour;
 
                     if (hitObject is SentakkiLanedHitObject laned && laned.Break)
-                        noteColor = Color4.OrangeRed;
+                        noteColor = breakColor;
                     else if (isTwin)
-                        noteColor = Color4.Gold;
+                        noteColor = twinColor;
 
                     // SlideTaps follow the typical coloring rules, while SlideBodies follow a different set of rules
                     if (hitObject is Slide slide)
                     {
                         slide.SlideTap.NoteColour = noteColor;
-                        if (group.Any(h => h is Slide && h != slide))
-                            foreach (var sBody in slide.SlideBodies)
-                                sBody.NoteColour = Color4.Gold;
+                        slideBodiesInGroup.AddRange(slide.SlideBodies);
                     }
                     else
                         hitObject.NoteColour = noteColor;
                 }
+
+                // Color slide bodies if more than one slide body exists at the same time
+                if (slideBodiesInGroup.Count > 1)
+                    foreach (var slideBody in slideBodiesInGroup)
+                        slideBody.NoteColour = twinColor;
             }
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapProcessor.cs
@@ -33,21 +33,14 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 
                     // SlideTaps follow the typical coloring rules, while SlideBodies follow a different set of rules
                     if (hitObject is Slide slide)
+                    {
                         slide.SlideTap.NoteColour = noteColor;
+                        if (group.Any(h => h is Slide && h != slide))
+                            foreach (var sBody in slide.SlideBodies)
+                                sBody.NoteColour = Color4.Gold;
+                    }
                     else
                         hitObject.NoteColour = noteColor;
-                }
-
-                // Slide bodies can't be break coloured, but can use the twin colour
-                // However, the twin colour is only used if there exists another SlideBody with the same start and end time
-                var slideBodies = group.OfType<Slide>().SelectMany(s => s.SlideBodies).GroupBy(sb => sb.EndTime).ToList();
-
-                foreach (var slideBodyGroup in slideBodies)
-                {
-                    bool isTwinSlide = slideBodyGroup.Count() > 1;
-
-                    foreach (var slideBody in slideBodyGroup)
-                        slideBody.NoteColour = isTwinSlide ? Color4.Gold : slideBody.DefaultNoteColour;
                 }
             }
         }

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapProcessor.cs
@@ -15,19 +15,39 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         public override void PostProcess()
         {
             base.PostProcess();
-            var hitObjectGroups = Beatmap.HitObjects.GroupBy(h => h.StartTime);
+
+            var hitObjectGroups = Beatmap.HitObjects.GroupBy(h => h.StartTime).ToList();
+
             foreach (var group in hitObjectGroups)
             {
                 bool isTwin = group.Count() > 1; // This determines whether the twin colour should be used
 
                 foreach (SentakkiHitObject hitObject in group)
                 {
+                    Color4 noteColor = hitObject.DefaultNoteColour;
+
                     if (hitObject is SentakkiLanedHitObject laned && laned.Break)
-                        hitObject.NoteColour = Color4.OrangeRed;
+                        noteColor = Color4.OrangeRed;
                     else if (isTwin)
-                        hitObject.NoteColour = Color4.Gold;
+                        noteColor = Color4.Gold;
+
+                    // SlideTaps follow the typical coloring rules, while SlideBodies follow a different set of rules
+                    if (hitObject is Slide slide)
+                        slide.SlideTap.NoteColour = noteColor;
                     else
-                        hitObject.NoteColour = hitObject.DefaultNoteColour;
+                        hitObject.NoteColour = noteColor;
+                }
+
+                // Slide bodies can't be break coloured, but can use the twin colour
+                // However, the twin colour is only used if there exists another SlideBody with the same start and end time
+                var slideBodies = group.OfType<Slide>().SelectMany(s => s.SlideBodies).GroupBy(sb => sb.EndTime).ToList();
+
+                foreach (var slideBodyGroup in slideBodies)
+                {
+                    bool isTwinSlide = slideBodyGroup.Count() > 1;
+
+                    foreach (var slideBody in slideBodyGroup)
+                        slideBody.NoteColour = isTwinSlide ? Color4.Gold : slideBody.DefaultNoteColour;
                 }
             }
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -102,14 +102,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             UpdateSlidePath();
             updatePathProgress();
             StarProgress = 0;
-
-            AccentColour.BindTo(ParentHitObject.AccentColour);
         }
 
         protected override void OnFree()
         {
             base.OnFree();
-            AccentColour.UnbindFrom(ParentHitObject.AccentColour);
             Slidepath.Free();
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideTap.cs
@@ -12,18 +12,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public DrawableSlideTap(SlideTap hitObject)
             : base(hitObject) { }
 
-        protected override void OnApply()
-        {
-            base.OnApply();
-            AccentColour.BindTo(ParentHitObject.AccentColour);
-        }
-
-        protected override void OnFree()
-        {
-            base.OnFree();
-            AccentColour.UnbindFrom(ParentHitObject.AccentColour);
-        }
-
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();

--- a/osu.Game.Rulesets.Sentakki/Objects/Slide.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Slide.cs
@@ -35,9 +35,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
         public List<SentakkiSlideInfo> SlideInfoList = new List<SentakkiSlideInfo>();
 
+        public SlideTap SlideTap { get; private set; }
+
+        public IList<SlideBody> SlideBodies { get; private set; }
+
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
         {
-            AddNested(new SlideTap
+            AddNested(SlideTap = new SlideTap
             {
                 LaneBindable = { BindTarget = LaneBindable },
                 StartTime = StartTime,
@@ -49,6 +53,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
         private void createSlideBodies()
         {
+            SlideBodies = new List<SlideBody>();
+
             foreach (var SlideInfo in SlideInfoList)
             {
                 SlideBody body;
@@ -56,6 +62,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                     AddNested(body = new SlideFan());
                 else
                     AddNested(body = new SlideBody());
+
+                SlideBodies.Add(body);
 
                 body.Lane = SlideInfo.SlidePath.EndLane + Lane;
                 body.StartTime = StartTime;


### PR DESCRIPTION
Previously, SlideBodies always inherited the note colour of the `Slide` object. This meant that SlideBodies can have the break colour, and the twin colour is applied on ANY other `HitObject` with the same start time as it, while not having the twin colour if there it is the only HitObject while having is multiple SlideBodies.

Now SlideBodies only get the twin colour applied to them iff another SlideBody exists at the same start time and won't use the Break colour since they aren't affected by Breaks anyways. SlideTaps retain the same colouring rule as regular Taps.