### PR TITLE
Add bonus for hitting Break notes within the critical window

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Judgements/SentakkiBonusJudgement.cs
+++ b/osu.Game.Rulesets.Sentakki/Judgements/SentakkiBonusJudgement.cs
@@ -1,0 +1,10 @@
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Sentakki.Judgements
+{
+    public class SentakkiBonusJudgement : Judgement
+    {
+        public override HitResult MaxResult => HitResult.LargeBonus;
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableScoreBonusObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableScoreBonusObject.cs
@@ -1,0 +1,22 @@
+using System;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
+{
+    public class DrawableScoreBonusObject : DrawableHitObject<ScoreBonusObject>
+    {
+        public DrawableScoreBonusObject() : this(null) { }
+
+        public DrawableScoreBonusObject(ScoreBonusObject? hitObject)
+            : base(hitObject!) { }
+
+        public void TriggerResult() => ApplyResult(static r => r.Type = (Math.Abs(r.TimeOffset) < 16) ? r.Judgement.MaxResult : r.Judgement.MinResult);
+
+        public new void ApplyResult(Action<JudgementResult> application)
+        {
+            if (!Result.HasResult)
+                base.ApplyResult(application);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Objects/ScoreBonusObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/ScoreBonusObject.cs
@@ -1,0 +1,14 @@
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Sentakki.Judgements;
+
+namespace osu.Game.Rulesets.Sentakki.Objects
+{
+    public class ScoreBonusObject : HitObject
+    {
+        public override Judgement CreateJudgement() => new SentakkiBonusJudgement();
+
+        protected override HitWindows CreateHitWindows() => HitWindows.Empty;
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiLanedHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiLanedHitObject.cs
@@ -31,8 +31,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             base.CreateNestedHitObjects(cancellationToken);
 
             if (Break)
+            {
                 for (int i = 0; i < 4; ++i)
                     AddNested(new ScorePaddingObject() { StartTime = this.GetEndTime() });
+
+                // Add bonus for players hitting within the critical window
+                AddNested(new ScoreBonusObject() { StartTime = this.GetEndTime() });
+            }
         }
 
         public override IList<HitSampleInfo> AuxiliarySamples => CreateBreakSample();

--- a/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
@@ -70,6 +70,8 @@ namespace osu.Game.Rulesets.Sentakki
         {
             switch (result)
             {
+                case HitResult.LargeBonus:
+                    return "Critical Break Bonus";
                 case HitResult.Great:
                     return "Perfect";
                 case HitResult.Good:

--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -179,6 +179,7 @@ namespace osu.Game.Rulesets.Sentakki
         {
             return new[]
             {
+                HitResult.LargeBonus,
                 HitResult.Great,
                 HitResult.Good,
                 HitResult.Ok,

--- a/osu.Game.Rulesets.Sentakki/UI/Lane.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Lane.cs
@@ -59,6 +59,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
             RegisterPool<SlideCheckpoint.CheckpointNode, DrawableSlideCheckpointNode>(18);
 
             RegisterPool<ScorePaddingObject, DrawableScorePaddingObject>(20);
+            RegisterPool<ScoreBonusObject, DrawableScoreBonusObject>(5);
         }
 
         protected override void OnNewDrawableHitObject(DrawableHitObject d) => OnLoaded?.Invoke(d);


### PR DESCRIPTION
Just something I want to try out, to reward players who managed to get a critical judgement on Break notes.

I'm using `HitResult.LargeBonus` which is worth 50pts, and is worth about a third of a regular break hit(1500pts); Also doesn't affect combo/accuracy.