### PR TITLE
Reduce slider leniencies

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -178,8 +178,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             {
                 if (!HitObject.HitWindows.CanBeHit(timeOffset))
                 {
-                    // Miss the last node to ensure that all of them have results
-                    SlideCheckpoints[^1].ForcefullyMiss();
+                    // Ensure that all of them have results
+                    foreach (var checkpoint in SlideCheckpoints)
+                        checkpoint.ForcefullyMiss();
+
                     if (SlideCheckpoints.Count(node => !node.Result.IsHit) <= 2 && SlideCheckpoints.Count > 2)
                         ApplyResult(HitResult.Ok);
                     else

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         // All hits can only be done after the parent StartTime
         public bool IsHittable => Time.Current > ParentHitObject.HitObject.StartTime && isPreviousNodeHit();
 
-        private bool isPreviousNodeHit() => ThisIndex < 2 || parentSlide.SlideCheckpoints[ThisIndex - 2].IsHit;
+        private bool isPreviousNodeHit() => ThisIndex < 1 || parentSlide.SlideCheckpoints[ThisIndex - 1].IsHit;
 
         private Container<DrawableSlideCheckpointNode> nodes;
 
@@ -71,9 +71,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         protected override void ApplyResult(Action<JudgementResult> application)
         {
-            // Judge the previous node, because that isn't guaranteed due to the leniency;
-            if (ThisIndex > 0)
-                parentSlide.SlideCheckpoints[ThisIndex - 1]?.ApplyResult(application);
+            if (Judged)
+                return;
 
             // Make sure remaining nodes are judged
             foreach (var node in nodes)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
@@ -30,10 +30,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             RelativeSizeAxes = Axes.None;
-            Size = new Vector2(200);
+            Size = new Vector2(value: 150);
             CornerExponent = 2f;
-            CornerRadius = 100;
-            Masking = true;
+            CornerRadius = 75;
         }
 
         protected override void OnApply()


### PR DESCRIPTION
This PR removes the slide order leniency and reduces the size of the slide node sensors.

Personally, I don't think that the slide order leniency is actually needed, given that slides are already easy enough to complete without it, and I believe the only reason it is in sentakki in the first place is because maimai has this leniency as well.

Not sure if any gameplay tech actually uses the slide order leniency, so I don't see any other reason to keep this. (maybe tapping through each slide, which isn't even faster given that you are following the slide anyways?)