### PR TITLE
Fix HitObjectLine not being a full circle when two notes are across each other

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/Components/HitObjectLine/LineLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/HitObjectLine/LineLifetimeEntry.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components.HitObjectLine
                 bool allBreaks = HitObjects.All(h => h.Break);
                 Colour = Color4.Gold;
 
-                int angleRange = 90 + (45 * delta);
+                int angleRange = delta == 4 ? 360 : (90 + (45 * delta));
 
                 AngleRange = angleRange / 360f;
 


### PR DESCRIPTION
Regressed in #416 due to an oversight, and allowed this to be possible
![image](https://user-images.githubusercontent.com/12001167/205465470-e9f0cb65-eed0-44fc-9b86-f629cec9fd02.png)


