### PR TITLE
Add Gori mod

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModGori.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModGori.cs
@@ -1,0 +1,46 @@
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Framework.Localisation;
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables;
+using osu.Framework.Graphics.Sprites;
+using System;
+using System.ComponentModel;
+
+namespace osu.Game.Rulesets.Sentakki.Mods;
+
+public class SentakkiModGori : Mod, IApplicableToDrawableHitObject
+{
+    public override string Name => "Gori";
+    public override string Acronym => "GR";
+
+    public override bool HasImplementation => true;
+    public override double ScoreMultiplier => 1;
+
+    public override IconUsage? Icon => FontAwesome.Solid.PooStorm;
+
+    public override Type[] IncompatibleMods => new Type[]{
+        typeof(ModAutoplay),
+    };
+
+    // TODO: LOCALISATION
+    public override LocalisableString Description => "You either hit it right, or you don't hit it at all.";
+
+    [SettingSource("Lowest valid hit result", "The minimum HitResult that is accepted during gameplay. Anything below will be considered a miss.")]
+    public Bindable<SentakkiHitResult> MaxHitResult { get; } = new Bindable<SentakkiHitResult>(SentakkiHitResult.Perfect);
+
+    public void ApplyToDrawableHitObject(DrawableHitObject drawable)
+    {
+        if (drawable is DrawableSentakkiHitObject d)
+            d.MinimumAcceptedHitResult = (HitResult)MaxHitResult.Value;
+    }
+
+    public enum SentakkiHitResult
+    {
+        Great = 4,
+        Perfect = 5,
+        [Description("Critical Perfect")] Critical = 6,
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -5,6 +5,8 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.UI;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Sentakki.Judgements;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
@@ -54,9 +56,28 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             AccentColour.BindTo(HitObject.ColourBindable);
         }
 
+        public HitResult MinimumAcceptedHitResult = HitResult.None;
+
         protected void ApplyResult(HitResult result)
         {
             void resultApplication(JudgementResult r) => r.Type = result;
+
+            // SentakkiModGori turns subpar judgements into misses
+            if (Result.Judgement is SentakkiJudgement)
+            {
+                if (MinimumAcceptedHitResult == HitResult.Perfect) // using the Perfect result to represent Crits
+                {
+                    double absTimeOffset = Math.Abs(Time.Current - HitObject.GetEndTime());
+
+                    if (absTimeOffset > 16)
+                        result = Result.Judgement.MinResult;
+                }
+                else if (result < MinimumAcceptedHitResult)
+                {
+                    result = Result.Judgement.MinResult;
+                }
+            }
+
             ApplyResult(resultApplication);
         }
 

--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -86,6 +86,7 @@ namespace osu.Game.Rulesets.Sentakki
                         new SentakkiModHardRock(),
                         new MultiMod(new SentakkiModSuddenDeath(), new SentakkiModPerfect()),
                         new MultiMod(new SentakkiModChallenge(), new SentakkiModAccuracyChallenge()),
+                        new SentakkiModGori(),
                         new MultiMod(new SentakkiModDoubleTime(), new SentakkiModNightcore()),
                         new SentakkiModHidden(),
                     };


### PR DESCRIPTION
This mod turns every HitResult below a chosen threshold into a miss, making subpar plays more punishing. (Similar to Gori judgement mode in maimai)

The minimum valid threshold can be either Greats, Perfects or Critical Perfects, and can be configured in the mod options.

This mod doesn't give a score boost, so it's purely for suffering.

<sub>Maybe I should name this mod Shitstorm 😛</sub>

<sub>Bloom todo: Make mod strings localisable</sub>