### PR TITLE
Remove break modifier from HoldTails

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Hold.cs
@@ -36,8 +36,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
         {
-            base.CreateNestedHitObjects(cancellationToken);
-
             AddNested(new HoldHead
             {
                 Break = Break,


### PR DESCRIPTION
Hold tails previously benefitted from the Break score multiplier, which made them way too valuable considering that they don't require the player to be precise with their release timing, unlike the Hold heads.