### PR TITLE
Adjust feedback when holding notes

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -74,7 +74,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             base.OnKilled();
             isHolding.Value = false;
             timeNotHeld = 0;
-            NoteBody.Recycle();
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -74,6 +74,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             base.OnKilled();
             isHolding.Value = false;
             timeNotHeld = 0;
+            NoteBody.Recycle();
         }
 
         protected override void UpdateInitialTransforms()
@@ -97,6 +98,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         .ResizeHeightTo(stretchAmount, stretchTime) // While we are moving, we stretch the hold note to match desired length
                         .Then().Delay(HitObject.Duration - stretchTime) // Wait until the end of the hold note, while considering how much time we need for shrinking
                         .ResizeHeightTo(0, stretchTime); // We shrink the hold note as it exits
+
+                // Safety to ensure note animations remain after note speed adjustments
+                using (BeginDelayedSequence(animTime))
+                    NoteBody.TriggerChange();
             }
         }
 
@@ -146,10 +151,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 return;
 
             if (Auto && Time.Current >= HitObject.StartTime)
-            {
                 isHolding.Value = true;
-                Console.WriteLine("Holding");
-            }
 
             if (isHolding.Value)
                 return;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -155,7 +155,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 return;
 
             timeNotHeld += Time.Elapsed;
-
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)
@@ -254,7 +253,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             Head.UpdateResult();
             isHolding.Value = true;
-            NoteBody.FadeColour(AccentColour.Value, 50);
             return true;
         }
 
@@ -273,9 +271,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             UpdateResult(true);
             isHolding.Value = false;
-
-            if (!AllJudged)
-                NoteBody.FadeColour(Color4.Gray, 100);
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
                 // Safety to ensure note animations remain after note speed adjustments
                 using (BeginDelayedSequence(animTime))
-                    NoteBody.TriggerChange();
+                    NoteBody.TriggerHitFeedback();
             }
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -91,6 +91,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.OnApply();
             AccentColour.Value = getCurrentHitResult().GetColorForSentakkiResult();
+            TouchHoldBody.Recycle();
         }
 
         protected override void OnFree()
@@ -119,6 +120,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 TouchHoldBody.centrePiece.FadeOut();
                 TouchHoldBody.CompletedCentre.FadeIn();
                 TouchHoldBody.ProgressPiece.TransformBindableTo(TouchHoldBody.ProgressPiece.ProgressBindable, 1, ((IHasDuration)HitObject).Duration);
+
+                TouchHoldBody.TriggerHitFeedback();
             }
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -69,11 +69,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                 colourContainer.Colour = colour.NewValue;
                 flashingColor = colour.NewValue.LightenHSL(0.4f);
             }, true);
-        }
 
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
             IsHitting.BindValueChanged(hitting =>
             {
                 const float animation_length = 80;
@@ -86,6 +82,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                     // wait for the next sync point
                     double synchronisedOffset = animation_length * 2 - Time.Current % (animation_length * 2);
 
+                    colourContainer.FadeColour(accentColour.Value);
+
                     using (BeginDelayedSequence(synchronisedOffset))
                     {
                         colourContainer.FadeColour(flashingColor, animation_length, Easing.OutSine).Then()
@@ -97,10 +95,17 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                 }
                 else
                 {
-                    colourContainer.FadeColour(accentColour.Value);
+                    colourContainer.FadeColour(Color4.Gray, 50);
                     hitExplosion.Alpha = 0;
                 }
-            }, true);
+            }, false);
+        }
+
+        public void TriggerChange() => IsHitting.TriggerChange();
+        public void Recycle()
+        {
+            colourContainer.ClearTransforms();
+            colourContainer.Colour = accentColour.Value;
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -4,6 +4,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.UI;
+using osu.Game.Rulesets.Sentakki.UI.Components;
 using osuTK;
 using osuTK.Graphics;
 
@@ -13,6 +14,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
     {
         // This will be proxied, so a must.
         public override bool RemoveWhenNotAlive => false;
+        public BindableBool IsHitting = new();
+
+        private HitExplosion hitExplosion;
+        private Container colourContainer;
 
         public HoldBody()
         {
@@ -20,16 +25,38 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             Position = new Vector2(0, -SentakkiPlayfield.NOTESTARTDISTANCE);
             Anchor = Anchor.Centre;
             Origin = Anchor.TopCentre;
-            InternalChildren = new Drawable[]
-            {
-                new Container{
+            InternalChildren =
+            [
+                colourContainer = new Container
+                {
                     RelativeSizeAxes = Axes.Both,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Child =  new NoteRingPiece(true)
+                    Children =
+                    [
+                        new Container
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.Centre,
+                            Alpha = 0.25f,
+                            Child = hitExplosion = new HitExplosion
+                            {
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.Centre,
+                                Alpha = 0,
+                            }
+                        },
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Child =  new NoteRingPiece(true)
+                        },
+                    ]
                 }
-            };
+            ];
         }
+
+        private Color4 flashingColor = Color4.White;
 
         private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
 
@@ -37,7 +64,64 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
         private void load(DrawableHitObject drawableObject)
         {
             accentColour.BindTo(drawableObject.AccentColour);
-            accentColour.BindValueChanged(colour => Colour = colour.NewValue, true);
+            accentColour.BindValueChanged(colour =>
+            {
+                colourContainer.Colour = colour.NewValue;
+                flashingColor = lighten(colour.NewValue, 0.4f);
+            }, true);
+        }
+
+        private Color4 lighten(Color4 colour, float amount)
+        {
+            float distanceR = 1 - colour.R;
+            float distanceG = 1 - colour.G;
+            float distanceB = 1 - colour.B;
+
+            float r = colour.R + amount * distanceR;
+            float g = colour.G + amount * distanceG;
+            float b = colour.B + amount * distanceB;
+
+            return new Color4(r, g, b, colour.A);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            IsHitting.BindValueChanged(hitting =>
+            {
+                const float animation_length = 80;
+
+                colourContainer.ClearTransforms();
+                hitExplosion.ClearTransforms();
+
+                if (hitting.NewValue)
+                {
+                    // wait for the next sync point
+                    double synchronisedOffset = animation_length * 2 - Time.Current % (animation_length * 2);
+
+                    using (BeginDelayedSequence(synchronisedOffset))
+                    {
+                        colourContainer.FadeColour(flashingColor, animation_length, Easing.OutSine).Then()
+                            .FadeColour(accentColour.Value, animation_length, Easing.InSine)
+                            .Loop();
+
+                        hitExplosion.Explode(160).Loop();
+                    }
+                }
+                else
+                {
+                    colourContainer.FadeColour(accentColour.Value);
+                    hitExplosion.Alpha = 0;
+                }
+            }, true);
+        }
+
+        public void Recycle()
+        {
+            colourContainer.ClearTransforms();
+            colourContainer.Colour = accentColour.Value;
+            hitExplosion.ClearTransforms();
+            hitExplosion.Alpha = 0;
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             }, false);
         }
 
-        public void TriggerChange() => IsHitting.TriggerChange();
+        public void TriggerHitFeedback() => IsHitting.TriggerChange();
         public void Recycle()
         {
             colourContainer.ClearTransforms();

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -67,21 +67,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
             accentColour.BindValueChanged(colour =>
             {
                 colourContainer.Colour = colour.NewValue;
-                flashingColor = lighten(colour.NewValue, 0.4f);
+                flashingColor = colour.NewValue.LightenHSL(0.4f);
             }, true);
-        }
-
-        private Color4 lighten(Color4 colour, float amount)
-        {
-            float distanceR = 1 - colour.R;
-            float distanceG = 1 - colour.G;
-            float distanceB = 1 - colour.B;
-
-            float r = colour.R + amount * distanceR;
-            float g = colour.G + amount * distanceG;
-            float b = colour.B + amount * distanceB;
-
-            return new Color4(r, g, b, colour.A);
         }
 
         protected override void LoadComplete()
@@ -118,10 +105,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
 
         public void Recycle()
         {
-            colourContainer.ClearTransforms();
-            colourContainer.Colour = accentColour.Value;
-            hitExplosion.ClearTransforms();
-            hitExplosion.Alpha = 0;
+            /*             colourContainer.ClearTransforms();
+                        colourContainer.Colour = accentColour.Value;
+                        hitExplosion.ClearTransforms();
+                        hitExplosion.Alpha = 0; */
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -1,4 +1,4 @@
-﻿using osu.Framework.Allocation;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                 if (hitting.NewValue)
                 {
                     // wait for the next sync point
-                    double synchronisedOffset = animation_length * 2 - Time.Current % (animation_length * 2);
+                    double synchronisedOffset = (animation_length * 2) - (Time.Current % (animation_length * 2));
 
                     colourContainer.FadeColour(accentColour.Value);
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -102,13 +102,5 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces
                 }
             }, true);
         }
-
-        public void Recycle()
-        {
-            /*             colourContainer.ClearTransforms();
-                        colourContainer.Colour = accentColour.Value;
-                        hitExplosion.ClearTransforms();
-                        hitExplosion.Alpha = 0; */
-        }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldBody.cs
@@ -2,6 +2,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Sentakki.Extensions;
 using osu.Game.Rulesets.Sentakki.UI.Components;
 using osuTK;
 using osuTK.Graphics;
@@ -55,18 +56,15 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
             };
         }
 
-        [Resolved]
-        private Bindable<bool> isHitting { get; set; } = null!;
-
-        [Resolved]
-        private DrawableTouchHold drawableTouchHold { get; set; } = null!;
+        private Bindable<bool> isHitting { get; set; } = new();
 
         private Bindable<Color4> accentColour = new();
 
-        [BackgroundDependencyLoader]
-        private void load()
+        [BackgroundDependencyLoader(true)]
+        private void load(Bindable<bool>? isHittingBindable, DrawableTouchHold? dth)
         {
-            accentColour.BindTo(drawableTouchHold.AccentColour);
+            isHitting.TryBindTo(isHittingBindable);
+            accentColour.TryBindTo(dth?.AccentColour);
 
             isHitting.BindValueChanged(hitting =>
             {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldBody.cs
@@ -30,9 +30,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Alpha = 0.25f,
-                    Child = hitExplosion = new HitExplosion
+                    Child = hitExplosion = new HitExplosion(true)
                     {
-                        Size = new Vector2(100)
+                        Size = new Vector2(80),
+                        Rotation = 45f
                     },
                 },
                 ProgressPiece = new TouchHoldProgressPiece(),

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldBody.cs
@@ -4,7 +4,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Sentakki.UI.Components;
 using osuTK;
-using osuTK.Audio.OpenAL;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
@@ -19,6 +18,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => ProgressPiece.ReceivePositionalInputAt(screenSpacePos);
 
+        private Container colourContainer;
+
         public TouchHoldBody()
         {
             Size = new Vector2(130);
@@ -26,22 +27,31 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
             Origin = Anchor.Centre;
             InternalChildren = new Drawable[]
             {
-                new Container{
+                colourContainer = new Container{
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Alpha = 0.25f,
-                    Child = hitExplosion = new HitExplosion(true)
-                    {
-                        Size = new Vector2(80),
-                        Rotation = 45f
-                    },
-                },
-                ProgressPiece = new TouchHoldProgressPiece(),
-                centrePiece = new TouchHoldCentrePiece(),
-                // We swap the centre piece with this other drawable to make it look better with the progress bar
-                // Otherwise we'd need to add a thick border in between the centre and the progress
-                CompletedCentre = new TouchHoldCompletedCentre(),
-                new DotPiece(),
+                    RelativeSizeAxes = Axes.Both,
+
+                    Children = [
+                        new Container{
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Alpha = 0.25f,
+                            Child = hitExplosion = new HitExplosion(true)
+                            {
+                                Size = new Vector2(80),
+                                Rotation = 45f
+                            },
+                        },
+                        ProgressPiece = new TouchHoldProgressPiece(),
+                        centrePiece = new TouchHoldCentrePiece(),
+                        // We swap the centre piece with this other drawable to make it look better with the progress bar
+                        // Otherwise we'd need to add a thick border in between the centre and the progress
+                        CompletedCentre = new TouchHoldCompletedCentre(),
+                        new DotPiece(),
+                    ]
+                }
+
             };
         }
 
@@ -53,10 +63,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
 
         private Bindable<Color4> accentColour = new();
 
-        protected override void LoadComplete()
+        [BackgroundDependencyLoader]
+        private void load()
         {
-            base.LoadComplete();
-
             accentColour.BindTo(drawableTouchHold.AccentColour);
 
             isHitting.BindValueChanged(hitting =>
@@ -64,11 +73,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                 const float animation_length = 80;
 
                 hitExplosion.ClearTransforms();
+                colourContainer.ClearTransforms();
 
                 if (hitting.NewValue)
                 {
                     // wait for the next sync point
                     double synchronisedOffset = animation_length * 2 - Time.Current % (animation_length * 2);
+                    colourContainer.FadeColour(Color4.White);
 
                     using (BeginDelayedSequence(synchronisedOffset))
                     {
@@ -78,10 +89,25 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                 else
                 {
                     hitExplosion.Alpha = 0;
+                    colourContainer.FadeColour(Color4.Gray);
                 }
-            }, true);
+            }, false);
 
             accentColour.BindValueChanged(c => hitExplosion.Colour = c.NewValue);
+        }
+
+        public void TriggerHitFeedback()
+        {
+            // HACK: I wanted to trigger isHitting for children, without going through like every component in between the target
+            bool value = isHitting.Value;
+            isHitting.Value = !value;
+            isHitting.Value = value;
+        }
+
+        public void Recycle()
+        {
+            colourContainer.ClearTransforms();
+            colourContainer.Colour = accentColour.Value;
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldBody.cs
@@ -1,6 +1,11 @@
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Sentakki.UI.Components;
 using osuTK;
+using osuTK.Audio.OpenAL;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
 {
@@ -8,8 +13,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
     {
         public readonly TouchHoldProgressPiece ProgressPiece;
         public readonly TouchHoldCentrePiece centrePiece;
-
         public readonly TouchHoldCompletedCentre CompletedCentre;
+
+        private readonly HitExplosion hitExplosion;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => ProgressPiece.ReceivePositionalInputAt(screenSpacePos);
 
@@ -20,6 +26,15 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
             Origin = Anchor.Centre;
             InternalChildren = new Drawable[]
             {
+                new Container{
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Alpha = 0.25f,
+                    Child = hitExplosion = new HitExplosion
+                    {
+                        Size = new Vector2(100)
+                    },
+                },
                 ProgressPiece = new TouchHoldProgressPiece(),
                 centrePiece = new TouchHoldCentrePiece(),
                 // We swap the centre piece with this other drawable to make it look better with the progress bar
@@ -27,6 +42,45 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                 CompletedCentre = new TouchHoldCompletedCentre(),
                 new DotPiece(),
             };
+        }
+
+        [Resolved]
+        private Bindable<bool> isHitting { get; set; } = null!;
+
+        [Resolved]
+        private DrawableTouchHold drawableTouchHold { get; set; } = null!;
+
+        private Bindable<Color4> accentColour = new();
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            accentColour.BindTo(drawableTouchHold.AccentColour);
+
+            isHitting.BindValueChanged(hitting =>
+            {
+                const float animation_length = 80;
+
+                hitExplosion.ClearTransforms();
+
+                if (hitting.NewValue)
+                {
+                    // wait for the next sync point
+                    double synchronisedOffset = animation_length * 2 - Time.Current % (animation_length * 2);
+
+                    using (BeginDelayedSequence(synchronisedOffset))
+                    {
+                        hitExplosion.Explode(160).Loop();
+                    }
+                }
+                else
+                {
+                    hitExplosion.Alpha = 0;
+                }
+            }, true);
+
+            accentColour.BindValueChanged(c => hitExplosion.Colour = c.NewValue);
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldBody.cs
@@ -52,7 +52,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                         new DotPiece(),
                     ]
                 }
-
             };
         }
 
@@ -76,7 +75,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                 if (hitting.NewValue)
                 {
                     // wait for the next sync point
-                    double synchronisedOffset = animation_length * 2 - Time.Current % (animation_length * 2);
+                    double synchronisedOffset = (animation_length * 2) - (Time.Current % (animation_length * 2));
                     colourContainer.FadeColour(Color4.White);
 
                     using (BeginDelayedSequence(synchronisedOffset))

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCircularProgress.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCircularProgress.cs
@@ -39,7 +39,7 @@ public partial class TouchHoldCircularProgress : CircularProgress
             if (hitting.NewValue)
             {
                 // wait for the next sync point
-                double synchronisedOffset = animation_length * 2 - Time.Current % (animation_length * 2);
+                double synchronisedOffset = (animation_length * 2) - (Time.Current % (animation_length * 2));
 
                 using (BeginDelayedSequence(synchronisedOffset))
                 {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCircularProgress.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCircularProgress.cs
@@ -1,0 +1,51 @@
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.UserInterface;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds;
+
+public partial class TouchHoldCircularProgress : CircularProgress
+{
+    private readonly Color4 originalColour;
+    private readonly Color4 flashingColour;
+
+    public TouchHoldCircularProgress(Color4 colour)
+    {
+        Colour = originalColour = colour;
+        flashingColour = colour.Lighten(0.4f);
+    }
+
+    [Resolved]
+    private Bindable<bool> isHitting { get; set; } = null!;
+
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+        isHitting.BindValueChanged(hitting =>
+        {
+            const float animation_length = 80;
+
+            ClearTransforms();
+
+            if (hitting.NewValue)
+            {
+                // wait for the next sync point
+                double synchronisedOffset = animation_length * 2 - Time.Current % (animation_length * 2);
+
+                using (BeginDelayedSequence(synchronisedOffset))
+                {
+                    this.FadeColour(flashingColour, animation_length, Easing.OutSine).Then()
+                        .FadeColour(originalColour, animation_length, Easing.InSine)
+                        .Loop();
+                }
+            }
+            else
+            {
+                this.FadeColour(originalColour);
+            }
+        }, true);
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCircularProgress.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCircularProgress.cs
@@ -3,6 +3,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
+using osu.Game.Rulesets.Sentakki.Extensions;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds;
@@ -18,8 +19,13 @@ public partial class TouchHoldCircularProgress : CircularProgress
         flashingColour = colour.Lighten(0.4f);
     }
 
-    [Resolved]
-    private Bindable<bool> isHitting { get; set; } = null!;
+    private Bindable<bool> isHitting { get; set; } = new();
+
+    [BackgroundDependencyLoader]
+    private void load(Bindable<bool>? isHittingBindable)
+    {
+        isHitting.TryBindTo(isHittingBindable);
+    }
 
     protected override void LoadComplete()
     {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCompletedCentrePiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCompletedCentrePiece.cs
@@ -38,37 +38,37 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                     Rotation = -45f,
                     Children = new Drawable[]
                     {
-                        new CircularProgress
+                        new TouchHoldCircularProgress(colours.Blue)
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             InnerRadius = 1,
                             Size = Vector2.One,
                             RelativeSizeAxes = Axes.Both,
-                            Progress = 1,
-                            Colour = colours.Blue
+                            Progress = 0.25,
+                            Rotation = 270
                         },
-                        new CircularProgress
+                        new TouchHoldCircularProgress(colours.Green)
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             InnerRadius = 1,
                             Size = Vector2.One,
                             RelativeSizeAxes = Axes.Both,
-                            Progress = 0.75 ,
-                            Colour = colours.Green
+                            Progress = 0.25,
+                            Rotation = 180
                         },
-                        new CircularProgress
+                        new TouchHoldCircularProgress(colours.Yellow)
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             InnerRadius = 1,
                             Size = Vector2.One,
                             RelativeSizeAxes = Axes.Both,
-                            Progress = 0.5 ,
-                            Colour = colours.Yellow,
+                            Progress = 0.25,
+                            Rotation = 90
                         },
-                        new CircularProgress
+                        new TouchHoldCircularProgress(colours.Red)
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
@@ -76,7 +76,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                             Size = Vector2.One,
                             RelativeSizeAxes = Axes.Both,
                             Progress = 0.25 ,
-                            Colour = colours.Red,
                         },
                     }
                 },

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldProgressPiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldProgressPiece.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                     Rotation = -45f,
                     Children = new Drawable[]
                     {
-                        blueProgress = new CircularProgress
+                        blueProgress = new TouchHoldCircularProgress(colours.Blue)
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
@@ -49,9 +49,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                             Size = Vector2.One,
                             RelativeSizeAxes = Axes.Both,
                             Progress = 0,
-                            Colour = colours.Blue
+                            Rotation = 270f
                         },
-                        greenProgress = new CircularProgress
+                        greenProgress = new TouchHoldCircularProgress(colours.Green)
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
@@ -59,9 +59,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                             Size = Vector2.One,
                             RelativeSizeAxes = Axes.Both,
                             Progress = 0,
-                            Colour = colours.Green
+                            Rotation = 180
                         },
-                        yellowProgress = new CircularProgress
+                        yellowProgress = new TouchHoldCircularProgress(colours.Yellow)
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
@@ -69,9 +69,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                             Size = Vector2.One,
                             RelativeSizeAxes = Axes.Both,
                             Progress = 0,
-                            Colour = colours.Yellow,
+                            Rotation = 90
                         },
-                        redProgress = new CircularProgress
+                        redProgress = new TouchHoldCircularProgress(colours.Red)
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
@@ -87,10 +87,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
 
             ProgressBindable.BindValueChanged(p =>
             {
-                redProgress.Progress = Math.Min(p.NewValue, .25);
-                yellowProgress.Progress = Math.Min(p.NewValue, .50);
-                greenProgress.Progress = Math.Min(p.NewValue, .75);
-                blueProgress.Progress = p.NewValue;
+                redProgress.Progress = Math.Clamp(p.NewValue, 0, .25);
+                yellowProgress.Progress = Math.Clamp(p.NewValue - 0.25, 0, .25);
+                greenProgress.Progress = Math.Clamp(p.NewValue - 0.5, 0, .25);
+                blueProgress.Progress = Math.Clamp(p.NewValue - 0.75, 0, .25);
             });
         }
     }

--- a/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
 using osuTK.Graphics;
@@ -126,6 +127,29 @@ namespace osu.Game.Rulesets.Sentakki
                 default:
                     return result.GetDescription();
             }
+        }
+
+        public static Color4 LightenHSL(this Color4 colour, float amount)
+        {
+            float distanceR = 1 - colour.R;
+            float distanceG = 1 - colour.G;
+            float distanceB = 1 - colour.B;
+
+            float r = colour.R + amount * distanceR;
+            float g = colour.G + amount * distanceG;
+            float b = colour.B + amount * distanceB;
+
+            return new Color4(r, g, b, colour.A);
+        }
+
+        public static Color4 IncreaseLightness(this Color4 colour, float amount)
+        {
+            Colour4 colour2 = colour;
+
+            var hsl = colour2.ToHSL();
+            float l = MathF.Min(hsl.Z + amount, 1);
+
+            return Colour4.FromHSL(hsl.X, hsl.Y, l, hsl.W);
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
@@ -135,9 +135,9 @@ namespace osu.Game.Rulesets.Sentakki
             float distanceG = 1 - colour.G;
             float distanceB = 1 - colour.B;
 
-            float r = colour.R + amount * distanceR;
-            float g = colour.G + amount * distanceG;
-            float b = colour.B + amount * distanceB;
+            float r = colour.R + (amount * distanceR);
+            float g = colour.G + (amount * distanceG);
+            float b = colour.B + (amount * distanceB);
 
             return new Color4(r, g, b, colour.A);
         }

--- a/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             Size = new Vector2(default_explosion_size);
-            Colour = Color4.Cyan;
+            Colour = Color4.White;
             Alpha = 0;
             InternalChildren = new Drawable[]
             {
@@ -97,19 +97,15 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             Explode().Expire(true);
         }
 
-        public TransformSequence<HitExplosion> Explode()
+        public TransformSequence<HitExplosion> Explode(double explode_duration = 80)
         {
-            const double explode_duration = 100;
-
-            double adjustedExplodeDuration = explode_duration * (drawableRuleset?.GameplaySpeed ?? 1);
-
             var sequence = this.FadeTo(0.8f)
                                .TransformBindableTo(borderRatio, 1)
                                .ScaleTo(1)
                                .Then()
-                               .TransformBindableTo(borderRatio, 0f, adjustedExplodeDuration)
-                               .ScaleTo(2f, adjustedExplodeDuration)
-                               .FadeOut(adjustedExplodeDuration);
+                               .TransformBindableTo(borderRatio, 0f, duration: explode_duration)
+                               .ScaleTo(2f, explode_duration)
+                               .FadeOut(explode_duration);
 
             return sequence;
         }

--- a/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
@@ -1,3 +1,4 @@
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -16,7 +17,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
     {
         public override bool RemoveWhenNotAlive => true;
 
-        private readonly CircularContainer circle;
+        private readonly HitExplosionContainer visual;
 
         private const float default_explosion_size = 75;
         private const float touch_hold_explosion_size = 100;
@@ -24,7 +25,9 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
         [Resolved]
         private DrawableSentakkiRuleset? drawableRuleset { get; set; }
 
-        public HitExplosion()
+        public HitExplosion() : this(false) { }
+
+        public HitExplosion(bool forTouch = false)
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
@@ -33,20 +36,8 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             Alpha = 0;
             InternalChildren = new Drawable[]
             {
-                circle = new CircularContainer
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Both,
-                    Masking = true,
-                    BorderThickness = 45,
-                    BorderColour = Color4.White,
-                    Child = new Box
-                    {
-                        Alpha = 0,
-                        RelativeSizeAxes = Axes.Both,
-                        AlwaysPresent = true,
-                    }
+                visual = new HitExplosionContainer(){
+                    Circular = !forTouch
                 },
             };
 
@@ -55,7 +46,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
 
         private void setBorderThiccness(ValueChangedEvent<float> v)
         {
-            circle.BorderThickness = Size.X / 2 * v.NewValue;
+            visual.BorderThickness = Size.X / 2 * v.NewValue;
         }
 
         private readonly BindableFloat borderRatio = new BindableFloat(1);
@@ -69,17 +60,22 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                 case SentakkiLanedHitObject lanedObject:
                     Position = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, lanedObject.Lane);
                     Size = new Vector2(default_explosion_size);
+                    visual.Circular = true;
                     break;
 
                 case Touch touchObject:
                     Position = touchObject.Position;
                     Size = new Vector2(default_explosion_size);
+                    visual.Circular = false;
+                    Rotation = 0;
                     break;
 
                 case TouchHold _:
                 default:
                     Position = Vector2.Zero;
                     Size = new Vector2(touch_hold_explosion_size);
+                    visual.Circular = false;
+                    Rotation = 45;
                     break;
             }
 
@@ -108,6 +104,36 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                                .FadeOut(explode_duration);
 
             return sequence;
+        }
+
+        private partial class HitExplosionContainer : Container
+        {
+            public bool Circular { get; set; }
+
+            public HitExplosionContainer()
+            {
+                Masking = true;
+                CornerExponent = 2;
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+                RelativeSizeAxes = Axes.Both;
+                BorderColour = Color4.White;
+                Child = new Box
+                {
+                    Alpha = 0,
+                    RelativeSizeAxes = Axes.Both,
+                    AlwaysPresent = true,
+                };
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+                if (Circular)
+                    CornerRadius = Math.Min(DrawSize.X, DrawSize.Y) * 0.5f;
+                else
+                    CornerRadius = 20;
+            }
         }
     }
 }


### PR DESCRIPTION
Instead of greying out when _not_ holding the note. The hold note instead gives continuous feedback when being held, and not greying out the hold note itself when not hit. 

This is implemented similarly to osu mania.