### PR TITLE
Use Samples instead of NodeSamples in Slides

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Beatmaps/Converter/SentakkiBeatmapConverter.Slider.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/Converter/SentakkiBeatmapConverter.Slider.cs
@@ -73,7 +73,7 @@ public partial class SentakkiBeatmapConverter
             },
             Lane = lane.NormalizePath(),
             StartTime = original.StartTime,
-            NodeSamples = nodeSamples,
+            Samples = nodeSamples.FirstOrDefault(),
             Break = headBreak
         };
 

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverterOld.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverterOld.cs
@@ -310,7 +310,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                 },
                 Lane = noteLane,
                 StartTime = original.StartTime,
-                NodeSamples = samples,
+                Samples = samples.FirstOrDefault(),
                 Break = hasBreakHead
             };
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlide.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlide.cs
@@ -44,6 +44,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 }
             });
         }
+        protected override void LoadSamples()
+        {
+            // The slide parent object doesn't need a sample
+        }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {

--- a/osu.Game.Rulesets.Sentakki/Objects/Slide.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Slide.cs
@@ -27,8 +27,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             set => throw new NotSupportedException();
         }
 
-        public IList<IList<HitSampleInfo>> NodeSamples = new List<IList<HitSampleInfo>>();
-
         public double EndTime => StartTime + Duration;
 
         public override Color4 DefaultNoteColour => Color4.Aqua;
@@ -45,7 +43,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             {
                 LaneBindable = { BindTarget = LaneBindable },
                 StartTime = StartTime,
-                Samples = NodeSamples.Any() ? NodeSamples.First() : new List<HitSampleInfo>(),
+                Samples = Samples,
                 Break = Break,
                 Ex = Ex
             });


### PR DESCRIPTION
NodeSamples no longer has a purpose now that SlideBodies don't play samples anymore. 