### PR TITLE
Award 100ms bonus hold time for holding until the end of a holdnote

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -106,7 +106,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             if (Time.Current > HitObject.GetEndTime())
             {
+                bool extendedHold = HoldStartTime is not null;
+
                 endHold();
+
+                TotalHoldTime += extendedHold ? 100 : 0;
+
                 double totalHoldRatio = TotalHoldTime / ((IHasDuration)HitObject).Duration;
                 HitResult result;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -106,11 +106,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             if (Time.Current > HitObject.GetEndTime())
             {
-                bool extendedHold = HoldStartTime is not null;
+                bool holdingAtEndTime = HoldStartTime is not null;
 
                 endHold();
 
-                TotalHoldTime += extendedHold ? 100 : 0;
+                // We award an extra 100ms hold time to encourage players to hold the note until the end
+                // This avoids the situation where a note is too short and is much harder to get a good judgement due to player reaction
+                TotalHoldTime += holdingAtEndTime ? 100 : 0;
 
                 double totalHoldRatio = TotalHoldTime / ((IHasDuration)HitObject).Duration;
                 HitResult result;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -144,6 +144,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             if (Time.Current < ((IHasDuration)HitObject).EndTime) return;
 
+            // We award an extra 100ms hold time to encourage players to hold the note until the end
+            // This avoids the situation where a note is too short and is much harder to get a good judgement due to player reaction
             if (isHitting.Value)
                 totalHoldTime += 100;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -144,6 +144,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             if (Time.Current < ((IHasDuration)HitObject).EndTime) return;
 
+            if (isHitting.Value)
+                totalHoldTime += 100;
+
             double result = totalHoldTime / ((IHasDuration)HitObject).Duration;
 
             HitResult resultType;


### PR DESCRIPTION
Some Hold/TouchHold notes are very short, short enough that the reaction time of players may make it hard to get a good judgements. 

In order to resolve this, 100ms of bonus time is awarded if the player is still holding the note upon its completion, this leniency is more effective/prominent the shorter the hold note is, while not contributing much on longer holds.
