### PR TITLE
Implement support for slide chains

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneAllSlides.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneAllSlides.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
         protected override Ruleset CreateRuleset() => new SentakkiRuleset();
 
         private int id;
-        private bool mirrored;
+
         private readonly SlideVisual slide;
         private readonly Container nodes;
 
@@ -44,12 +44,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
                 RefreshSlide();
             });
 
-            AddToggleStep("Mirrored", b =>
-            {
-                mirrored = b;
-                RefreshSlide();
-            });
-
             Add(nodes = new Container()
             {
                 Anchor = Anchor.Centre,
@@ -57,11 +51,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
             });
         }
 
-        protected SentakkiSlidePath CreatePattern()
-        {
-            var param = SlidePaths.VALIDPATHS[id];
-            SlidePaths.CreateSlidePath(param.)
-        };
+        protected SentakkiSlidePath CreatePattern() => SlidePaths.CreateSlidePath(SlidePaths.VALIDPATHS[id].parameters);
 
         protected override void LoadComplete()
         {

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneAllSlides.csa
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneAllSlides.csa
@@ -57,7 +57,11 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
             });
         }
 
-        protected SentakkiSlidePath CreatePattern() => SlidePaths.GetSlidePath(id, mirrored);
+        protected SentakkiSlidePath CreatePattern()
+        {
+            var param = SlidePaths.VALIDPATHS[id];
+            SlidePaths.CreateSlidePath(param.)
+        };
 
         protected override void LoadComplete()
         {

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneCircleSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneCircleSlide.cs
@@ -14,6 +14,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
                 RefreshSlide();
             });
         }
-        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateCirclePattern(EndPath, clockwise ? RotationDirection.Clockwise : RotationDirection.Counterclockwise);
+        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateCirclePattern(StartPath, EndPath, clockwise ? RotationDirection.Clockwise : RotationDirection.Counterclockwise);
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneCircleSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneCircleSlide.cs
@@ -1,19 +1,9 @@
-using osu.Framework.Graphics;
 using osu.Game.Rulesets.Sentakki.Objects;
 
 namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
 {
     public class TestSceneCircleSlide : TestSceneSlide
     {
-        private bool clockwise;
-        public TestSceneCircleSlide()
-        {
-            AddToggleStep("Clockwise", b =>
-            {
-                clockwise = b;
-                RefreshSlide();
-            });
-        }
-        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateCirclePattern(StartPath, EndPath, clockwise ? RotationDirection.Clockwise : RotationDirection.Counterclockwise);
+        protected override SlidePaths.PathShapes PathShape => SlidePaths.PathShapes.Circle;
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneCupSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneCupSlide.cs
@@ -15,6 +15,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
             });
         }
 
-        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateCupPattern(EndPath, mirrored);
+        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateCupPattern(StartPath, EndPath, mirrored);
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneCupSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneCupSlide.cs
@@ -4,17 +4,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
 {
     public class TestSceneCupSlide : TestSceneSlide
     {
-        private bool mirrored;
-
-        public TestSceneCupSlide()
-        {
-            AddToggleStep("Mirrored", b =>
-            {
-                mirrored = b;
-                RefreshSlide();
-            });
-        }
-
-        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateCupPattern(StartPath, EndPath, mirrored);
+        protected override SlidePaths.PathShapes PathShape => SlidePaths.PathShapes.Cup;
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneLSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneLSlide.cs
@@ -15,6 +15,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
             });
         }
 
-        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateLPattern(EndPath, mirrored);
+        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateLPattern(StartPath, EndPath, mirrored);
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneLSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneLSlide.cs
@@ -4,17 +4,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
 {
     public class TestSceneLSlide : TestSceneSlide
     {
-        private bool mirrored;
-
-        public TestSceneLSlide()
-        {
-            AddToggleStep("Mirrored", b =>
-            {
-                mirrored = b;
-                RefreshSlide();
-            });
-        }
-
-        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateLPattern(StartPath, EndPath, mirrored);
+        protected override SlidePaths.PathShapes PathShape => SlidePaths.PathShapes.L;
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneSlide.cs
@@ -40,11 +40,12 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
             });
             Add(slide = new SlideVisual());
 
-            AddSliderStep("Path offset", 0, 7, 0, p =>
+            AddSliderStep("Start lane", 0, 7, 0, p =>
             {
-                slide.Rotation = 45 * p;
+                StartPath = p;
+                RefreshSlide();
             });
-            AddSliderStep("End Path", 0, 7, 4, p =>
+            AddSliderStep("End lane", 0, 7, 4, p =>
             {
                 EndPath = p;
                 RefreshSlide();

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneSlide.cs
@@ -66,7 +66,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
                 RefreshSlide();
             });
 
-
             AddStep("Perform entry animation", () => slide.PerformEntryAnimation(1000));
             AddWaitStep("Wait for transforms", 5);
 

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneSlide.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides;
+using osu.Game.Rulesets.Sentakki.Objects.SlidePath;
 using osu.Game.Rulesets.Sentakki.UI;
 using osu.Game.Rulesets.Sentakki.UI.Components;
 using osu.Game.Tests.Visual;
@@ -20,8 +21,12 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
     {
         protected override Ruleset CreateRuleset() => new SentakkiRuleset();
 
-        protected int StartPath;
-        protected int EndPath;
+        private int startPath;
+        private int endPath;
+
+        private bool mirrored;
+
+        protected abstract SlidePaths.PathShapes PathShape { get; }
 
         private readonly SlideVisual slide;
         private readonly Container nodes;
@@ -42,18 +47,25 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
 
             AddSliderStep("Start lane", 0, 7, 0, p =>
             {
-                StartPath = p;
+                startPath = p;
                 RefreshSlide();
             });
             AddSliderStep("End lane", 0, 7, 4, p =>
             {
-                EndPath = p;
+                endPath = p;
                 RefreshSlide();
             });
             AddSliderStep("Progress", 0.0f, 1.0f, 0.0f, p =>
             {
                 slide.Progress = p;
             });
+
+            AddToggleStep("Mirrored", b =>
+            {
+                mirrored = b;
+                RefreshSlide();
+            });
+
 
             AddStep("Perform entry animation", () => slide.PerformEntryAnimation(1000));
             AddWaitStep("Wait for transforms", 5);
@@ -68,7 +80,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
             });
         }
 
-        protected abstract SentakkiSlidePath CreatePattern();
+        protected SentakkiSlidePath CreatePattern() => SlidePaths.CreateSlidePath(startPath, new PathParameters(PathShape, endPath, mirrored));
 
         protected override void LoadComplete()
         {

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneStraightSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneStraightSlide.cs
@@ -4,6 +4,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
 {
     public class TestSceneStraightSlide : TestSceneSlide
     {
-        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateStraightPattern(StartPath, EndPath);
+        protected override SlidePaths.PathShapes PathShape => SlidePaths.PathShapes.Straight;
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneStraightSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneStraightSlide.cs
@@ -4,6 +4,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
 {
     public class TestSceneStraightSlide : TestSceneSlide
     {
-        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateStraightPattern(EndPath);
+        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateStraightPattern(StartPath, EndPath);
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneThunderSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneThunderSlide.cs
@@ -14,6 +14,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
                 RefreshSlide();
             });
         }
-        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateThunderPattern(mirrored);
+        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateThunderPattern(StartPath, mirrored);
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneThunderSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneThunderSlide.cs
@@ -4,16 +4,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
 {
     public class TestSceneThunderSlide : TestSceneSlide
     {
-        private bool mirrored;
-
-        public TestSceneThunderSlide()
-        {
-            AddToggleStep("Mirrored", b =>
-            {
-                mirrored = b;
-                RefreshSlide();
-            });
-        }
-        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateThunderPattern(StartPath, mirrored);
+        protected override SlidePaths.PathShapes PathShape => SlidePaths.PathShapes.Thunder;
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneUSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneUSlide.cs
@@ -15,6 +15,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
             });
         }
 
-        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateUPattern(EndPath, reversed);
+        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateUPattern(StartPath, EndPath, reversed);
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneUSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneUSlide.cs
@@ -4,17 +4,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
 {
     public class TestSceneUSlide : TestSceneSlide
     {
-        private bool reversed;
-
-        public TestSceneUSlide()
-        {
-            AddToggleStep("Mirrored", b =>
-            {
-                reversed = b;
-                RefreshSlide();
-            });
-        }
-
-        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateUPattern(StartPath, EndPath, reversed);
+        protected override SlidePaths.PathShapes PathShape => SlidePaths.PathShapes.U;
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneVSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneVSlide.cs
@@ -4,6 +4,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
 {
     public class TestSceneVSlide : TestSceneSlide
     {
-        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateVPattern(StartPath, EndPath);
+        protected override SlidePaths.PathShapes PathShape => SlidePaths.PathShapes.V;
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneVSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneVSlide.cs
@@ -4,6 +4,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
 {
     public class TestSceneVSlide : TestSceneSlide
     {
-        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateVPattern(EndPath);
+        protected override SentakkiSlidePath CreatePattern() => SlidePaths.GenerateVPattern(StartPath, EndPath);
     }
 }

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneSlideFan.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneSlideFan.cs
@@ -43,9 +43,9 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
             var slide = new Slide
             {
                 //Break = true,
-                SlideInfoList = new List<SentakkiSlideInfo>
+                SlideInfoList = new List<SlideBodyInfo>
                 {
-                    new SentakkiSlideInfo {
+                    new SlideBodyInfo {
                         PathParameters = new[] {new PathParameters(SlidePaths.PathShapes.Fan, 4, false)},
                         Duration = 1000,
                     },

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneSlideFan.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneSlideFan.cs
@@ -9,6 +9,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides;
+using osu.Game.Rulesets.Sentakki.Objects.SlidePath;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Sentakki.Tests.Objects
@@ -45,7 +46,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
                 SlideInfoList = new List<SentakkiSlideInfo>
                 {
                     new SentakkiSlideInfo {
-                        ID = SlidePaths.FANID,
+                        PathParameters = new[] {new PathParameters(SlidePaths.PathShapes.Fan, 4, false)},
                         Duration = 1000,
                     },
                 },

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneSlideNote.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneSlideNote.cs
@@ -10,6 +10,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides;
+using osu.Game.Rulesets.Sentakki.Objects.SlidePath;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Sentakki.Tests.Objects
@@ -36,6 +37,10 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
             AddStep("Miss Single", () => testSingle(2000));
             AddStep("Hit Single", () => testSingle(2000, true));
             AddUntilStep("Wait for object despawn", () => !Children.Any(h => (h is DrawableSentakkiHitObject) && (h as DrawableSentakkiHitObject).AllJudged == false));
+
+            AddStep("Miss chain", () => testChain(5000));
+            AddStep("Hit chain", () => testChain(5000, true));
+            AddUntilStep("Wait for object despawn", () => !Children.Any(h => (h is DrawableSentakkiHitObject) && (h as DrawableSentakkiHitObject).AllJudged == false));
         }
 
         private void testSingle(double duration, bool auto = false)
@@ -46,17 +51,54 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
                 SlideInfoList = new List<SentakkiSlideInfo>
                 {
                     new SentakkiSlideInfo {
-                        ID = 25,
+                        PathParameters = new []{new PathParameters(SlidePaths.PathShapes.Circle, 0, false)},
                         Duration = 1000,
                     },
                     new SentakkiSlideInfo {
-                        ID = 27,
+                        PathParameters = new []{new PathParameters(SlidePaths.PathShapes.Straight, 4, false)},
                         Duration = 1500,
                     },
                     new SentakkiSlideInfo {
-                        ID = 0,
+                        PathParameters = new []{new PathParameters(SlidePaths.PathShapes.Cup, 2, false)},
                         Duration = 2000,
                     }
+                },
+                StartTime = Time.Current + 1000,
+            };
+
+            slide.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { });
+
+            DrawableSlide dSlide;
+
+            Add(dSlide = new DrawableSlide(slide)
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Depth = depthIndex++,
+                Auto = auto
+            });
+
+            foreach (DrawableSentakkiHitObject nested in dSlide.NestedHitObjects)
+                foreach (DrawableSentakkiHitObject nested2 in nested.NestedHitObjects)
+                    nested2.Auto = auto;
+        }
+
+        private void testChain(double duration, bool auto = false)
+        {
+            var slide = new Slide
+            {
+                //Break = true,
+                SlideInfoList = new List<SentakkiSlideInfo>
+                {
+                    new SentakkiSlideInfo {
+                        PathParameters = new []{
+                            new PathParameters(SlidePaths.PathShapes.Cup, 2, false),
+                            new PathParameters(SlidePaths.PathShapes.Cup, 2, false),
+                            new PathParameters(SlidePaths.PathShapes.Cup, 2, false),
+                            new PathParameters(SlidePaths.PathShapes.Cup, 2, false),
+                        },
+                        Duration = duration,
+                    },
                 },
                 StartTime = Time.Current + 1000,
             };

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneSlideNote.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneSlideNote.cs
@@ -48,17 +48,17 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
             var slide = new Slide
             {
                 //Break = true,
-                SlideInfoList = new List<SentakkiSlideInfo>
+                SlideInfoList = new List<SlideBodyInfo>
                 {
-                    new SentakkiSlideInfo {
+                    new SlideBodyInfo {
                         PathParameters = new []{new PathParameters(SlidePaths.PathShapes.Circle, 0, false)},
                         Duration = 1000,
                     },
-                    new SentakkiSlideInfo {
+                    new SlideBodyInfo {
                         PathParameters = new []{new PathParameters(SlidePaths.PathShapes.Straight, 4, false)},
                         Duration = 1500,
                     },
-                    new SentakkiSlideInfo {
+                    new SlideBodyInfo {
                         PathParameters = new []{new PathParameters(SlidePaths.PathShapes.Cup, 2, false)},
                         Duration = 2000,
                     }
@@ -88,9 +88,9 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
             var slide = new Slide
             {
                 //Break = true,
-                SlideInfoList = new List<SentakkiSlideInfo>
+                SlideInfoList = new List<SlideBodyInfo>
                 {
-                    new SentakkiSlideInfo {
+                    new SlideBodyInfo {
                         PathParameters = new []{
                             new PathParameters(SlidePaths.PathShapes.Cup, 2, false),
                             new PathParameters(SlidePaths.PathShapes.Cup, 2, false),

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
@@ -299,8 +299,8 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             var selectedPath = validPaths[patternGenerator.RNG.Next(validPaths.Count)];
             return new Slide
             {
-                SlideInfoList = new List<SentakkiSlideInfo>{
-                    new SentakkiSlideInfo{
+                SlideInfoList = new List<SlideBodyInfo>{
+                    new SlideBodyInfo{
                         PathParameters = new PathParameters[]{selectedPath},
                         Duration = ((IHasDuration)original).Duration
                     }

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverter.cs
@@ -9,6 +9,7 @@ using osu.Game.Beatmaps.Legacy;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.SlidePath;
 using osu.Game.Rulesets.Sentakki.UI;
 using osuTK;
 
@@ -197,7 +198,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 
             // If there is a SlideFan, we always prioritize that, and ignore the rest
             foreach (var slide in slides)
-                if (slide.SlideInfoList[0].ID == SlidePaths.FANID)
+                if (slide.SlideInfoList[0].PathParameters[0].Shape == SlidePaths.PathShapes.Fan)
                 {
                     yield return slide;
                     yield break;
@@ -206,11 +207,8 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             // If both slides have the same start lane, we attempt to merge them
             if (slides.Count == 2 && slides[0].Lane == slides[1].Lane)
             {
-                bool isSamePattern = slides[0].SlideInfoList[0].ID == slides[1].SlideInfoList[0].ID;
-                bool isSameOrientation = slides[0].SlideInfoList[0].Mirrored == slides[1].SlideInfoList[0].Mirrored;
-
                 // We merge both slides only if they both have the same pattern AND orientation
-                if (!isSamePattern || !isSameOrientation)
+                if (slides[0] == slides[1])
                     slides[0].SlideInfoList.AddRange(slides[1].SlideInfoList);
 
                 slides.RemoveAt(1);
@@ -285,27 +283,25 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         private SentakkiHitObject createSlideNote(HitObject original, IList<IList<HitSampleInfo>> samples, bool twin = false, bool isBreak = false)
         {
             int noteLane = patternGenerator.GetNextLane(twin);
-            List<(SentakkiSlidePath, SentakkiSlidePath)> validPaths;
+            List<PathParameters> validPaths;
 
             {
-                IEnumerable<(SentakkiSlidePath, SentakkiSlidePath)> pathEnumerable = SlidePaths.VALIDPATHS.Where(p => ((IHasDuration)original).Duration >= p.Item1.MinDuration && ((IHasDuration)original).Duration <= p.Item1.MaxDuration);
+                var pathEnumerable = SlidePaths.VALIDPATHS.Where(p => ((IHasDuration)original).Duration >= p.MinDuration && ((IHasDuration)original).Duration <= p.MinDuration * 10)
+                                                                                      .Select(t => t.parameters);
 
                 if (!EnabledExperiments.HasFlag(ConversionExperiments.fanSlides))
-                    pathEnumerable = pathEnumerable.Where(s => s != SlidePaths.VALIDPATHS[^1]);
+                    pathEnumerable = pathEnumerable.Where(s => s.Shape != SlidePaths.PathShapes.Fan);
 
                 validPaths = pathEnumerable.ToList();
             }
 
             if (!validPaths.Any()) return null;
-            int selectedSlideID = SlidePaths.VALIDPATHS.IndexOf(validPaths[patternGenerator.RNG.Next(validPaths.Count)]);
-            bool mirrored = patternGenerator.RNG.NextDouble() < 0.5;
-
+            var selectedPath = validPaths[patternGenerator.RNG.Next(validPaths.Count)];
             return new Slide
             {
                 SlideInfoList = new List<SentakkiSlideInfo>{
                     new SentakkiSlideInfo{
-                        ID = selectedSlideID,
-                        Mirrored = mirrored,
+                        PathParameters = new PathParameters[]{selectedPath},
                         Duration = ((IHasDuration)original).Duration
                     }
                 },

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModMirror.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModMirror.cs
@@ -35,17 +35,14 @@ namespace osu.Game.Rulesets.Sentakki.Mods
             Value = false
         };
 
-
         public void ApplyToBeatmap(IBeatmap beatmap)
         {
             // Mirroring in both directions at the same time is equivalent to an 180deg rotation
             // Because of that, we wouldn't need to swap slide paths with their mirrored counterpart
             bool mirrored = VerticalMirrored.Value ^ HorizontalMirrored.Value;
 
-
             beatmap.HitObjects.OfType<SentakkiLanedHitObject>().ForEach(laned =>
             {
-
                 if (HorizontalMirrored.Value)
                     laned.Lane = 7 - laned.Lane;
 

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModMirror.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModMirror.cs
@@ -41,6 +41,7 @@ namespace osu.Game.Rulesets.Sentakki.Mods
             // Because of that, we wouldn't need to swap slide paths with their mirrored counterpart
             bool mirrored = VerticalMirrored.Value ^ HorizontalMirrored.Value;
 
+
             beatmap.HitObjects.OfType<SentakkiLanedHitObject>().ForEach(laned =>
             {
                 if (HorizontalMirrored.Value)
@@ -55,7 +56,15 @@ namespace osu.Game.Rulesets.Sentakki.Mods
                 }
 
                 if (mirrored && laned is Slide slide)
-                    slide.SlideInfoList.ForEach(slideInfo => slideInfo.Mirrored ^= mirrored);
+                {
+                    foreach (var slideInfo in slide.SlideInfoList)
+                    {
+                        foreach (var param in slideInfo.PathParameters)
+                        {
+                            param.Mirrored ^= mirrored;
+                        }
+                    }
+                }
             });
 
             beatmap.HitObjects.OfType<Touch>().ForEach(touch =>

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModMirror.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModMirror.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Rulesets.Sentakki.Mods
             Value = false
         };
 
+
         public void ApplyToBeatmap(IBeatmap beatmap)
         {
             // Mirroring in both directions at the same time is equivalent to an 180deg rotation
@@ -44,10 +45,9 @@ namespace osu.Game.Rulesets.Sentakki.Mods
 
             beatmap.HitObjects.OfType<SentakkiLanedHitObject>().ForEach(laned =>
             {
+
                 if (HorizontalMirrored.Value)
-                {
                     laned.Lane = 7 - laned.Lane;
-                }
 
                 if (VerticalMirrored.Value)
                 {
@@ -56,15 +56,15 @@ namespace osu.Game.Rulesets.Sentakki.Mods
                 }
 
                 if (mirrored && laned is Slide slide)
-                {
                     foreach (var slideInfo in slide.SlideInfoList)
                     {
                         foreach (var param in slideInfo.PathParameters)
                         {
+                            param.EndOffset = (param.EndOffset * -1).NormalizePath();
                             param.Mirrored ^= mirrored;
                         }
+                        slideInfo.UpdatePaths();
                     }
-                }
             });
 
             beatmap.HitObjects.OfType<Touch>().ForEach(touch =>

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
@@ -30,10 +30,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             RelativeSizeAxes = Axes.None;
-            Size = new Vector2(200);
+            Size = new Vector2(150);
             CornerExponent = 2f;
-            CornerRadius = 100;
-            Masking = true;
+            CornerRadius = 75;
         }
 
         protected override void OnApply()

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiSlideInfo.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiSlideInfo.cs
@@ -1,10 +1,23 @@
+using osu.Game.Rulesets.Sentakki.Objects.SlidePath;
+using osuTK;
+
 namespace osu.Game.Rulesets.Sentakki.Objects
 {
     public class SentakkiSlideInfo
     {
-        // Index of the slide, used to select a slide pattern from the list of ValidPaths
-        public int ID;
-        public bool Mirrored;
+        private PathParameters[] pathParameters;
+
+        public PathParameters[] PathParameters
+        {
+            get => pathParameters;
+            set
+            {
+                pathParameters = value;
+                updatePaths();
+            }
+        }
+
+        public SentakkiSlidePath SlidePath { get; private set; }
 
         // Duration of the slide
         public double Duration;
@@ -12,6 +25,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         // Delay before the star on the slide starts moving to the end
         public int ShootDelay = 1;
 
-        public SentakkiSlidePath SlidePath => SlidePaths.GetSlidePath(ID, Mirrored);
+        public (Vector2 position, Vector2 rotation) ChevronPositions { get; private set; }
+
+        private void updatePaths()
+        {
+            SlidePath = SlidePaths.CreateSlidePath(pathParameters);
+        }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiSlidePath.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiSlidePath.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         // While it is completely playable even beyond this value, it would look awkward for shorter slides
         public double MaxDuration => MinDuration * 10;
 
-        public double TotalDistance;
+        public double TotalDistance { get; private set; }
 
         public readonly SliderPath[] SlideSegments;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Slide.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Slide.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
         public override Color4 DefaultNoteColour => Color4.Aqua;
 
-        public List<SentakkiSlideInfo> SlideInfoList = new List<SentakkiSlideInfo>();
+        public List<SlideBodyInfo> SlideInfoList = new List<SlideBodyInfo>();
 
         public SlideTap SlideTap { get; private set; }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Slide.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Slide.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             foreach (var SlideInfo in SlideInfoList)
             {
                 SlideBody body;
-                if (SlideInfo.ID == SlidePaths.FANID)
+                if (SlideInfo.PathParameters[0].Shape == SlidePaths.PathShapes.Fan)
                     AddNested(body = new SlideFan());
                 else
                     AddNested(body = new SlideBody());

--- a/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             set => SlideInfo.Duration = value;
         }
 
-        public SentakkiSlideInfo SlideInfo { get; set; }
+        public SlideBodyInfo SlideInfo { get; set; }
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
         {

--- a/osu.Game.Rulesets.Sentakki/Objects/SlideBodyInfo.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlideBodyInfo.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             set
             {
                 pathParameters = value;
-                updatePaths();
+                UpdatePaths();
             }
         }
 
@@ -24,9 +24,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         // Delay before the star on the slide starts moving to the end
         public int ShootDelay = 1;
 
-        private void updatePaths()
-        {
-            SlidePath = SlidePaths.CreateSlidePath(pathParameters);
-        }
+        public void UpdatePaths() => SlidePath = SlidePaths.CreateSlidePath(pathParameters);
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/SlideBodyInfo.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlideBodyInfo.cs
@@ -1,9 +1,8 @@
 using osu.Game.Rulesets.Sentakki.Objects.SlidePath;
-using osuTK;
 
 namespace osu.Game.Rulesets.Sentakki.Objects
 {
-    public class SentakkiSlideInfo
+    public class SlideBodyInfo
     {
         private PathParameters[] pathParameters;
 
@@ -24,8 +23,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
         // Delay before the star on the slide starts moving to the end
         public int ShootDelay = 1;
-
-        public (Vector2 position, Vector2 rotation) ChevronPositions { get; private set; }
 
         private void updatePaths()
         {

--- a/osu.Game.Rulesets.Sentakki/Objects/SlidePath/PathParameters.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlidePath/PathParameters.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace osu.Game.Rulesets.Sentakki.Objects.SlidePath
+{
+    public class PathParameters : IEquatable<PathParameters>
+    {
+        public SlidePaths.PathShapes Shape { get; private set; }
+        public int EndOffset { get; set; }
+        public bool Mirrored { get; set; }
+
+        public PathParameters(SlidePaths.PathShapes shape, int endOffset, bool mirrored)
+        {
+            Shape = shape;
+            EndOffset = endOffset;
+            Mirrored = mirrored;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is not PathParameters otherPath)
+                return false;
+
+            return Equals(otherPath);
+        }
+
+        public bool Equals(PathParameters other) => Shape == other.Shape && EndOffset == EndOffset;
+
+
+        public override int GetHashCode() => HashCode.Combine(Shape, EndOffset, Mirrored);
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Objects/SlidePath/PathParameters.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlidePath/PathParameters.cs
@@ -25,7 +25,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.SlidePath
 
         public bool Equals(PathParameters other) => Shape == other.Shape && EndOffset == EndOffset;
 
-
         public override int GetHashCode() => HashCode.Combine(Shape, EndOffset, Mirrored);
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
@@ -32,13 +32,18 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                     for (int k = 0; k < 2; ++k)
                     {
                         var tmp = new PathParameters(i, j, k == 1);
-                        if (CheckSlideValidity(tmp))
+                        if (CheckSlideValidity(tmp, true))
+                        {
                             VALIDPATHS.Add((tmp, CreateSlidePath(tmp).MinDuration));
+                        }
                     }
         }
 
         // Checks if a slide is valid given parameters
-        public static bool CheckSlideValidity(PathParameters param)
+        //
+        // Discarding redundant mirrors should be used making a list of all the shapes, as to not get identical shapes
+        // Not discarding them allows leniency in the check, so that a identical path can still be placed, without needing the mapper to explicitly turn of mirroring for a part.
+        public static bool CheckSlideValidity(PathParameters param, bool discardRedundantMirrors = false)
         {
             int normalizedEnd = param.EndOffset.NormalizePath();
             bool mirrored = param.Mirrored;
@@ -46,13 +51,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             switch (param.Shape)
             {
                 case PathShapes.Straight:
-                    return normalizedEnd > 1 && normalizedEnd < 7;
+                    return (!mirrored || !discardRedundantMirrors) && normalizedEnd > 1 && normalizedEnd < 7;
 
                 case PathShapes.Circle:
                     return mirrored ? normalizedEnd != 7 : normalizedEnd != 1;
 
                 case PathShapes.V:
-                    return normalizedEnd != 0;
+                    return (!mirrored || !discardRedundantMirrors) && normalizedEnd != 0;
 
                 case PathShapes.L:
                     return normalizedEnd != 0 && (mirrored ? normalizedEnd > 3 : normalizedEnd < 5);
@@ -62,6 +67,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                     return true;
 
                 case PathShapes.Fan:
+                    return (!mirrored || !discardRedundantMirrors) && normalizedEnd == 4;
+
                 case PathShapes.Thunder:
                     return normalizedEnd == 4;
             }

--- a/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         // Checks if a slide is valid given parameters
         public static bool CheckSlideValidity(PathParameters param)
         {
-            int normalizedEnd = param.EndOffset;
+            int normalizedEnd = param.EndOffset.NormalizePath();
             bool mirrored = param.Mirrored;
 
             switch (param.Shape)
@@ -49,20 +49,20 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                     return normalizedEnd > 1 && normalizedEnd < 7;
 
                 case PathShapes.Circle:
-                    return mirrored ? normalizedEnd != 0 : normalizedEnd != 7;
+                    return mirrored ? normalizedEnd != 7 : normalizedEnd != 1;
 
                 case PathShapes.V:
-                    return normalizedEnd != 4;
+                    return normalizedEnd != 0;
 
                 case PathShapes.L:
-                    return mirrored ? normalizedEnd < 5 : normalizedEnd > 3;
+                    return normalizedEnd != 0 && (mirrored ? normalizedEnd > 3 : normalizedEnd < 5);
 
                 case PathShapes.U:
                 case PathShapes.Cup:
-                case PathShapes.Thunder:
                     return true;
 
                 case PathShapes.Fan:
+                case PathShapes.Thunder:
                     return normalizedEnd == 4;
             }
 
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                         break;
 
                     case PathShapes.L:
-                        slideSegments.AddRange(generateLPattern(startOffset, path.EndOffset));
+                        slideSegments.AddRange(generateLPattern(startOffset, path.EndOffset, path.Mirrored));
                         break;
 
                     case PathShapes.U:

--- a/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
@@ -194,7 +194,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                     new PathControlPoint(Node1Pos, PathType.Linear),
                     new PathControlPoint(Node2Pos, PathType.Linear),
                 });
-            };
+            }
         }
 
         // Covers DX L pattern 2-5

--- a/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlidePaths.cs
@@ -12,42 +12,42 @@ namespace osu.Game.Rulesets.Sentakki.Objects
     {
         public static int FANID => VALIDPATHS.Count - 1;
         public static readonly List<(SentakkiSlidePath, SentakkiSlidePath)> VALIDPATHS = new List<(SentakkiSlidePath, SentakkiSlidePath)>{
-            (GenerateCirclePattern(2), GenerateCirclePattern(6, RotationDirection.Counterclockwise)),
-            (GenerateCirclePattern(3), GenerateCirclePattern(5, RotationDirection.Counterclockwise)),
-            (GenerateCirclePattern(4), GenerateCirclePattern(4, RotationDirection.Counterclockwise)),
-            (GenerateCirclePattern(5), GenerateCirclePattern(3, RotationDirection.Counterclockwise)),
-            (GenerateCirclePattern(6), GenerateCirclePattern(2, RotationDirection.Counterclockwise)),
-            (GenerateCirclePattern(7), GenerateCirclePattern(1, RotationDirection.Counterclockwise)),
-            (GenerateCirclePattern(8), GenerateCirclePattern(0, RotationDirection.Counterclockwise)),
-            (GenerateLPattern(1), GenerateLPattern(7, true)),
-            (GenerateLPattern(2), GenerateLPattern(6, true)),
-            (GenerateLPattern(3), GenerateLPattern(5, true)),
-            (GenerateLPattern(4), GenerateLPattern(4, true)),
-            (GenerateStraightPattern(2), GenerateStraightPattern(6)),
-            (GenerateStraightPattern(3), GenerateStraightPattern(5)),
-            (GenerateStraightPattern(4), null),
-            (GenerateThunderPattern(), GenerateThunderPattern(true)),
-            (GenerateUPattern(0), GenerateUPattern(0, true)),
-            (GenerateUPattern(1), GenerateUPattern(7, true)),
-            (GenerateUPattern(2), GenerateUPattern(6, true)),
-            (GenerateUPattern(3), GenerateUPattern(5, true)),
-            (GenerateUPattern(4), GenerateUPattern(4, true)),
-            (GenerateUPattern(5), GenerateUPattern(3, true)),
-            (GenerateUPattern(6), GenerateUPattern(2, true)),
-            (GenerateUPattern(7), GenerateUPattern(1, true)),
-            (GenerateVPattern(1), GenerateVPattern(7)),
-            (GenerateVPattern(2), GenerateVPattern(6)),
-            (GenerateVPattern(3), GenerateVPattern(5)),
-            (GenerateCupPattern(0),GenerateCupPattern(0, true)),
-            (GenerateCupPattern(1),GenerateCupPattern(7, true)),
-            (GenerateCupPattern(2),GenerateCupPattern(6, true)),
-            (GenerateCupPattern(3),GenerateCupPattern(5, true)),
-            (GenerateCupPattern(4),GenerateCupPattern(4, true)),
-            (GenerateCupPattern(5),GenerateCupPattern(3, true)),
-            (GenerateCupPattern(6),GenerateCupPattern(2, true)),
-            (GenerateCupPattern(7),GenerateCupPattern(1, true)),
+            (GenerateCirclePattern(0, 2), GenerateCirclePattern(0, 6, RotationDirection.Counterclockwise)),
+            (GenerateCirclePattern(0, 3), GenerateCirclePattern(0, 5, RotationDirection.Counterclockwise)),
+            (GenerateCirclePattern(0, 4), GenerateCirclePattern(0, 4, RotationDirection.Counterclockwise)),
+            (GenerateCirclePattern(0, 5), GenerateCirclePattern(0, 3, RotationDirection.Counterclockwise)),
+            (GenerateCirclePattern(0, 6), GenerateCirclePattern(0, 2, RotationDirection.Counterclockwise)),
+            (GenerateCirclePattern(0, 7), GenerateCirclePattern(0, 1, RotationDirection.Counterclockwise)),
+            (GenerateCirclePattern(0, 8), GenerateCirclePattern(0, 0, RotationDirection.Counterclockwise)),
+            (GenerateLPattern(0, 1), GenerateLPattern(0, 7, true)),
+            (GenerateLPattern(0, 2), GenerateLPattern(0, 6, true)),
+            (GenerateLPattern(0, 3), GenerateLPattern(0, 5, true)),
+            (GenerateLPattern(0, 4), GenerateLPattern(0, 4, true)),
+            (GenerateStraightPattern(0,2), GenerateStraightPattern(0,2)),
+            (GenerateStraightPattern(0,3), GenerateStraightPattern(0,5)),
+            (GenerateStraightPattern(0,4), null),
+            (GenerateThunderPattern(0), GenerateThunderPattern(0,true)),
+            (GenerateUPattern(0, 0), GenerateUPattern(0, 0, true)),
+            (GenerateUPattern(0, 1), GenerateUPattern(0, 7, true)),
+            (GenerateUPattern(0, 2), GenerateUPattern(0, 6, true)),
+            (GenerateUPattern(0, 3), GenerateUPattern(0, 5, true)),
+            (GenerateUPattern(0, 4), GenerateUPattern(0, 4, true)),
+            (GenerateUPattern(0, 5), GenerateUPattern(0, 3, true)),
+            (GenerateUPattern(0, 6), GenerateUPattern(0, 2, true)),
+            (GenerateUPattern(0, 7), GenerateUPattern(0, 1, true)),
+            (GenerateVPattern(0,1), GenerateVPattern(0,7)),
+            (GenerateVPattern(0,2), GenerateVPattern(0,6)),
+            (GenerateVPattern(0,3), GenerateVPattern(0,5)),
+            (GenerateCupPattern(0, 0),GenerateCupPattern(0, 0, true)),
+            (GenerateCupPattern(0, 1),GenerateCupPattern(0, 7, true)),
+            (GenerateCupPattern(0, 2),GenerateCupPattern(0, 6, true)),
+            (GenerateCupPattern(0, 3),GenerateCupPattern(0, 5, true)),
+            (GenerateCupPattern(0, 4),GenerateCupPattern(0, 4, true)),
+            (GenerateCupPattern(0, 5),GenerateCupPattern(0, 3, true)),
+            (GenerateCupPattern(0, 6),GenerateCupPattern(0, 2, true)),
+            (GenerateCupPattern(0, 7),GenerateCupPattern(0, 1, true)),
 
-            (GenerateStraightPattern(4), null),//An extra entry for the Fan Slide
+            (GenerateStraightPattern(0,4), null),//An extra entry for the Fan Slide
         };
 
         public static SentakkiSlidePath GetSlidePath(int ID, bool IsMirrored = false)
@@ -61,14 +61,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         private static Vector2 getPositionInBetween(Vector2 first, Vector2 second, float ratio = .5f) => first + ((second - first) * ratio);
 
         // Covers DX Straight 3-7
-        public static SentakkiSlidePath GenerateStraightPattern(int end)
+        public static SentakkiSlidePath GenerateStraightPattern(int offset, int end)
         {
             var path = new SliderPath(new PathControlPoint[] {
-                new PathControlPoint(SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, 0), PathType.Linear),
+                new PathControlPoint(SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, offset), PathType.Linear),
                 new PathControlPoint(SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end), PathType.Linear),
             });
 
-            return new SentakkiSlidePath(path, end);
+            return new SentakkiSlidePath(path, end + offset);
         }
 
         private static Vector2 getIntesectPoint(Vector2 A1, Vector2 A2, Vector2 B1, Vector2 B2)
@@ -83,19 +83,19 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         }
 
         // Thunder pattern
-        public static SentakkiSlidePath GenerateThunderPattern(bool mirrored = false)
+        public static SentakkiSlidePath GenerateThunderPattern(int offset, bool mirrored = false)
         {
-            int lane1 = mirrored ? 3 : 5;
-            int lane2 = mirrored ? 2 : 6;
-            int lane3 = mirrored ? 6 : 2;
-            int lane4 = mirrored ? 7 : 1;
+            int lane1 = (mirrored ? 3 : 5) + offset;
+            int lane2 = (mirrored ? 2 : 6) + offset;
+            int lane3 = (mirrored ? 6 : 2) + offset;
+            int lane4 = (mirrored ? 7 : 1) + offset;
 
             static Vector2 lanestart(int x) => SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, x);
-            Vector2 Node0Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, 0);
-            Vector2 Node1Pos = getIntesectPoint(lanestart(0), lanestart(lane1), lanestart(lane2), lanestart(lane3));
+            Vector2 Node0Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, offset);
+            Vector2 Node1Pos = getIntesectPoint(lanestart(offset), lanestart(lane1), lanestart(lane2), lanestart(lane3));
 
-            Vector2 Node2Pos = getIntesectPoint(lanestart(lane2), lanestart(lane3), lanestart(lane4), lanestart(4));
-            Vector2 Node3Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, 4);
+            Vector2 Node2Pos = getIntesectPoint(lanestart(lane2), lanestart(lane3), lanestart(lane4), lanestart(4 + offset));
+            Vector2 Node3Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, 4 + offset);
 
             SliderPath[] segments = new SliderPath[]{
                 new SliderPath(new PathControlPoint[]{
@@ -112,15 +112,17 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                 })
             };
 
-            return new SentakkiSlidePath(segments, 4);
+            return new SentakkiSlidePath(segments, offset + 4);
         }
 
         // Covers DX V pattern 1-8
-        public static SentakkiSlidePath GenerateVPattern(int end)
+        public static SentakkiSlidePath GenerateVPattern(int offset, int end)
         {
-            Vector2 Node0Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, 0);
+            Vector2 Node0Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, offset);
             Vector2 Node1Pos = Vector2.Zero;
-            Vector2 Node2Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end);
+            Vector2 Node2Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end + offset);
+
+
 
             if (end >= 3 && end <= 5)
             {
@@ -144,16 +146,16 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                     })
                 };
 
-                return new SentakkiSlidePath(segments, end);
+                return new SentakkiSlidePath(segments, end + offset);
             }
         }
 
         // Covers DX L pattern 2-5
-        public static SentakkiSlidePath GenerateLPattern(int end, bool mirrored = false)
+        public static SentakkiSlidePath GenerateLPattern(int offset, int end, bool mirrored = false)
         {
-            Vector2 Node0Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, 0);
-            Vector2 Node1Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, mirrored ? 2 : 6);
-            Vector2 Node2Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end);
+            Vector2 Node0Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, offset);
+            Vector2 Node1Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, (mirrored ? 2 : 6) + offset);
+            Vector2 Node2Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end + offset);
 
             var segments = new SliderPath[]{
                 new SliderPath(new PathControlPoint[]{
@@ -166,34 +168,34 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                 }),
             };
 
-            return new SentakkiSlidePath(segments, end);
+            return new SentakkiSlidePath(segments, end + offset);
         }
 
         // DX Circle Pattern
-        public static SentakkiSlidePath GenerateCirclePattern(int end, RotationDirection direction = RotationDirection.Clockwise)
+        public static SentakkiSlidePath GenerateCirclePattern(int offset, int end, RotationDirection direction = RotationDirection.Clockwise)
         {
-            float centre = ((0.GetRotationForLane() + end.GetRotationForLane()) / 2) + (direction == RotationDirection.Counterclockwise ? 180 : 0);
-            Vector2 centreNode = SentakkiExtensions.GetCircularPosition(SentakkiPlayfield.INTERSECTDISTANCE, centre == 0.GetRotationForLane() ? centre + 180 : centre);
+            float centre = ((offset.GetRotationForLane() + (end + offset).GetRotationForLane()) / 2) + (direction == RotationDirection.Counterclockwise ? 180 : 0);
+            Vector2 centreNode = SentakkiExtensions.GetCircularPosition(SentakkiPlayfield.INTERSECTDISTANCE, centre == offset.GetRotationForLane() ? centre + 180 : centre);
 
             var path = new SliderPath(new PathControlPoint[]{
-                new PathControlPoint(SentakkiExtensions.GetCircularPosition(SentakkiPlayfield.INTERSECTDISTANCE, 0.GetRotationForLane() + (direction == RotationDirection.Counterclockwise ? -.5f : .5f)), PathType.PerfectCurve),
+                new PathControlPoint(SentakkiExtensions.GetCircularPosition(SentakkiPlayfield.INTERSECTDISTANCE, offset.GetRotationForLane() + (direction == RotationDirection.Counterclockwise ? -.5f : .5f)), PathType.PerfectCurve),
                 new PathControlPoint(centreNode),
-                new PathControlPoint(SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end), PathType.PerfectCurve)
+                new PathControlPoint(SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end+offset), PathType.PerfectCurve)
             });
 
-            return new SentakkiSlidePath(path, end);
+            return new SentakkiSlidePath(path, end + offset);
         }
 
-        public static SentakkiSlidePath GenerateUPattern(int end, bool reversed = false)
+        public static SentakkiSlidePath GenerateUPattern(int offset, int end, bool reversed = false)
         {
-            Vector2 Node0Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, 0);
-            Vector2 Node1Pos = getPositionInBetween(Node0Pos, SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, reversed ? 3 : 5), .51f);
+            Vector2 Node0Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, offset);
+            Vector2 Node1Pos = getPositionInBetween(Node0Pos, SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, (reversed ? 3 : 5) + offset), .51f);
 
-            float angleDiff = ((end.GetRotationForLane() + 0.GetRotationForLane()) / 2) + (Math.Abs(end) > (reversed ? 3 : 4) ? 0 : 180);
+            float angleDiff = (((end + offset).GetRotationForLane() + offset.GetRotationForLane()) / 2) + (Math.Abs(end) > (reversed ? 3 : 4) ? 0 : 180);
             Vector2 Node2Pos = SentakkiExtensions.GetCircularPosition(115, angleDiff);
 
-            Vector2 Node4Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end);
-            Vector2 Node3Pos = getPositionInBetween(Node4Pos, SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end + (reversed ? -3 : 3)), .51f);
+            Vector2 Node4Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end + offset);
+            Vector2 Node3Pos = getPositionInBetween(Node4Pos, SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end + (reversed ? -3 : 3) + offset), .51f);
 
             var path = new SliderPath(new PathControlPoint[]{
                 new PathControlPoint(Node0Pos,PathType.Linear),
@@ -202,10 +204,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                 new PathControlPoint(Node3Pos, PathType.PerfectCurve),
                 new PathControlPoint(Node4Pos,PathType.Linear)
             });
-            return new SentakkiSlidePath(path, end);
+            return new SentakkiSlidePath(path, end + offset);
         }
 
-        public static SentakkiSlidePath GenerateCupPattern(int end, bool mirrored = false)
+        public static SentakkiSlidePath GenerateCupPattern(int offset, int end, bool mirrored = false)
         {
             float r = 270 / 2f;
 
@@ -227,6 +229,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             else if (x == 6) loopEndAngle = 360;
             else if (x == 7) loopEndAngle = 390;
 
+            float offsetAdjustment = offset.GetRotationForLane() - 22.5f;
             if (mirrored)
             {
                 originAngle = -originAngle + 45;
@@ -236,15 +239,15 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                 loopEndAngle = -loopEndAngle + 45;
             }
 
-            Vector2 loopOrigin = SentakkiExtensions.GetCircularPosition(r, originAngle);
+            Vector2 loopOrigin = SentakkiExtensions.GetCircularPosition(r, originAngle + offsetAdjustment);
 
-            Vector2 Node0Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, 0);
-            Vector2 Node1Pos = loopOrigin + SentakkiExtensions.GetCircularPosition(r, angle1);
-            Vector2 Node2Pos = loopOrigin + SentakkiExtensions.GetCircularPosition(r, angle2);
-            Vector2 Node3Pos = loopOrigin + SentakkiExtensions.GetCircularPosition(r, angle3);
-            Vector2 Node4Pos = loopOrigin + SentakkiExtensions.GetCircularPosition(r, ((angle3 + loopEndAngle) / 2) + (x >= 3 ? 180 : 0));
-            Vector2 Node5Pos = loopOrigin + SentakkiExtensions.GetCircularPosition(r, loopEndAngle);
-            Vector2 Node6Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end);
+            Vector2 Node0Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, offset);
+            Vector2 Node1Pos = loopOrigin + SentakkiExtensions.GetCircularPosition(r, angle1 + offsetAdjustment);
+            Vector2 Node2Pos = loopOrigin + SentakkiExtensions.GetCircularPosition(r, angle2 + offsetAdjustment);
+            Vector2 Node3Pos = loopOrigin + SentakkiExtensions.GetCircularPosition(r, angle3 + offsetAdjustment);
+            Vector2 Node4Pos = loopOrigin + SentakkiExtensions.GetCircularPosition(r, ((angle3 + loopEndAngle) / 2) + (x >= 3 ? 180 : 0) + offsetAdjustment);
+            Vector2 Node5Pos = loopOrigin + SentakkiExtensions.GetCircularPosition(r, loopEndAngle + offsetAdjustment);
+            Vector2 Node6Pos = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, end + offset);
 
             var path = new SliderPath(new PathControlPoint[]{
                 new PathControlPoint(Node0Pos, PathType.Linear),

--- a/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
@@ -1,7 +1,6 @@
 using System;
 using osu.Framework.Extensions;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Rulesets.Sentakki.UI;
 using osuTK;
 using osuTK.Graphics;
 
@@ -35,12 +34,8 @@ namespace osu.Game.Rulesets.Sentakki
             return x;
         }
 
-        public static float GetRotationForLane(this int lane)
-        {
-            while (lane < 0) lane += 8;
-            lane %= 8;
-            return SentakkiPlayfield.LANEANGLES[lane];
-        }
+        public static float GetRotationForLane(this int lane) => 22.5f + (lane * 45);
+
         public static Vector2 GetPositionAlongLane(float distance, int lane) => GetCircularPosition(distance, lane.GetRotationForLane());
 
         public static Vector2 GetCircularPosition(float distance, float angle)


### PR DESCRIPTION
This PR adds support for slide bodies that is a composed of a sequence of regular slide paths, as opposed to the single shape limitation the is present before. This could previously be done in a roundabout way by manually placing a Slide at the endpoint of a previous one, but that meant that timing is stricter as the SlideTaps are generated at such points.

These won't appear in osu! beatmap conversions.  (for now)

![An example of a complex slide shape made out of simple slide shapes](https://user-images.githubusercontent.com/12001167/190479799-c27a4ad0-3d2e-4a49-a1b1-4e40936ffdd6.png)

# The details
`SentakkiSlideInfo` has been renamed to `SlideBodyInfo` to better match its actual use.

`SlideBodyInfo` is now initialised using a list of `PathParameters` (name tbd), which contains info about the Shape, the ending offset from the origin (0 - 7), and whether it is mirrored. The backing `SentakkiSlidePath` will be generated on the spot using that info, unlike previously where the path will be generated ahead of time, and fetched using the ID.

When generating a path for a sequence of `PathParameters`, the ending offset is relative the current part's origin lane, with the start offset being relative to the previous path's end offset (or 0 if there isn't a previous part). The segments for each part will then be combined into a single `SentakkiSlidePath` where it is ready for use.

If the first `PathParameter` has the SlideFan shape, then a SlideFan will be created, and future parts ignored. If a `PathParameter` with a SlideFan shape is used elsewhere in the list, it'll be treated as a regular straight. I might consider allowing SlideFans to be used as a part, but only if it is at the end of the list, since it is possible to transition from a line to a fan, and not the other way around.

The `SlidePaths.VALIDPATHS` list is still computed, for use in conversions from osu! beatmaps, since the converter uses path distance information to determine whether it is appropriate to use a shape with a given duration. However, instead of holding `SentakkiSlidePaths`s, they hold the `PathParameter` used to create the same path, since it is now the primary way of creating a `SlideBodyInfo`. Not sure if this is an improvement to the previous setup, or whether I should just store the `SlideBodyInfo` instead of the parameters. Not a big issue though since the computation happens before gameplay.

