### PR TITLE
Avoid punishing players for accurately following the star on slow Slides

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -198,6 +199,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     break;
                 }
             }
+
             if (!userTriggered)
             {
                 if (!HitObject.HitWindows.CanBeHit(timeOffset))
@@ -216,19 +218,20 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 return;
             }
 
+
+
             var result = HitObject.HitWindows.ResultFor(timeOffset);
 
-            if (timeOffset < 0)
-            {
-                // If the slide was completed before the early windows, just give an OK result
-                if (result == HitResult.None)
-                    result = HitResult.Ok;
+            // Give the player an OK for extremely early completion
+            // This is also a safegaurd for super late hits beyond the late windows, where the input may have occured prior to the late window being exceeded due to lag.
+            if (result == HitResult.None)
+                result = HitResult.Ok;
 
-                // Give a perfect result if the star is intersecting with the last node
-                // This is to preserve the expected invariant that following the star perfectly should guarantee a perfect judgement.
+            // Give a perfect result if the star is intersecting with the last node
+            // This is to preserve the expected invariant that following the star perfectly should guarantee a perfect judgement.
+            if (timeOffset < 0)
                 if ((1 - StarProgress) * Slidepath.Path.TotalDistance <= DrawableSlideCheckpointNode.DETECTION_RADIUS)
                     result = HitResult.Perfect;
-            }
 
             ApplyResult(result);
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -218,9 +218,17 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             var result = HitObject.HitWindows.ResultFor(timeOffset);
 
-            // If the slide was completed before the early windows, just give an OK result
-            if (result == HitResult.None)
-                result = HitResult.Ok;
+            if (timeOffset < 0)
+            {
+                // If the slide was completed before the early windows, just give an OK result
+                if (result == HitResult.None)
+                    result = HitResult.Ok;
+
+                // Give a perfect result if the star is intersecting with the last node
+                // This is to preserve the expected invariant that following the star perfectly should guarantee a perfect judgement.
+                if ((1 - StarProgress) * Slidepath.Path.TotalDistance <= DrawableSlideCheckpointNode.DETECTION_RADIUS)
+                    result = HitResult.Perfect;
+            }
 
             ApplyResult(result);
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
@@ -24,6 +24,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         private SentakkiInputManager sentakkiActionInputManager = null!;
         internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= ((SentakkiInputManager)GetContainingInputManager());
 
+        public const float DETECTION_RADIUS = 100;
+
         public DrawableSlideCheckpointNode()
             : this(null)
         {
@@ -35,9 +37,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             RelativeSizeAxes = Axes.None;
-            Size = new Vector2(200);
+            Size = new Vector2(DETECTION_RADIUS * 2);
             CornerExponent = 2f;
-            CornerRadius = 100;
+            CornerRadius = DETECTION_RADIUS;
         }
 
         protected override void OnApply()


### PR DESCRIPTION
This is another "anti-BS/What you see is what you get" measure to prevents players from being punished for following the Slide star visual. This issue was most noticable on slow Slides (such as the one at the end of Altale expert)

Slides will now give the player a perfect if the star intersects with the detection region of the last slide segment prior to reaching the end.