### PR TITLE
Add approximated maimaiDX accuracy in detailed statistics screen

### DIFF
--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -163,6 +163,7 @@ namespace osu.Game.Rulesets.Sentakki
 
             new StatisticItem(string.Empty, () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
             {
+                new MaimaiDXAccuracy(score.HitEvents),
                 new UnstableRate(score.HitEvents)
             }), true)
         };

--- a/osu.Game.Rulesets.Sentakki/Statistics/MaimaiDXAccuracy.cs
+++ b/osu.Game.Rulesets.Sentakki/Statistics/MaimaiDXAccuracy.cs
@@ -39,7 +39,7 @@ public partial class MaimaiDXAccuracy : SimpleStatisticItem<double>
                     break;
 
                 case HitResult.Good:
-                    actual += 0.75;
+                    actual += 0.8;
                     break;
 
                 case HitResult.Ok:

--- a/osu.Game.Rulesets.Sentakki/Statistics/MaimaiDXAccuracy.cs
+++ b/osu.Game.Rulesets.Sentakki/Statistics/MaimaiDXAccuracy.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Screens.Ranking.Statistics;
+
+namespace osu.Game.Rulesets.Sentakki.Statistics;
+
+public partial class MaimaiDXAccuracy : SimpleStatisticItem<double>
+{
+    public MaimaiDXAccuracy(IEnumerable<HitEvent> hitEvents) : base("MaimaiDX accuracy (approximated)")
+    {
+        Value = calculateDXAcc(hitEvents);
+    }
+
+    private static double calculateDXAcc(IEnumerable<HitEvent> hitEvents)
+    {
+        double maximum = 0;
+        double actual = 0;
+
+        int maxBonus = 0;
+        int actualBonuses = 0;
+
+        foreach (HitEvent hitEvent in hitEvents)
+        {
+            switch (hitEvent.HitObject.Judgement.MaxResult)
+            {
+                case HitResult.Great:
+                    maximum += 1;
+                    break;
+
+                case HitResult.LargeBonus:
+                    maxBonus += 1;
+                    break;
+            }
+
+            switch (hitEvent.Result)
+            {
+                case HitResult.Great:
+                    actual += 1;
+                    break;
+
+                case HitResult.Good:
+                    actual += 0.75;
+                    break;
+
+                case HitResult.Ok:
+                    actual += 0.5;
+                    break;
+
+                case HitResult.LargeBonus:
+                    actualBonuses += 1;
+                    break;
+            }
+        }
+
+        // If there are no regular notes, then a perfect play is vacuosly true
+        if (maximum == 0)
+            actual = maximum = 1;
+
+        // If there are no break notes, then the player vacuosly hit all the breaks perfectly
+        if (maxBonus == 0)
+            actualBonuses = maxBonus = 1;
+
+        return ((actual / maximum) * 100) + (actualBonuses / (float)maxBonus);
+    }
+
+    protected override string DisplayValue(double value) => $"{value:N4}%";
+}


### PR DESCRIPTION
A QOL feature to make it easier to make accuracy comparisons with maimai, which rewards more acc for non-perfect hits and factors critical break bonuses into the acc.

The maimaiDX accuracy is a best effort approximation, but likely still an underestimation due to slight mechanical difference. (for example, sentakki separates the hold head and tail into distinct timing points, while maimaiDX holds seems to be percentage based) 
![image](https://github.com/user-attachments/assets/f926d2c8-a0ef-4cf8-8099-a1ac995d5424)
