### PR TITLE
Use ClearSamples to clear samples

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiLanedHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiLanedHitObject.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void OnFree()
         {
             base.OnFree();
-            breakSample.Samples = null!;
+            breakSample.ClearSamples();
         }
 
         protected override void ApplyResult(Action<JudgementResult> application)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.OnFree();
 
-            holdSample.Samples = null!;
+            holdSample.ClearSamples();
             holdStartTime = null;
             totalHoldTime = 0;
         }


### PR DESCRIPTION
In https://github.com/ppy/osu/pull/22430, the method to clear samples have been changed. Instead of setting the samples to `null`, `ClearSamples()` should be used instead.

Fixes #437.