### PR TITLE
Prevent HOLD notes from blocking input meant for future hitobjects

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -71,6 +71,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             base.OnFree();
             HoldStartTime = null;
             TotalHoldTime = 0;
+            pressedCount = 0;
         }
 
         protected override void UpdateInitialTransforms()
@@ -214,6 +215,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             HoldStartTime = null;
         }
 
+        // Tracks how many inputs are pressing on this HitObject currently
+        private int pressedCount = 0;
         public bool OnPressed(KeyBindingPressEvent<SentakkiAction> e)
         {
             if (AllJudged)
@@ -228,7 +231,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 NoteBody.FadeColour(AccentColour.Value, 50);
             }
 
-            return true;
+            // Only the first input to this hitobject will be blocked
+            if (pressedCount++ == 0)
+                return true;
+
+            // Passthrough excess inputs to later hitobjects in the same lane
+            return false;
         }
 
         public void OnReleased(KeyBindingReleaseEvent<SentakkiAction> e)
@@ -239,7 +247,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             if (e.Action != SentakkiAction.Key1 + HitObject.Lane)
                 return;
 
-            endHold();
+
+            // We only release the hold once ALL inputs are released
+            if (--pressedCount == 0)
+                endHold();
 
             if (!AllJudged)
                 NoteBody.FadeColour(Color4.Gray, 100);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -247,7 +247,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             if (e.Action != SentakkiAction.Key1 + HitObject.Lane)
                 return;
 
-
             // We only release the hold once ALL inputs are released
             if (--pressedCount == 0)
                 endHold();

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -200,6 +200,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         private bool beginHoldAt(double timeOffset)
         {
+            if (HoldStartTime is not null)
+                return false;
+
             if (timeOffset < -Head.HitObject.HitWindows.WindowFor(HitResult.Miss))
                 return false;
 
@@ -225,15 +228,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             if (e.Action != SentakkiAction.Key1 + HitObject.Lane)
                 return false;
 
+            pressedCount++;
+
             if (beginHoldAt(Time.Current - Head.HitObject.StartTime))
             {
                 Head.UpdateResult();
                 NoteBody.FadeColour(AccentColour.Value, 50);
-            }
-
-            // Only the first input to this hitobject will be blocked
-            if (pressedCount++ == 0)
                 return true;
+            }
 
             // Passthrough excess inputs to later hitobjects in the same lane
             return false;


### PR DESCRIPTION
This makes sure that TAPs underneath a HOLD can still be completed, if the HOLD is already being held down. Useful for UTAGE charts ported from maimai.