### PR TITLE
Apply results to score padding in reverse order

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiLanedHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiLanedHitObject.cs
@@ -80,11 +80,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         protected override void ApplyResult(Action<JudgementResult> application)
         {
-            base.ApplyResult(application);
-
             // Also give Break note score padding a judgement
-            foreach (var breakObj in scorePaddingObjects)
-                breakObj.ApplyResult(application);
+            for (int i = 0; i < scorePaddingObjects.Count; ++i)
+                scorePaddingObjects[^(i + 1)].ApplyResult(application);
+
+            base.ApplyResult(application);
         }
     }
 }


### PR DESCRIPTION
When a `DrawableHitObject` is judged, the score processor would add combo information from before the DHO is judged to the `JudgementResult`. This information is then used during reverts to ensure that combo information remains accurate.

For `DrawableHitObject`s (and `CompositeDrawable`s in general), `Update`s are done on parent first, then children in ascending order. 

> ```
> Parent -> Children[0] -> Children[1] ... -> Children[n]
> ```

For most situations, this isn't really a problem as it is quite rare that multiple scored objects are judged at the same time. However, in Sentakki, the score padding objects in Break notes are judged at the exact same time; and due to the order in which I apply the results, the combo information is applied incorrectly during a revert.

> ```
> // How break results are applied (and the combo before the result is applied)
> Parent (0) -> padding[0] (1) -> padding[1] (2) -> padding[2] (3) -> padding[3] (4) 
>
> // how the combo changes during a revert (from combo 4)
> 5 -> 1 -> 2 -> 3 -> 4 
> ```

As shown, reverting a break judgement will cause the combo count to desync, and can only be reverted by reverting a non-break judgement prior to that break judgement. (the same applies to earlier desyncs)

By changing the order I apply results on break notes, we can ensure that reverts remain correct.