### PR TITLE
Fix rewind visuals on Slides

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -128,7 +128,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         private void onRevertResult(DrawableHitObject hitObject, JudgementResult result)
         {
-            var checkpoint = (DrawableSlideCheckpoint)hitObject;
+            if (hitObject is not DrawableSlideCheckpoint checkpoint)
+                return;
 
             Slidepath.Progress = checkpoint.ThisIndex == 0 ? 0 : SlideCheckpoints[checkpoint.ThisIndex - 1].HitObject.Progress;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -96,6 +96,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             }
 
             AccentColour.BindValueChanged(c => Colour = c.NewValue);
+
+            OnNewResult += onNewResult;
+            OnRevertResult += onRevertResult;
         }
 
         protected override void OnApply()
@@ -111,16 +114,19 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             Slidepath.Free();
         }
 
-        public void OnNewCheckpointResult(DrawableHitObject hitObject, JudgementResult result)
+        private void onNewResult(DrawableHitObject hitObject, JudgementResult result)
         {
             if (hitObject is not DrawableSlideCheckpoint checkpoint)
+                return;
+
+            if (!result.IsHit)
                 return;
 
             Slidepath.Progress = checkpoint.HitObject.Progress;
             Slidepath.UpdateChevronVisibility();
         }
 
-        public void OnRevertCheckpointResult(DrawableHitObject hitObject, JudgementResult result)
+        private void onRevertResult(DrawableHitObject hitObject, JudgementResult result)
         {
             var checkpoint = (DrawableSlideCheckpoint)hitObject;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -96,8 +96,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             }
 
             AccentColour.BindValueChanged(c => Colour = c.NewValue);
-            OnNewResult += updateSlideCompletion;
-            OnRevertResult += updateSlideCompletion;
         }
 
         protected override void OnApply()
@@ -113,27 +111,22 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             Slidepath.Free();
         }
 
-        // Updates the path to have correct information of completion progress, then updates the visuals
-        private void updateSlideCompletion(DrawableHitObject hitObject, JudgementResult result)
+        public void OnNewCheckpointResult(DrawableHitObject hitObject, JudgementResult result)
         {
-            updateCompletionProgress();
+            if (hitObject is not DrawableSlideCheckpoint checkpoint)
+                return;
+
+            Slidepath.Progress = checkpoint.HitObject.Progress;
             Slidepath.UpdateChevronVisibility();
         }
 
-        // Used to hide and show segments accurately
-        private void updateCompletionProgress()
+        public void OnRevertCheckpointResult(DrawableHitObject hitObject, JudgementResult result)
         {
-            float progress = 0;
+            var checkpoint = (DrawableSlideCheckpoint)hitObject;
 
-            for (int i = 0; i < SlideCheckpoints.Count; ++i)
-            {
-                if (!SlideCheckpoints[i].Result.IsHit)
-                    break;
+            Slidepath.Progress = checkpoint.ThisIndex == 0 ? 0 : SlideCheckpoints[checkpoint.ThisIndex - 1].HitObject.Progress;
 
-                progress = SlideCheckpoints[i].HitObject.Progress;
-            }
-
-            Slidepath.Progress = progress;
+            Slidepath.UpdateChevronVisibility();
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
@@ -61,6 +61,17 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             // Nodes are applied before being added to the parent playfield, so this node isn't in SlideNodes yet
             // Since we know that the node isn't in the container yet, and that the count is always one higher than the topmost element, we can use that as the predicted index
             ThisIndex = parentSlide.SlideCheckpoints.Count;
+
+            OnNewResult += parentSlide.OnNewCheckpointResult;
+            OnRevertResult += parentSlide.OnRevertCheckpointResult;
+        }
+
+        protected override void OnFree()
+        {
+            base.OnFree();
+
+            OnNewResult -= parentSlide.OnNewCheckpointResult;
+            OnRevertResult -= parentSlide.OnRevertCheckpointResult;
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
@@ -61,17 +61,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             // Nodes are applied before being added to the parent playfield, so this node isn't in SlideNodes yet
             // Since we know that the node isn't in the container yet, and that the count is always one higher than the topmost element, we can use that as the predicted index
             ThisIndex = parentSlide.SlideCheckpoints.Count;
-
-            OnNewResult += parentSlide.OnNewCheckpointResult;
-            OnRevertResult += parentSlide.OnRevertCheckpointResult;
-        }
-
-        protected override void OnFree()
-        {
-            base.OnFree();
-
-            OnNewResult -= parentSlide.OnNewCheckpointResult;
-            OnRevertResult -= parentSlide.OnRevertCheckpointResult;
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)


### PR DESCRIPTION
In https://github.com/ppy/osu/pull/22291, the revert logic has been moved from the `DrawableHitObject` to the `Playfield`. In the process, DHOs no longer respond to reverts of nested HitObjects, causing the SlideBody to not update its visuals when SlideCheckpoints are reverted.

This PR manually adds back that functionality, along with a minor simplification to avoid iterating through all checkpoints to find the correct reset progress.

Related issue: https://github.com/ppy/osu/issues/23069