### PR TITLE
Make HitExplosions less flashy

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
 
             double adjustedExplodeDuration = explode_duration * (drawableRuleset?.GameplaySpeed ?? 1);
 
-            var sequence = this.FadeTo(0.5f)
+            var sequence = this.FadeTo(0.8f)
                                .TransformBindableTo(borderRatio, 1)
                                .ScaleTo(1)
                                .Then()

--- a/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
 
             double adjustedExplodeDuration = explode_duration * (drawableRuleset?.GameplaySpeed ?? 1);
 
-            var sequence = this.FadeIn()
+            var sequence = this.FadeTo(0.5f)
                                .TransformBindableTo(borderRatio, 1)
                                .ScaleTo(1)
                                .Then()

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -76,10 +76,10 @@ namespace osu.Game.Rulesets.Sentakki.UI
                         ring = new SentakkiRing(),
                     }
                 },
+                explosionLayer = new Container<HitExplosion> { RelativeSizeAxes = Axes.Both },
                 LanedPlayfield = new LanedPlayfield(),
                 HitObjectContainer, // This only contains TouchHolds, which needs to be above others types
                 touchPlayfield = new TouchPlayfield(), // This only contains Touch, which needs a custom playfield to handle their input
-                explosionLayer = new Container<HitExplosion> { RelativeSizeAxes = Axes.Both },
                 judgementLayer = new Container<DrawableSentakkiJudgement>
                 {
                     RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
Two changes to make HitExplosions less distracting/in the way.

* Explosions now happen _under_ the hitobjects, rather than on top.
* HitExplosions start at 80% opacity rather than 100%.