### PR TITLE
Alter beatmap conversion to allow variance in taps generated from repeats

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiPatternGenerator.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             // Lane difference determined by offset2, but will make sure offset2 is never 0.
             (twin)=>{
                 offset2 = offset2 == 0 ? 1 : offset2;
-                offset+=offset2;
+                offset+=offset2 * (twin ? 2: 1);
                 offset2= -offset2;
 
                 return offset;


### PR DESCRIPTION
This will mainly affect the "Twin notes" and "Twin slides" experiments.

With the above flags enabled, extra Tap notes may be generated alongside Holds and Slides if they don't have the requirements to become a twin. Previously, these extra taps are generated from osu Slider Repeats exclusively (unless the slider spams repeats). 

This behavior has been adjusted so that it doesn't always generate Taps for Sliders with repeats. And if it does do so, then it may choose to generate an extra Tap for SliderHeads and SliderTails (Each having a 50% chance, and the SliderTails is not considered is SliderHeads aren't).

https://user-images.githubusercontent.com/12001167/185747187-1c24f17e-4807-4c62-8c61-6d2f55c8d710.mp4

