### PR TITLE
Adjust slide body detection regions to be more lenient

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
@@ -34,9 +34,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             RelativeSizeAxes = Axes.None;
-            Size = new Vector2(150);
+            Size = new Vector2(200);
             CornerExponent = 2f;
-            CornerRadius = 75;
+            CornerRadius = 100;
         }
 
         protected override void OnApply()


### PR DESCRIPTION
A user noted that slides felt harder to play even on a Galaxy Ultra S9 (which is a big boy). This change makes things much easier, and I was able to play on a microscopic phone.

|Before|After|
|---|---|
|![image](https://github.com/LumpBloom7/sentakki/assets/12001167/973d71c8-bd9e-4924-a303-d1c65e2ac1f1)|![image](https://github.com/LumpBloom7/sentakki/assets/12001167/90beeb4b-4ef5-4841-a3e8-558ee9f57302)|

