### PR TITLE
Add localizable strings for statistics titles

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Localisation/SentakkiResumeOverlayStrings.cs
+++ b/osu.Game.Rulesets.Sentakki/Localisation/SentakkiResumeOverlayStrings.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Sentakki.Localisation
         public static LocalisableString GetReady => new TranslatableString(getKey(@"get_ready"), @"Get ready!");
 
         /// <summary>
-        /// "Get's go!"
+        /// "Let's go!"
         /// </summary>
         public static LocalisableString LetsGo => new TranslatableString(getKey(@"lets_go"), @"Let's go!");
 

--- a/osu.Game.Rulesets.Sentakki/Localisation/SentakkiStatisticsStrings.cs
+++ b/osu.Game.Rulesets.Sentakki/Localisation/SentakkiStatisticsStrings.cs
@@ -1,0 +1,21 @@
+using osu.Framework.Localisation;
+
+namespace osu.Game.Rulesets.Sentakki.Localisation
+{
+    public static class SentakkiStatisticsStrings
+    {
+        private const string prefix = @"osu.Game.Rulesets.Sentakki.Resources.Localisation.SentakkiStatisticsStrings";
+
+        /// <summary>
+        /// "Timing Distribution"
+        /// </summary>
+        public static LocalisableString TimingDistribution => new TranslatableString(getKey(@"timing_distribution"), @"Timing Distribution");
+
+        /// <summary>
+        /// "Judgement Chart"
+        /// </summary>
+        public static LocalisableString JudgementChart => new TranslatableString(getKey(@"judgement_chart"), @"Judgement Chart");
+
+        private static string getKey(string key) => $"{prefix}:{key}";
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Resources/Localisation/SentakkiStatisticsStrings.resx
+++ b/osu.Game.Rulesets.Sentakki/Resources/Localisation/SentakkiStatisticsStrings.resx
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+        <xsd:element name="root" msdata:IsDataSet="true">
+            <xsd:complexType>
+                <xsd:choice maxOccurs="unbounded">
+                    <xsd:element name="metadata">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                            </xsd:sequence>
+                            <xsd:attribute name="name" use="required" type="xsd:string"/>
+                            <xsd:attribute name="type" type="xsd:string"/>
+                            <xsd:attribute name="mimetype" type="xsd:string"/>
+                            <xsd:attribute ref="xml:space"/>
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="assembly">
+                        <xsd:complexType>
+                            <xsd:attribute name="alias" type="xsd:string"/>
+                            <xsd:attribute name="name" type="xsd:string"/>
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="data">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                            </xsd:sequence>
+                            <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
+                            <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
+                            <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
+                            <xsd:attribute ref="xml:space"/>
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="resheader">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                            </xsd:sequence>
+                            <xsd:attribute name="name" type="xsd:string" use="required"/>
+                        </xsd:complexType>
+                    </xsd:element>
+                </xsd:choice>
+            </xsd:complexType>
+        </xsd:element>
+    </xsd:schema>
+    <resheader name="resmimetype">
+        <value>text/microsoft-resx</value>
+    </resheader>
+    <resheader name="version">
+        <value>2.0</value>
+    </resheader>
+    <resheader name="reader">
+        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <resheader name="writer">
+        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <data name="timing_distribution" xml:space="preserve">
+        <value>Timing Distribution</value>
+    </data>
+    <data name="judgement_chart" xml:space="preserve">
+        <value>Judgement Chartsss</value>
+    </data>
+</root>

--- a/osu.Game.Rulesets.Sentakki/Resources/Localisation/SentakkiStatisticsStrings.resx
+++ b/osu.Game.Rulesets.Sentakki/Resources/Localisation/SentakkiStatisticsStrings.resx
@@ -62,6 +62,6 @@
         <value>Timing Distribution</value>
     </data>
     <data name="judgement_chart" xml:space="preserve">
-        <value>Judgement Chartsss</value>
+        <value>Judgement Chart</value>
     </data>
 </root>

--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -23,6 +23,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.Beatmaps;
 using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Difficulty;
+using osu.Game.Rulesets.Sentakki.Localisation;
 using osu.Game.Rulesets.Sentakki.Mods;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Replays;
@@ -142,7 +143,7 @@ namespace osu.Game.Rulesets.Sentakki
             {
                 Columns = new[]
                 {
-                    new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(score.HitEvents)
+                    new StatisticItem(SentakkiStatisticsStrings.TimingDistribution, () => new HitEventTimingDistributionGraph(score.HitEvents)
                     {
                         RelativeSizeAxes = Axes.X,
                         Height = 250
@@ -153,7 +154,7 @@ namespace osu.Game.Rulesets.Sentakki
             {
                 Columns = new[]
                 {
-                    new StatisticItem("Judgement Distribution", ()=>new JudgementChart(score.HitEvents.Where(e=>e.HitObject is SentakkiHitObject).ToList())
+                    new StatisticItem(SentakkiStatisticsStrings.JudgementChart, () => new JudgementChart(score.HitEvents.Where(e=>e.HitObject is SentakkiHitObject).ToList())
                     {
                         RelativeSizeAxes = Axes.X,
                         Size = new Vector2(1, 250)
@@ -164,7 +165,7 @@ namespace osu.Game.Rulesets.Sentakki
             {
                 Columns = new[]
                 {
-                    new StatisticItem(string.Empty, ()=>new SimpleStatisticTable(3, new SimpleStatisticItem[]
+                    new StatisticItem(string.Empty, () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
                     {
                         new UnstableRate(score.HitEvents)
                     }), true)


### PR DESCRIPTION
Only two strings this time.

"Unstable Rate` is not included as that is a default osu component, with the title provided by the component itself.
^^ On that same note, "Timing Distribution" should also be handled osu-side, but for now this is fine.