### PR TITLE
Ignore Touch hit attempts before the early Perfect window

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public override bool HandlePositionalInput => true;
 
         // This HitObject uses a completely different offset
-        protected override double InitialLifetimeOffset => base.InitialLifetimeOffset + HitObject.HitWindows.WindowFor(HitResult.Ok);
+        protected override double InitialLifetimeOffset => base.InitialLifetimeOffset + HitObject.HitWindows.WindowFor(HitResult.Great);
 
         // Similar to IsHovered for mouse, this tracks whether a pointer (touch or mouse) is interacting with this drawable
         // Interaction == (IsHovered && ActionPressed) || (OnTouch && TouchPointerInBounds)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -108,11 +108,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             var result = HitObject.HitWindows.ResultFor(timeOffset);
 
+            // This is hit before any hit window
             if (result == HitResult.None)
                 return;
 
-            if (timeOffset < 0)
-                result = Result.Judgement.MaxResult;
+            // Hit before the early Great window
+            if (timeOffset < 0 && result is not HitResult.Great)
+                return;
 
             ApplyResult(result);
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -80,11 +80,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.UpdateInitialTransforms();
             double fadeIn = AdjustedAnimationDuration / 2;
-            double moveTo = HitObject.HitWindows.WindowFor(HitResult.Ok);
+            double moveTo = HitObject.HitWindows.WindowFor(HitResult.Great);
 
             TouchBody.FadeIn(fadeIn);
 
-            using (BeginDelayedSequence(AdjustedAnimationDuration))
+            using (BeginAbsoluteSequence(HitObject.StartTime - moveTo))
             {
                 TouchBody.ResizeTo(90, moveTo, Easing.InCirc);
                 TouchBody.BorderContainer.Delay(moveTo).FadeIn();

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiHitObjectLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiHitObjectLifetimeEntry.cs
@@ -8,7 +8,12 @@ namespace osu.Game.Rulesets.Sentakki.UI
 {
     public class SentakkiHitObjectLifetimeEntry : HitObjectLifetimeEntry
     {
-        protected override double InitialLifetimeOffset => initialLifetimeOffsetFor(HitObject);
+        protected override double InitialLifetimeOffset
+            => HitObject switch
+            {
+                Touch => AdjustedAnimationDuration + HitObject.HitWindows.WindowFor(HitResult.Great),
+                _ => AdjustedAnimationDuration
+            };
 
         private readonly DrawableSentakkiRuleset drawableRuleset;
 
@@ -41,18 +46,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 case TouchHold:
                     sentakkiConfigs?.BindWith(SentakkiRulesetSettings.TouchAnimationDuration, AnimationDurationBindable);
                     break;
-            }
-        }
-
-        private double initialLifetimeOffsetFor(HitObject hitObject)
-        {
-            switch (hitObject)
-            {
-                case Touch:
-                    return AdjustedAnimationDuration + HitObject.HitWindows.WindowFor(HitResult.Ok);
-
-                default:
-                    return AdjustedAnimationDuration;
             }
         }
     }


### PR DESCRIPTION
Ignore Touch hit attempts before the early Perfect window

Previously any non-miss results would've been counted as a perfect if it was made early. This is not really good as the hit windows of Touches are much larger than any other note type. Hopefully this would make it less likely that an accidental hit was made too early, which feels bad. 

The "closing-in" animation of touches have been adjusted to only happen once it is possible to hit the Touch note.

<sub>This behavior also matches what maimaiDX does, so a plus in terms of maimai player expectation as well</sub>