### PR TITLE
Fix valid slide part list being corrupted when using mirror mod

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModMirror.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModMirror.cs
@@ -56,8 +56,10 @@ namespace osu.Game.Rulesets.Sentakki.Mods
                 {
                     foreach (var slideInfo in slide.SlideInfoList)
                     {
-                        foreach (var part in slideInfo.SlidePathParts)
+
+                        for (int i = 0; i < slideInfo.SlidePathParts.Length; ++i)
                         {
+                            var part = slideInfo.SlidePathParts[i];
                             part.EndOffset = (part.EndOffset * -1).NormalizePath();
                             part.Mirrored ^= mirrored;
                         }

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModMirror.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModMirror.cs
@@ -56,10 +56,9 @@ namespace osu.Game.Rulesets.Sentakki.Mods
                 {
                     foreach (var slideInfo in slide.SlideInfoList)
                     {
-
                         for (int i = 0; i < slideInfo.SlidePathParts.Length; ++i)
                         {
-                            var part = slideInfo.SlidePathParts[i];
+                            ref var part = ref slideInfo.SlidePathParts[i];
                             part.EndOffset = (part.EndOffset * -1).NormalizePath();
                             part.Mirrored ^= mirrored;
                         }

--- a/osu.Game.Rulesets.Sentakki/Objects/SlidePathPart.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlidePathPart.cs
@@ -1,8 +1,6 @@
-using System;
-
 namespace osu.Game.Rulesets.Sentakki.Objects
 {
-    public class SlideBodyPart : IEquatable<SlideBodyPart>
+    public record struct SlideBodyPart
     {
         public SlidePaths.PathShapes Shape { get; private set; }
         public int EndOffset { get; set; }
@@ -14,11 +12,5 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             EndOffset = endOffset;
             Mirrored = mirrored;
         }
-
-        public override bool Equals(object? obj) => obj is not null && obj is SlideBodyPart otherPart && Equals(otherPart);
-
-        public bool Equals(SlideBodyPart? other) => other is not null && (ReferenceEquals(this, other) || (Shape == other.Shape && EndOffset == other.EndOffset));
-
-        public override int GetHashCode() => HashCode.Combine(Shape, EndOffset, Mirrored);
     }
 }


### PR DESCRIPTION
`SlidePaths` precomputes a bunch of valid paths parts to be used in beatmap conversions. The converted maps will use the parts when creating slides.

The mirrored mod would then adjust the `EndOffset` and `Mirrored` properties so that it actually gets mirrored.

The problem is that `SlideBodyPart` is a class, which meant that adjustments to a part's properties that will affect the original copy within the valid path listing, causing problems in future map conversions.

Now `SlideBodyPart` is a struct, which is copy-on-use, avoiding the problem.