### PR TITLE
Fix judgement chart overcounting breaks

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Statistics/JudgementChart.cs
+++ b/osu.Game.Rulesets.Sentakki/Statistics/JudgementChart.cs
@@ -18,11 +18,12 @@ namespace osu.Game.Rulesets.Sentakki.Statistics
         private static readonly (string, Func<HitEvent, bool>)[] entries =
         {
             ("Tap", e => e.HitObject is Tap x && !x.Break),
-            ("Hold", e => (e.HitObject is Hold or Hold.HoldHead) && !((SentakkiLanedHitObject)e.HitObject).Break),
+            ("Hold", e => ((e.HitObject is Hold.HoldHead) && !((SentakkiLanedHitObject)e.HitObject).Break) || e.HitObject is Hold),
             ("Slide", e => e.HitObject is SlideBody x),
             ("Touch", e => e.HitObject is Touch),
             ("Touch Hold", e => e.HitObject is TouchHold),
-            ("Break", e => e.HitObject is SentakkiLanedHitObject x && x is not Hold && x.Break),
+            // Note Hold and Slide breaks are applied to child objects, not itself.
+            ("Break", e => e.HitObject is SentakkiLanedHitObject x && (x is not Hold) && (x is not Slide) && x.Break),
         };
 
         private readonly IReadOnlyList<HitEvent> hitEvents;

--- a/osu.Game.Rulesets.Sentakki/Statistics/JudgementChart.cs
+++ b/osu.Game.Rulesets.Sentakki/Statistics/JudgementChart.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Sentakki.Statistics
             ("Slide", e => e.HitObject is SlideBody x),
             ("Touch", e => e.HitObject is Touch),
             ("Touch Hold", e => e.HitObject is TouchHold),
-            ("Break", e => e.HitObject is SentakkiLanedHitObject x && x.Break),
+            ("Break", e => e.HitObject is SentakkiLanedHitObject x && x is not Hold && x.Break),
         };
 
         private readonly IReadOnlyList<HitEvent> hitEvents;


### PR DESCRIPTION
Fixes #609 

Two things contributed to excess breaks
1. Holds are counted as well, despite the `Break` not applying to itself, but the nested Hold.head object
2. Slides are also wrapper objects that are incorrectly counted. (The break property is applied to the nested tap object)