### PR TITLE
Refactor AnimationSpeed related stuff

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Configuration/SentakkiRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Sentakki/Configuration/SentakkiRulesetConfigManager.cs
@@ -1,4 +1,6 @@
-﻿using osu.Game.Configuration;
+﻿using osu.Framework.Configuration.Tracking;
+using osu.Framework.Localisation;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Configuration;
 
 namespace osu.Game.Rulesets.Sentakki.Configuration
@@ -24,6 +26,30 @@ namespace osu.Game.Rulesets.Sentakki.Configuration
             SetDefault(SentakkiRulesetSettings.SnakingSlideBody, true);
             SetDefault(SentakkiRulesetSettings.DetailedJudgements, false);
             SetDefault(SentakkiRulesetSettings.BreakSampleVolume, 1d, 0d, 1d, 0.01f);
+        }
+
+        public override TrackedSettings CreateTrackedSettings() => new TrackedSettings
+        {
+            new TrackedSetting<double>(SentakkiRulesetSettings.AnimationDuration, t => new SettingDescription(
+                rawValue: t,
+                name: "Note animation speed",
+                value: generateNoteSpeedDescription(t)
+            ))
+        };
+
+        private string generateNoteSpeedDescription(double time)
+        {
+            string speedRating()
+            {
+                double speed = (2200 - time) / 200;
+
+                if (speed == 10.5)
+                    return "Sonic";
+
+                return speed.ToString();
+            }
+
+            return $"{time:N0}ms ({speedRating()})";
         }
     }
 

--- a/osu.Game.Rulesets.Sentakki/Extensions/BindableExtensions.cs
+++ b/osu.Game.Rulesets.Sentakki/Extensions/BindableExtensions.cs
@@ -1,0 +1,17 @@
+using osu.Framework.Bindables;
+
+namespace osu.Game.Rulesets.Sentakki.Extensions;
+
+public static class BindableExtensions
+{
+    /// <summary>
+    /// Attempts to bind <paramref name="bindable"/> to <paramref name="other"/>, but does nothing if <paramref name="other"/> is null.
+    /// </summary>
+    public static void TryBindTo<T>(this Bindable<T> bindable, Bindable<T>? other)
+    {
+        if (other is null)
+            return;
+
+        bindable.BindTo(other);
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();
-            double animTime = AdjustedAnimationDuration / 2;
+            double animTime = AnimationDuration.Value / 2;
             NoteBody.FadeInFromZero(animTime).ScaleTo(1, animTime);
 
             NoteBody.FadeColour(AccentColour.Value);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             base.UpdateHitStateTransforms(state);
-            const double time_fade_miss = 400;
+            double time_fade_miss = 400 * (DrawableSentakkiRuleset?.GameplaySpeed ?? 1);
 
             switch (state)
             {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
     public partial class DrawableSentakkiHitObject : DrawableHitObject<SentakkiHitObject>
     {
-        protected override double InitialLifetimeOffset => AdjustedAnimationDuration;
+        protected override double InitialLifetimeOffset => AnimationDuration.Value;
 
         public readonly BindableBool AutoBindable = new BindableBool();
 
@@ -36,11 +36,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         }
 
         [Resolved]
-        private DrawableSentakkiRuleset? drawableSentakkiRuleset { get; set; }
-
-        public double GameplaySpeed => drawableSentakkiRuleset?.GameplaySpeed ?? 1;
-
-        protected double AdjustedAnimationDuration => AnimationDuration.Value * GameplaySpeed;
+        protected DrawableSentakkiRuleset? DrawableSentakkiRuleset { get; set; }
 
         protected override void LoadAsyncComplete()
         {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         }
 
         [Resolved]
-        protected DrawableSentakkiRuleset? DrawableSentakkiRuleset { get; set; }
+        protected DrawableSentakkiRuleset? DrawableSentakkiRuleset { get; private set; }
 
         protected override void LoadAsyncComplete()
         {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiJudgement.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiJudgement.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.Configuration;
+using osu.Game.Rulesets.Sentakki.UI;
 using osuTK;
 using osuTK.Graphics;
 
@@ -28,8 +29,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         private readonly BindableBool detailedJudgements = new BindableBool();
 
+        [Resolved]
+        private DrawableSentakkiRuleset drawableRuleset { get; set; } = null!;
+
         [BackgroundDependencyLoader]
-        private void load(SentakkiRulesetConfigManager? sentakkiConfigs)
+        private void load(SentakkiRulesetConfigManager sentakkiConfigs)
         {
             sentakkiConfigs?.BindWith(SentakkiRulesetSettings.DetailedJudgements, detailedJudgements);
 
@@ -116,13 +120,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         private void applyHitAnimations()
         {
-            judgementBody.ScaleTo(1, 50, Easing.OutElastic);
+            double speedFactor = drawableRuleset.GameplaySpeed;
+            judgementBody.ScaleTo(1, 50 * speedFactor, Easing.OutElastic);
 
-            judgementBody.Delay(50)
-                         .ScaleTo(0.8f, 300)
-                         .FadeOut(300);
+            judgementBody.Delay(50 * speedFactor)
+                         .ScaleTo(0.8f, 300 * speedFactor)
+                         .FadeOut(300 * speedFactor);
 
-            this.Delay(350).Expire();
+            this.Delay(350 * speedFactor).Expire();
         }
 
         private partial class SentakkiJudgementPiece : DefaultJudgementPiece

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiLanedHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiLanedHitObject.cs
@@ -39,7 +39,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 breakSample = new PausableSkinnableSound(),
             });
 
-            sentakkiConfig?.BindWith(SentakkiRulesetSettings.AnimationDuration, AnimationDuration);
+            if (DrawableSentakkiRuleset is not null)
+                AnimationDuration.BindTo(DrawableSentakkiRuleset?.AdjustedAnimDuration);
+
             sentakkiConfig?.BindWith(SentakkiRulesetSettings.BreakSampleVolume, breakSample.Volume);
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -212,19 +212,20 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             base.UpdateHitStateTransforms(state);
-            const double time_fade_miss = 400 /* time_fade_miss = 400 */;
+            double time_fade_miss = 400 * (DrawableSentakkiRuleset?.GameplaySpeed ?? 1);
+            double time_fade_hit = 200 * (DrawableSentakkiRuleset?.GameplaySpeed ?? 1);
 
             switch (state)
             {
                 case ArmedState.Hit:
                     using (BeginAbsoluteSequence(Math.Max(Result.TimeAbsolute, HitObject.GetEndTime() - HitObject.HitWindows.WindowFor(HitResult.Good))))
                     {
-                        Slidepath.PerformExitAnimation(200);
+                        Slidepath.PerformExitAnimation(time_fade_hit);
 
                         foreach (var star in SlideStars)
-                            star.FadeOut(200);
+                            star.FadeOut(time_fade_hit);
 
-                        this.FadeOut(200).Expire();
+                        this.FadeOut(time_fade_hit).Expire();
                     }
 
                     break;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -139,7 +139,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();
-            Slidepath.PerformEntryAnimation(AdjustedAnimationDuration);
+            Slidepath.PerformEntryAnimation(AnimationDuration.Value);
 
             using (BeginAbsoluteSequence(HitObject.StartTime - 50))
             {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideTap.cs
@@ -22,13 +22,15 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.UpdateInitialTransforms();
 
+            const double baseline_spin_duration = 250;
+
             var note = (SlideTapPiece)TapVisual;
 
-            double spinDuration = 0;
+            double spinDuration = baseline_spin_duration * (DrawableSentakkiRuleset?.GameplaySpeed ?? 1);
 
             if (ParentHitObject is DrawableSlide slide)
             {
-                spinDuration = ((Slide)slide.HitObject).SlideInfoList.FirstOrDefault()?.Duration ?? 1000;
+                spinDuration += ((Slide)slide.HitObject).SlideInfoList.FirstOrDefault()?.Duration ?? 1000;
                 note.SecondStar.Alpha = slide.SlideBodies.Count > 1 ? 1 : 0;
             }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             base.UpdateHitStateTransforms(state);
-            const double time_fade_miss = 400;
+            double time_fade_miss = 400 * (DrawableSentakkiRuleset?.GameplaySpeed ?? 1);
 
             switch (state)
             {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();
-            double animTime = AdjustedAnimationDuration / 2;
+            double animTime = AnimationDuration.Value / 2;
             TapVisual.FadeInFromZero(animTime).ScaleTo(1, animTime);
 
             using (BeginDelayedSequence(animTime))

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -123,14 +123,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             base.UpdateHitStateTransforms(state);
-            const double time_fade_hit = 100, time_fade_miss = 400;
+            double time_fade_miss = 400 * (DrawableSentakkiRuleset?.GameplaySpeed ?? 1);
 
             switch (state)
             {
                 case ArmedState.Hit:
-                    TouchBody.FadeOut();
-                    this.Delay(time_fade_hit).Expire();
-
+                    Expire();
                     break;
 
                 case ArmedState.Miss:

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -40,9 +40,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load(SentakkiRulesetConfigManager? sentakkiConfigs)
+        private void load()
         {
-            sentakkiConfigs?.BindWith(SentakkiRulesetSettings.TouchAnimationDuration, AnimationDuration);
+            if (DrawableSentakkiRuleset is not null)
+                AnimationDuration.BindTo(DrawableSentakkiRuleset?.AdjustedTouchAnimDuration);
 
             Size = new Vector2(105);
             Origin = Anchor.Centre;
@@ -79,7 +80,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();
-            double fadeIn = AdjustedAnimationDuration / 2;
+            double fadeIn = AnimationDuration.Value / 2;
             double moveTo = HitObject.HitWindows.WindowFor(HitResult.Great);
 
             TouchBody.FadeIn(fadeIn);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -163,12 +163,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             base.UpdateHitStateTransforms(state);
-            const double time_fade_hit = 100, time_fade_miss = 400;
+            double time_fade_miss = 400 * (DrawableSentakkiRuleset?.GameplaySpeed ?? 1);
 
             switch (state)
             {
                 case ArmedState.Hit:
-                    this.Delay(time_fade_hit).Expire();
+                    Expire();
                     break;
 
                 case ArmedState.Miss:

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();
-            double fadeIn = AdjustedAnimationDuration;
+            double fadeIn = AnimationDuration.Value;
             this.FadeInFromZero(fadeIn).ScaleTo(1, fadeIn);
 
             using (BeginDelayedSequence(fadeIn))

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldBody.cs
@@ -26,27 +26,5 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                 centrePiece = new TouchHoldCentrePiece(),
             };
         }
-
-        private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
-
-        [BackgroundDependencyLoader]
-        private void load(DrawableHitObject drawableObject)
-        {
-            drawableObject.ApplyCustomUpdateState += updateState;
-        }
-
-        private void updateState(DrawableHitObject drawableObject, ArmedState state)
-        {
-            using (BeginAbsoluteSequence(drawableObject.HitStateUpdateTime))
-            {
-                switch (state)
-                {
-                    case ArmedState.Hit:
-                        ProgressPiece.FadeOut();
-                        centrePiece.FadeOut();
-                        break;
-                }
-            }
-        }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
@@ -1,3 +1,4 @@
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -18,7 +19,10 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
         private readonly CircularContainer circle;
 
         private const float default_explosion_size = 75;
-        private const float touch_hold_explosion_size = 110;
+        private const float touch_hold_explosion_size = 100;
+
+        [Resolved]
+        private DrawableSentakkiRuleset? drawableRuleset { get; set; }
 
         public HitExplosion()
         {
@@ -97,13 +101,15 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
         {
             const double explode_duration = 100;
 
+            double adjustedExplodeDuration = explode_duration * (drawableRuleset?.GameplaySpeed ?? 1);
+
             var sequence = this.FadeIn()
                                .TransformBindableTo(borderRatio, 1)
                                .ScaleTo(1)
                                .Then()
-                               .TransformBindableTo(borderRatio, 0f, explode_duration)
-                               .ScaleTo(2f, explode_duration)
-                               .FadeOut(explode_duration);
+                               .TransformBindableTo(borderRatio, 0f, adjustedExplodeDuration)
+                               .ScaleTo(2f, adjustedExplodeDuration)
+                               .FadeOut(adjustedExplodeDuration);
 
             return sequence;
         }

--- a/osu.Game.Rulesets.Sentakki/UI/Components/HitObjectLine/DrawableLine.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/HitObjectLine/DrawableLine.cs
@@ -3,7 +3,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.UserInterface;
-using osu.Game.Rulesets.Sentakki.Configuration;
+using osu.Game.Rulesets.Sentakki.Extensions;
 using osuTK;
 
 namespace osu.Game.Rulesets.Sentakki.UI.Components.HitObjectLine
@@ -27,9 +27,9 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components.HitObjectLine
         private readonly BindableDouble animationDuration = new BindableDouble(1000);
 
         [BackgroundDependencyLoader]
-        private void load(SentakkiRulesetConfigManager? sentakkiConfigs)
+        private void load(DrawableSentakkiRuleset? drawableRuleset)
         {
-            sentakkiConfigs?.BindWith(SentakkiRulesetSettings.AnimationDuration, animationDuration);
+            animationDuration.TryBindTo(drawableRuleset?.AdjustedAnimDuration);
             animationDuration.BindValueChanged(_ => resetAnimation());
 
             AddInternal(line = new CircularProgress
@@ -60,8 +60,8 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components.HitObjectLine
 
             ApplyTransformsAt(double.MinValue);
             ClearTransforms();
-            using (BeginAbsoluteSequence(Entry.StartTime - Entry.AdjustedAnimationDuration))
-                this.FadeIn(Entry.AdjustedAnimationDuration / 2).Then().ScaleTo(1, Entry.AdjustedAnimationDuration / 2).Then().FadeOut();
+            using (BeginAbsoluteSequence(Entry.StartTime - animationDuration.Value))
+                this.FadeIn(animationDuration.Value / 2).Then().ScaleTo(1, animationDuration.Value / 2).Then().FadeOut();
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/Components/HitObjectLine/LineLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/HitObjectLine/LineLifetimeEntry.cs
@@ -7,26 +7,22 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Performance;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osuTK.Graphics;
+using osu.Game.Rulesets.Sentakki.Extensions;
 
 namespace osu.Game.Rulesets.Sentakki.UI.Components.HitObjectLine
 {
     public class LineLifetimeEntry : LifetimeEntry
     {
         private readonly BindableDouble animationDuration = new BindableDouble(1000);
-        public double AdjustedAnimationDuration => animationDuration.Value * GameplaySpeed;
-
-        public double GameplaySpeed => drawableRuleset?.GameplaySpeed ?? 1;
-
-        private readonly DrawableSentakkiRuleset? drawableRuleset;
 
         public double StartTime { get; private set; }
 
-        public LineLifetimeEntry(BindableDouble animationDuration, DrawableSentakkiRuleset? drawableSentakkiRuleset, double startTime)
+        public LineLifetimeEntry(DrawableSentakkiRuleset? drawableSentakkiRuleset, double startTime)
         {
             StartTime = startTime;
-            drawableRuleset = drawableSentakkiRuleset;
-            this.animationDuration.BindTo(animationDuration);
-            this.animationDuration.BindValueChanged(refreshLifetime, true);
+
+            animationDuration.TryBindTo(drawableSentakkiRuleset?.AdjustedAnimDuration);
+            animationDuration.BindValueChanged(refreshLifetime, true);
         }
 
         public List<SentakkiLanedHitObject> HitObjects = new List<SentakkiLanedHitObject>();
@@ -90,7 +86,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components.HitObjectLine
 
         private void refreshLifetime(ValueChangedEvent<double> valueChangedEvent)
         {
-            LifetimeStart = StartTime - AdjustedAnimationDuration;
+            LifetimeStart = StartTime - valueChangedEvent.NewValue;
             LifetimeEnd = StartTime;
         }
 

--- a/osu.Game.Rulesets.Sentakki/UI/Components/HitObjectLine/LineRenderer.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/HitObjectLine/LineRenderer.cs
@@ -30,16 +30,12 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components.HitObjectLine
             lifetimeManager.EntryBecameDead += onEntryBecameDead;
         }
 
-        private readonly BindableDouble animationDuration = new BindableDouble(1000);
-
         [Resolved]
         private DrawableSentakkiRuleset? drawableRuleset { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(SentakkiRulesetConfigManager? sentakkiConfigs)
+        private void load()
         {
-            sentakkiConfigs?.BindWith(SentakkiRulesetSettings.AnimationDuration, animationDuration);
-
             AddInternal(linePool = new DrawablePool<DrawableLine>(5));
         }
 
@@ -120,7 +116,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components.HitObjectLine
             // Create new line entry for this entryTime if none exists
             if (!lineEntries.ContainsKey(entryTime))
             {
-                var newEntry = new LineLifetimeEntry(animationDuration, drawableRuleset, entryTime);
+                var newEntry = new LineLifetimeEntry(drawableRuleset, entryTime);
                 lineEntries[entryTime] = newEntry;
                 lifetimeManager.AddEntry(newEntry);
 

--- a/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
@@ -17,11 +17,14 @@ using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
+using osu.Framework.Input.Bindings;
+using osu.Game.Input.Bindings;
 
 namespace osu.Game.Rulesets.Sentakki.UI
 {
     [Cached]
-    public partial class DrawableSentakkiRuleset : DrawableRuleset<SentakkiHitObject>
+    public partial class DrawableSentakkiRuleset : DrawableRuleset<SentakkiHitObject>, IKeyBindingHandler<GlobalAction>
     {
         private SlideFanChevrons slideFanChevronsTextures = null!;
 
@@ -60,7 +63,11 @@ namespace osu.Game.Rulesets.Sentakki.UI
             smoothTouchAnimDuration = configTouchAnimDuration.Value;
         }
 
-        private readonly Bindable<double> configAnimDuration = new Bindable<double>(1000);
+        private readonly Bindable<double> configAnimDuration = new BindableDouble(1000)
+        {
+            MinValue = 100,
+            MaxValue = 2000,
+        };
         private double smoothAnimDuration = 1000;
         public readonly Bindable<double> AdjustedAnimDuration = new Bindable<double>(1000);
 
@@ -80,6 +87,22 @@ namespace osu.Game.Rulesets.Sentakki.UI
             AdjustedTouchAnimDuration.Value = smoothTouchAnimDuration * speedAdjustmentTrack.AggregateTempo.Value * speedAdjustmentTrack.AggregateFrequency.Value;
         }
 
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            switch (e.Action)
+            {
+                case GlobalAction.DecreaseScrollSpeed:
+                    configAnimDuration.Value -= 100;
+                    return true;
+                case GlobalAction.IncreaseScrollSpeed:
+                    configAnimDuration.Value += 100;
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e) { }
 
         // Gameplay speed specifics
         private readonly Track speedAdjustmentTrack = new TrackVirtual(0);

--- a/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/DrawableSentakkiRuleset.cs
@@ -83,8 +83,8 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
         private void updateAnimationDurations()
         {
-            AdjustedAnimDuration.Value = smoothAnimDuration * speedAdjustmentTrack.AggregateTempo.Value * speedAdjustmentTrack.AggregateFrequency.Value;
-            AdjustedTouchAnimDuration.Value = smoothTouchAnimDuration * speedAdjustmentTrack.AggregateTempo.Value * speedAdjustmentTrack.AggregateFrequency.Value;
+            AdjustedAnimDuration.Value = smoothAnimDuration * GameplaySpeed;
+            AdjustedTouchAnimDuration.Value = smoothTouchAnimDuration * GameplaySpeed;
         }
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)

--- a/osu.Game.Rulesets.Sentakki/UI/Lane.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Lane.cs
@@ -41,9 +41,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
         [Resolved]
         private DrawableSentakkiRuleset drawableSentakkiRuleset { get; set; } = null!;
 
-        [Resolved]
-        private SentakkiRulesetConfigManager? sentakkiRulesetConfig { get; set; }
-
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -64,7 +61,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
         protected override void OnNewDrawableHitObject(DrawableHitObject d) => OnLoaded?.Invoke(d);
 
-        protected override HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject) => new SentakkiHitObjectLifetimeEntry(hitObject, sentakkiRulesetConfig, drawableSentakkiRuleset);
+        protected override HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject) => new SentakkiHitObjectLifetimeEntry(hitObject, drawableSentakkiRuleset);
 
         #region Input Handling
 

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiHitObjectLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiHitObjectLifetimeEntry.cs
@@ -1,7 +1,6 @@
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Objects;
 
 namespace osu.Game.Rulesets.Sentakki.UI

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiHitObjectLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiHitObjectLifetimeEntry.cs
@@ -11,24 +11,17 @@ namespace osu.Game.Rulesets.Sentakki.UI
         protected override double InitialLifetimeOffset
             => HitObject switch
             {
-                Touch => AdjustedAnimationDuration + HitObject.HitWindows.WindowFor(HitResult.Great),
-                _ => AdjustedAnimationDuration
+                Touch => AnimationDurationBindable.Value + HitObject.HitWindows.WindowFor(HitResult.Great),
+                _ => AnimationDurationBindable.Value
             };
 
         private readonly DrawableSentakkiRuleset drawableRuleset;
 
-        public double GameplaySpeed => drawableRuleset?.GameplaySpeed ?? 1;
-
         public BindableDouble AnimationDurationBindable = new BindableDouble(1000);
 
-        protected double AdjustedAnimationDuration => AnimationDurationBindable.Value * GameplaySpeed;
-
-        private readonly SentakkiRulesetConfigManager? sentakkiConfigs;
-
-        public SentakkiHitObjectLifetimeEntry(HitObject hitObject, SentakkiRulesetConfigManager? configManager, DrawableSentakkiRuleset senRuleset)
+        public SentakkiHitObjectLifetimeEntry(HitObject hitObject, DrawableSentakkiRuleset senRuleset)
             : base(hitObject)
         {
-            sentakkiConfigs = configManager;
             drawableRuleset = senRuleset;
             bindAnimationDuration();
             AnimationDurationBindable.BindValueChanged(x => LifetimeStart = HitObject.StartTime - InitialLifetimeOffset, true);
@@ -39,12 +32,12 @@ namespace osu.Game.Rulesets.Sentakki.UI
             switch (HitObject)
             {
                 case SentakkiLanedHitObject:
-                    sentakkiConfigs?.BindWith(SentakkiRulesetSettings.AnimationDuration, AnimationDurationBindable);
+                    AnimationDurationBindable.BindTo(drawableRuleset.AdjustedAnimDuration);
                     break;
 
                 case Touch:
                 case TouchHold:
-                    sentakkiConfigs?.BindWith(SentakkiRulesetSettings.TouchAnimationDuration, AnimationDurationBindable);
+                    AnimationDurationBindable.BindTo(drawableRuleset.AdjustedTouchAnimDuration);
                     break;
             }
         }

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
             ringColor.BindValueChanged(_ => changePlayfieldAccent(), true);
         }
 
-        protected override HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject) => new SentakkiHitObjectLifetimeEntry(hitObject, sentakkiRulesetConfig, drawableSentakkiRuleset);
+        protected override HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject) => new SentakkiHitObjectLifetimeEntry(hitObject, drawableSentakkiRuleset);
 
         protected override GameplayCursorContainer CreateCursor() => new SentakkiCursorContainer();
 

--- a/osu.Game.Rulesets.Sentakki/UI/TouchPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/TouchPlayfield.cs
@@ -28,16 +28,13 @@ namespace osu.Game.Rulesets.Sentakki.UI
         [Resolved]
         private DrawableSentakkiRuleset drawableSentakkiRuleset { get; set; } = null!;
 
-        [Resolved]
-        private SentakkiRulesetConfigManager? sentakkiRulesetConfig { get; set; }
-
         [BackgroundDependencyLoader]
         private void load()
         {
             RegisterPool<Touch, DrawableTouch>(8);
         }
 
-        protected override HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject) => new SentakkiHitObjectLifetimeEntry(hitObject, sentakkiRulesetConfig, drawableSentakkiRuleset);
+        protected override HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject) => new SentakkiHitObjectLifetimeEntry(hitObject, drawableSentakkiRuleset);
 
         protected override HitObjectContainer CreateHitObjectContainer() => new TouchHitObjectContainer();
 


### PR DESCRIPTION
Previously, `AdjustedAnimationSpeed` was computed within `DrawableSentakkiHitObject`, `SentakkiHitObjectLifetimeEntry` and `LineLifetimeEntry`. Now this calculation is done centrally within `DrawableSentakkiRuleset`, with each of the mentioned above binding to the bindables provided by it, instead of directly to the config values.

Since `DrawableRuleset` is guaranteed to be alive during gameplay, we can actually easy recompute the AnimationSpeed every update to compensate for rate-adjusting mods like `ModWindUp` or `ModAdaptiveSpeed`, resulting in the animation speeds being consistent throughout. (LifetimeEntries aren't drawables, so they can't spontaneously update; DHO's aren't always on screen, so they can only update if they are present)

**__Bonus changes__**
* When adjusting the animation speed configs, gameplay will smoothly transition to the new value.
* Judgements, HitExplosions and the SlideTap star also compensate for rate-adjust now.
* Players can change the laned note animation speed using the global scroll speed up/down bindings

<sub>The performance impact of refreshing transforms every frame seems negligible in my basic eyeballing. Profiling shows roughtly 400ms of CPU time over a 4 minute beatmap, which should only apply when using rate adjusting mods.</sub>
