### PR TITLE
Proxy all slidebody stars above slide body

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -18,8 +18,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
     public partial class DrawableSlideBody : DrawableSentakkiLanedHitObject
     {
-        public override bool RemoveWhenNotAlive => false;
-
         private new DrawableSlide ParentHitObject => (DrawableSlide)base.ParentHitObject;
         public new SlideBody HitObject => (SlideBody)base.HitObject;
 
@@ -78,7 +76,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             AddRangeInternal(new Drawable[]
             {
                 Slidepath = new SlideVisual() { Colour = inactive_color },
-                SlideStars = new Container<StarPiece>
+                SlideStars = new ProxyableContainer<StarPiece>
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -287,6 +285,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.ClearNestedHitObjects();
             SlideCheckpoints.Clear(false);
+        }
+
+        private partial class ProxyableContainer<T> : Container<T> where T : Drawable
+        {
+            public override bool RemoveWhenNotAlive => false;
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/LanedPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/LanedPlayfield.cs
@@ -17,6 +17,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
         public readonly List<Lane> Lanes = new List<Lane>();
 
         private readonly SortedDrawableProxyContainer slideBodyProxyContainer;
+        private readonly SortedDrawableProxyContainer slideStarProxyContainer;
         private readonly SortedDrawableProxyContainer lanedNoteProxyContainer;
 
         public readonly LineRenderer HitObjectLineRenderer;
@@ -49,6 +50,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 chevronPool = new DrawablePool<SlideChevron>(100),
                 HitObjectLineRenderer = new LineRenderer(),
                 slideBodyProxyContainer = new SortedDrawableProxyContainer(),
+                slideStarProxyContainer = new SortedDrawableProxyContainer(),
                 LanedHitObjectArea = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -87,7 +89,8 @@ namespace osu.Game.Rulesets.Sentakki.UI
             switch (hitObject)
             {
                 case DrawableSlideBody s:
-                    slideBodyProxyContainer.Add(s.CreateProxy(), s);
+                    slideBodyProxyContainer.Add(s.Slidepath.CreateProxy(), s);
+                    slideStarProxyContainer.Add(s.SlideStars.CreateProxy(), s);
                     break;
 
                 case DrawableTap t:


### PR DESCRIPTION
This makes sure that even when slides overlap, the stars remain visible