### PR TITLE
Fix sample playback position issues

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         // Used for the animation update
         protected readonly Bindable<double> AnimationDuration = new Bindable<double>(1000);
 
-        protected override float SamplePlaybackPosition => Position.X / (SentakkiPlayfield.INTERSECTDISTANCE * 2);
+        protected override float SamplePlaybackPosition => (Position.X / (SentakkiPlayfield.INTERSECTDISTANCE * 2)) + 0.5f;
 
         public DrawableSentakkiHitObject()
             : this(null)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
     public partial class DrawableSlideBody : DrawableSentakkiLanedHitObject
     {
-        private new DrawableSlide ParentHitObject => (DrawableSlide)base.ParentHitObject;
+        public new DrawableSlide ParentHitObject => (DrawableSlide)base.ParentHitObject;
         public new SlideBody HitObject => (SlideBody)base.HitObject;
 
         // This slide body can only be interacted with iff the slidetap associated with this slide is judged

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
@@ -6,6 +6,7 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Sentakki.UI;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
@@ -20,6 +21,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         public override bool DisplayResult => false;
 
         private new DrawableSlideBody ParentHitObject => (DrawableSlideBody)base.ParentHitObject;
+        private int slideOriginLane => ParentHitObject.ParentHitObject.HitObject.Lane;
 
         // Used to determine the node order
         public int ThisIndex;
@@ -36,6 +38,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         private bool isPreviousNodeHit() => ThisIndex < trackingLookBehindDistance || ParentHitObject.SlideCheckpoints[ThisIndex - trackingLookBehindDistance].IsHit;
 
         private Container<DrawableSlideCheckpointNode> nodes = null!;
+
+        protected override float SamplePlaybackPosition => (SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, slideOriginLane).X / (SentakkiPlayfield.INTERSECTDISTANCE * 2)) + .5f;
 
         public DrawableSlideCheckpoint()
             : this(null)
@@ -70,7 +74,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
-            // Counting  hit notes manually to avoid LINQ alloc overhead
+            // Counting hit notes manually to avoid LINQ alloc overhead
             int hitNotes = 0;
 
             foreach (var node in nodes)


### PR DESCRIPTION
This ensures that Slide and Touch note samples aren't leaning to the left. (This is apparent when stereo sound separation is set higher)