### PR TITLE
Fix underhold tracker not being reset on DHO usage

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -70,6 +70,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.OnApply();
             isHolding = false;
+            timeNotHeld = 0;
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
                 var newResult = originalResult - deduction;
 
-                if (originalResult <= HitResult.Ok)
+                if (newResult <= HitResult.Ok)
                     return HitResult.Ok;
 
                 return newResult;


### PR DESCRIPTION
The underhold tracker was being carried over for future pooled usages of the `DrawableHold`, causing future notes to punish players for any underhold accumulated from previous Holds.