### PR TITLE
Expand lane sensor radius outside the ring

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/Lane.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Lane.cs
@@ -65,8 +65,11 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
         #region Input Handling
 
-        private const float receptor_angle_range = 45 * 1.4f;
+        private const float receptor_angle_range = 45;
         private const float receptor_angle_range_mid = receptor_angle_range / 2;
+
+        private const float receptor_angle_range_inner = receptor_angle_range * 1.4f;
+        private const float receptor_angle_range_inner_mid = receptor_angle_range_inner / 2;
 
         private SentakkiInputManager sentakkiActionInputManager = null!;
         internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= (SentakkiInputManager)GetContainingInputManager();
@@ -78,10 +81,12 @@ namespace osu.Game.Rulesets.Sentakki.UI
             var localPos = ToLocalSpace(screenSpacePos);
 
             float distance = Vector2.DistanceSquared(Vector2.Zero, localPos);
-            if (distance is < (200 * 200) or > (400 * 400)) return false;
+            if (distance is < (200 * 200) or > (600 * 600)) return false;
+
+            float targetAngleRangeMid = distance > 400 ? receptor_angle_range_mid : receptor_angle_range_inner_mid;
 
             float angleDelta = SentakkiExtensions.GetDeltaAngle(0, Vector2.Zero.GetDegreesFromPosition(localPos));
-            if (Math.Abs(angleDelta) > receptor_angle_range_mid) return false;
+            if (Math.Abs(angleDelta) > targetAngleRangeMid) return false;
 
             return true;
         }


### PR DESCRIPTION
This allows taps and holds to be hittable from further outside of the ring, as if the ring buttons are there.