### PR TITLE
Improve Hold release checks

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -225,7 +225,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             get
             {
                 int count = 0;
-                foreach (var pressedAction in sentakkiActionInputManager.PressedActions)
+                foreach (var pressedAction in SentakkiActionInputManager.PressedActions)
                 {
                     if (pressedAction == SentakkiAction.Key1 + HitObject.Lane)
                         ++count;


### PR DESCRIPTION
Holds will no longer release as long as the lane is pressed by something. This prevents the situation where the hold is released by an input that was pressed prior to the hold note existing.

Example scenario:
1. Finger one on lane 1
2. Hold note spawns
3. Finger two on lane 1, hold is pressed
4. Finger one off lane 1, hold is released despite finger two still being there