### PR TITLE
Slightly improve feedback given when hitting hold notes

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/Graphics/TestSceneChevronVisuals.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Graphics/TestSceneChevronVisuals.cs
@@ -35,8 +35,9 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Graphics
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Size = new Vector2(80, 62.5f),
-                Thickness = 7
+                Size = new Vector2(80, 60f),
+                ShadowRadius = 15,
+                Thickness = 6.5f
             });
         }
     }

--- a/osu.Game.Rulesets.Sentakki.Tests/Graphics/TestSceneFanChevronVisuals.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Graphics/TestSceneFanChevronVisuals.cs
@@ -102,6 +102,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Graphics
                     Thickness = t,
                     Y = -y + 300 - 50,
                     FanChevron = true,
+                    ShadowRadius = 15f
                 };
 
                 fanChevContainer.Add(fanChev);

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneCircleChaining.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneCircleChaining.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
             AddStep("Perform entry animation", () => slide.PerformEntryAnimation(1000));
             AddWaitStep("Wait for transforms", 5);
 
-            AddStep("Perform exit animation", () => slide.PerformExitAnimation(1000));
+            AddStep("Perform exit animation", () => slide.PerformExitAnimation(1000, Time.Current));
             AddWaitStep("Wait for transforms", 5);
 
             Add(nodes = new Container

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneFanSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneFanSlide.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
             AddStep("Perform entry animation", () => slide.PerformEntryAnimation(1000));
             AddWaitStep("Wait for transforms", 5);
 
-            AddStep("Perform exit animation", () => slide.PerformExitAnimation(1000));
+            AddStep("Perform exit animation", () => slide.PerformExitAnimation(1000, Time.Current));
             AddWaitStep("Wait for transforms", 5);
         }
 

--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneSlide.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneSlide.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
             AddStep("Perform entry animation", () => slide.PerformEntryAnimation(1000));
             AddWaitStep("Wait for transforms", 5);
 
-            AddStep("Perform exit animation", () => slide.PerformExitAnimation(1000));
+            AddStep("Perform exit animation", () => slide.PerformExitAnimation(1000, Time.Current));
             AddWaitStep("Wait for transforms", 5);
 
             Add(nodes = new Container

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapProcessor.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 
             foreach (var group in hitObjectGroups)
             {
-                bool isTwin = group.Count(canBeTwin) > 1; // This determines whether the twin colour should be used for eligible objects
+                bool isTwin = group.Count(countsForTwin) > 1; // This determines whether the twin colour should be used for eligible objects
 
                 foreach (SentakkiHitObject hitObject in group)
                 {
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
 
                     if (hitObject is SentakkiLanedHitObject laned && laned.Break)
                         noteColor = breakColor;
-                    else if (isTwin && canBeTwin(hitObject))
+                    else if (isTwin)
                         noteColor = twinColor;
 
                     hitObject.NoteColour = noteColor;
@@ -88,7 +88,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             return false;
         }
 
-        private static bool canBeTwin(HitObject hitObject) => hitObject switch
+        private static bool countsForTwin(HitObject hitObject) => hitObject switch
         {
             Hold.HoldHead => false,
             TouchHold => false,

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            AccentColour.BindValueChanged(c => flashingColour = AccentColour.Value.LightenHSL(0.3f), true);
+            AccentColour.BindValueChanged(c => flashingColour = AccentColour.Value.LightenHSL(0.4f), true);
         }
 
         private Color4 flashingColour = Color4.White;
@@ -129,7 +129,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             double flashProg = (Time.Current % (flashing_time * 2)) / (flashing_time * 2);
 
-            NoteBody.Colour = Interpolation.ValueAt(flashProg, AccentColour.Value, flashingColour, 0, 0.5, Easing.OutSine);
+            if (flashProg <= 0.5)
+                NoteBody.Colour = Interpolation.ValueAt(flashProg, AccentColour.Value, flashingColour, 0, 0.5, Easing.OutSine);
+            else
+                NoteBody.Colour = Interpolation.ValueAt(flashProg, flashingColour, AccentColour.Value, 0.5, 0, Easing.InSine);
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -60,11 +60,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
-            AddRangeInternal(new Drawable[]
-            {
+            AddRangeInternal(
+            [
                 NoteBody = new HoldBody(),
                 headContainer = new Container<DrawableHoldHead> { RelativeSizeAxes = Axes.Both },
-            });
+            ]);
         }
 
         protected override void LoadComplete()
@@ -79,13 +79,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.OnApply();
             timeNotHeld = 0;
-            lastHoldTime = null;
+            isHolding = false;
         }
 
         private double timeNotHeld = 0;
-        private double? lastHoldTime = null;
 
-        private bool isHolding => lastHoldTime != null;
+        private bool isHolding;
 
         protected override void Update()
         {
@@ -106,7 +105,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 return;
             }
 
-            if (!lastHoldTime.HasValue && !Auto)
+            if (!isHolding && !Auto)
             {
                 // Remove alterations to NoteBody colour
                 NoteBody.Colour = AccentColour.Value;
@@ -181,7 +180,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             HitResult applyDeductionTo(HitResult originalResult)
             {
-                int deduction = (int)Math.Min(Math.Floor(timeNotHeld / 300), 3);
+                int deduction = (int)Math.Clamp(Math.Floor(timeNotHeld / 300), 0, 3);
 
                 var newResult = originalResult - deduction;
 
@@ -286,7 +285,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 return false;
 
             Head.UpdateResult();
-            lastHoldTime = Time.Current;
+            isHolding = true;
             NoteBody.FadeColour(AccentColour.Value, 50);
             return true;
         }
@@ -305,7 +304,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 return;
 
             UpdateResult(true);
-            lastHoldTime = null;
+            isHolding = false;
 
             if (!AllJudged)
                 NoteBody.FadeColour(Color4.Gray, 100);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableScorePaddingObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableScorePaddingObject.cs
@@ -1,8 +1,5 @@
-using System;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Rulesets.Sentakki.Judgements;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiJudgement.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiJudgement.cs
@@ -11,7 +11,6 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Scoring;
-using osu.Game.Rulesets.Sentakki.UI;
 using osuTK;
 using osuTK.Graphics;
 
@@ -27,9 +26,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         private OsuSpriteText timingPiece = null!;
 
         private readonly BindableBool detailedJudgements = new BindableBool();
-
-        [Resolved]
-        private DrawableSentakkiRuleset drawableRuleset { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load(SentakkiRulesetConfigManager sentakkiConfigs)
@@ -122,14 +118,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         private void applyHitAnimations()
         {
-            double speedFactor = drawableRuleset.GameplaySpeed;
-            judgementBody.ScaleTo(1, 50 * speedFactor, Easing.OutElastic);
+            judgementBody.ScaleTo(1, 50, Easing.OutElastic);
 
-            judgementBody.Delay(50 * speedFactor)
-                         .ScaleTo(0.8f, 300 * speedFactor)
-                         .FadeOut(300 * speedFactor);
+            judgementBody.Delay(50)
+                         .ScaleTo(0.8f, 300)
+                         .FadeOut(300);
 
-            this.Delay(350 * speedFactor).Expire();
+            this.Delay(350).Expire();
         }
 
         private partial class SentakkiJudgementPiece : DefaultJudgementPiece

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -265,11 +265,15 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
                     this.FadeOut(time_fade_hit).Expire();
 
-
                     break;
 
                 case ArmedState.Miss:
                     Slidepath.PerformExitAnimation(time_fade_miss, Result.TimeAbsolute);
+
+                    foreach (var star in SlideStars)
+                        star.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
+                            .MoveToOffset(SentakkiExtensions.GetCircularPosition(100, star.Rotation), time_fade_miss, Easing.OutCubic);
+
                     this.FadeColour(Color4.Red, time_fade_miss, Easing.OutQuint).FadeOut(time_fade_miss).Expire();
                     break;
             }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -146,7 +146,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 return;
 
             Slidepath.Progress = checkpoint.HitObject.Progress;
-            Slidepath.UpdateChevronVisibility();
         }
 
         private void onRevertResult(DrawableHitObject hitObject, JudgementResult result)
@@ -155,8 +154,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 return;
 
             Slidepath.Progress = checkpoint.ThisIndex == 0 ? 0 : SlideCheckpoints[checkpoint.ThisIndex - 1].HitObject.Progress;
-
-            Slidepath.UpdateChevronVisibility();
         }
 
         protected override void Update()
@@ -170,31 +167,33 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         {
             base.UpdateInitialTransforms();
             Slidepath.PerformEntryAnimation(AnimationDuration.Value);
+        }
 
-            using (BeginAbsoluteSequence(HitObject.StartTime))
+        protected override void UpdateStartTimeStateTransforms()
+        {
+            base.UpdateStartTimeStateTransforms();
+
+            // The primary star is always guaranteed to enter.
+            SlideStars[2].FadeInFromZero(HitObject.ShootDelay).ScaleTo(1.25f, HitObject.ShootDelay);
+
+            // The fan slide stars will enter with the same transforms as the primary star iff the slide starts with a fan
+            if (Slidepath.Path.StartsWithSlideFan)
             {
-                SlideStars[2].FadeInFromZero(HitObject.ShootDelay).ScaleTo(1.25f, HitObject.ShootDelay);
-                SlideStars[0].FadeOut().ScaleTo(1.25f, HitObject.ShootDelay);
-                SlideStars[1].FadeOut().ScaleTo(1.25f, HitObject.ShootDelay);
+                SlideStars[0].FadeInFromZero(HitObject.ShootDelay).ScaleTo(1.25f, HitObject.ShootDelay);
+                SlideStars[1].FadeInFromZero(HitObject.ShootDelay).ScaleTo(1.25f, HitObject.ShootDelay);
+            }
 
-                if (Slidepath.Path.StartsWithSlideFan)
+            // This indirectly controls the animation of the stars following the path
+            using (BeginDelayedSequence(HitObject.ShootDelay))
+                this.TransformTo(nameof(StarProgress), 1f, (HitObject as IHasDuration).Duration - HitObject.ShootDelay);
+
+            // If the slide doesn't start with a fan, but ends with it, then we fade them in instantly at the point the fan begins on the path.
+            if (!Slidepath.Path.StartsWithSlideFan && Slidepath.Path.EndsWithSlideFan)
+            {
+                using (BeginDelayedSequence(HitObject.ShootDelay + (HitObject.Duration - HitObject.ShootDelay) * Slidepath.Path.FanStartProgress))
                 {
-                    SlideStars[0].FadeInFromZero(HitObject.ShootDelay);
-                    SlideStars[1].FadeInFromZero(HitObject.ShootDelay);
-                }
-
-                using (BeginDelayedSequence(HitObject.ShootDelay))
-                {
-                    if (!Slidepath.Path.StartsWithSlideFan && Slidepath.Path.EndsWithSlideFan)
-                    {
-                        using (BeginDelayedSequence((HitObject.Duration - HitObject.ShootDelay) * Slidepath.Path.FanStartProgress))
-                        {
-                            SlideStars[0].FadeIn();
-                            SlideStars[1].FadeIn();
-                        }
-                    }
-
-                    this.TransformTo(nameof(StarProgress), 1f, (HitObject as IHasDuration).Duration - HitObject.ShootDelay);
+                    SlideStars[0].FadeIn().ScaleTo(1.25f);
+                    SlideStars[1].FadeIn().ScaleTo(1.25f);
                 }
             }
         }
@@ -253,16 +252,20 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             base.UpdateHitStateTransforms(state);
-            double time_fade_miss = 400 * (DrawableSentakkiRuleset?.GameplaySpeed ?? 1);
-            double time_fade_hit = 200 * (DrawableSentakkiRuleset?.GameplaySpeed ?? 1);
+
+            const double time_fade_miss = 400;
+            const double time_fade_hit = 200;
 
             switch (state)
             {
                 case ArmedState.Hit:
-                    using (BeginAbsoluteSequence(Math.Max(Result.TimeAbsolute, HitObject.GetEndTime() - HitObject.HitWindows.WindowFor(HitResult.Good))))
-                    {
-                        Slidepath.PerformExitAnimation(time_fade_hit);
+                    // We choose the later time between HitStateUpdateTime and the earliest point the good window is valid.
+                    // This is to allow the stars to continue following the path, to indicate that the slide was completed way too early.
+                    double exitTransformStartTime = Math.Max(HitStateUpdateTime, HitObject.GetEndTime() - HitObject.HitWindows.WindowFor(HitResult.Good));
 
+                    Slidepath.PerformExitAnimation(time_fade_hit, exitTransformStartTime);
+                    using (BeginAbsoluteSequence(exitTransformStartTime))
+                    {
                         foreach (var star in SlideStars)
                             star.FadeOut(time_fade_hit);
 
@@ -272,7 +275,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     break;
 
                 case ArmedState.Miss:
-                    Slidepath.PerformExitAnimation(time_fade_miss);
+                    Slidepath.PerformExitAnimation(time_fade_miss, Result.TimeAbsolute);
                     this.FadeColour(Color4.Red, time_fade_miss, Easing.OutQuint).FadeOut(time_fade_miss).Expire();
                     break;
             }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -261,9 +261,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 case ArmedState.Hit:
                     Slidepath.PerformExitAnimation(time_fade_hit, HitStateUpdateTime);
                     foreach (var star in SlideStars)
-                        star.FadeOut();
+                        star.FadeOut(time_fade_hit);
 
-                    this.FadeOut(time_fade_hit).Expire();
+                    this.Delay(time_fade_hit).Expire();
 
                     break;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -190,7 +190,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             // If the slide doesn't start with a fan, but ends with it, then we fade them in instantly at the point the fan begins on the path.
             if (!Slidepath.Path.StartsWithSlideFan && Slidepath.Path.EndsWithSlideFan)
             {
-                using (BeginDelayedSequence(HitObject.ShootDelay + (HitObject.Duration - HitObject.ShootDelay) * Slidepath.Path.FanStartProgress))
+                using (BeginDelayedSequence(HitObject.ShootDelay + ((HitObject.Duration - HitObject.ShootDelay) * Slidepath.Path.FanStartProgress)))
                 {
                     SlideStars[0].FadeIn().ScaleTo(1.25f);
                     SlideStars[1].FadeIn().ScaleTo(1.25f);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -259,18 +259,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             switch (state)
             {
                 case ArmedState.Hit:
-                    // We choose the later time between HitStateUpdateTime and the earliest point the good window is valid.
-                    // This is to allow the stars to continue following the path, to indicate that the slide was completed way too early.
-                    double exitTransformStartTime = Math.Max(HitStateUpdateTime, HitObject.GetEndTime() - HitObject.HitWindows.WindowFor(HitResult.Good));
+                    Slidepath.PerformExitAnimation(time_fade_hit, HitStateUpdateTime);
+                    foreach (var star in SlideStars)
+                        star.FadeOut();
 
-                    Slidepath.PerformExitAnimation(time_fade_hit, exitTransformStartTime);
-                    using (BeginAbsoluteSequence(exitTransformStartTime))
-                    {
-                        foreach (var star in SlideStars)
-                            star.FadeOut(time_fade_hit);
+                    this.FadeOut(time_fade_hit).Expire();
 
-                        this.FadeOut(time_fade_hit).Expire();
-                    }
 
                     break;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
@@ -1,8 +1,6 @@
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             base.UpdateHitStateTransforms(state);
-            double time_fade_miss = 400 * (DrawableSentakkiRuleset?.GameplaySpeed ?? 1);
+            double time_fade_miss = 400;
 
             switch (state)
             {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             TouchBody.FadeIn(fadeTime);
 
-            using (BeginAbsoluteSequence(HitObject.StartTime - animTime))
+            using (BeginDelayedSequence(fadeTime))
             {
                 TouchBody.ResizeTo(90, animTime, Easing.InCirc);
                 TouchBody.BorderContainer.Delay(animTime).FadeIn();

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -1,9 +1,7 @@
-using System;
 using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Transforms;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Touches;
@@ -121,7 +119,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             base.UpdateHitStateTransforms(state);
-            double time_fade_miss = 400 * (DrawableSentakkiRuleset?.GameplaySpeed ?? 1);
+            double time_fade_miss = 400;
 
             switch (state)
             {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -141,7 +141,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             {
                 holdSample.Stop();
             }
-
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
@@ -126,6 +125,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             TouchHoldBody.ProgressPiece.TransformBindableTo(TouchHoldBody.ProgressPiece.ProgressBindable, 1, ((IHasDuration)HitObject).Duration);
         }
 
+        [Cached]
         private readonly Bindable<bool> isHitting = new Bindable<bool>();
 
         private double totalHoldTime;
@@ -147,6 +147,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void Update()
         {
             base.Update();
+
+            if (AllJudged) return;
 
             isHitting.Value = Time.Current >= HitObject.StartTime
                               && Time.Current <= HitObject.GetEndTime()

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -63,8 +63,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             Alpha = 0;
-            AddRangeInternal(new Drawable[]
-            {
+            AddRangeInternal(
+            [
                 TouchHoldBody = new TouchHoldBody(),
                 holdSample = new PausableSkinnableSound
                 {
@@ -72,7 +72,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     Looping = true,
                     Frequency = { Value = 1 }
                 }
-            });
+            ]);
 
             isHitting.BindValueChanged(updateHoldSample);
         }
@@ -198,7 +198,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             base.UpdateHitStateTransforms(state);
-            double time_fade_miss = 400 * (DrawableSentakkiRuleset?.GameplaySpeed ?? 1);
+            double time_fade_miss = 400;
 
             switch (state)
             {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideChevron.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideChevron.cs
@@ -53,5 +53,15 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides
                 Thickness = 6.5f
             });
         }
+
+        protected override void FreeAfterUse()
+        {
+            // This is used to ensure that the chevrons transforms are reverted to the initial state.
+            // TODO: Investigate what clears the transforms without rewinding them...
+            ApplyTransformsAt(double.MinValue, propagateChildren: true);
+            ClearTransformsAfter(double.MinValue, propagateChildren: true);
+
+            base.FreeAfterUse();
+        }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideChevron.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideChevron.cs
@@ -58,7 +58,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides
         {
             // This is used to ensure that the chevrons transforms are reverted to the initial state.
             // TODO: Investigate what clears the transforms without rewinding them...
-            ApplyTransformsAt(double.MinValue, propagateChildren: true);
+            if (!RemoveCompletedTransforms)
+                ApplyTransformsAt(double.MinValue, propagateChildren: true);
             ClearTransformsAfter(double.MinValue, propagateChildren: true);
 
             base.FreeAfterUse();

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideChevron.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideChevron.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
-
+                ShadowRadius = 15,
                 Thickness = 6.5f
             });
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideVisual.cs
@@ -270,15 +270,12 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides
             double fadeoutOffset = 0;
             double fadeoutDuration = duration / (i + 1);
 
-            using (BeginAbsoluteSequence(hitTime))
+            for (; i >= 0; --i)
             {
-                for (; i >= 0; --i)
-                {
-                    var chevron = chevrons[i];
+                var chevron = chevrons[i];
 
-                    chevron.FadeIn().Delay(fadeoutOffset).FadeOut(fadeoutDuration);
-                    fadeoutOffset += fadeoutDuration / 2;
-                }
+                chevron.FadeIn().Delay(fadeoutOffset).FadeOut(fadeoutDuration);
+                fadeoutOffset += fadeoutDuration / 2;
             }
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCentrePiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCentrePiece.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
         public Container PieceContainer;
 
         [Resolved]
-        private Bindable<IReadOnlyList<Color4>> paletteBindable { get; set; } = null!;
+        private Bindable<IReadOnlyList<Color4>>? paletteBindable { get; set; } = null!;
 
         private Container progressParts;
 
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
         {
             base.LoadComplete();
 
-            paletteBindable.BindValueChanged(p =>
+            paletteBindable?.BindValueChanged(p =>
             {
                 for (int i = 0; i < progressParts.Count; ++i)
                     progressParts[i].Colour = p.NewValue[i];

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCentrePiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCentrePiece.cs
@@ -26,20 +26,20 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
             Rotation = 45;
             Scale = new Vector2(80 / 90f);
 
-            InternalChildren = new Drawable[]
-            {
+            InternalChildren =
+            [
                 PieceContainer = new Container
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
-                    {
+                    Children =
+                    [
                         createTouchShapeWith<TouchPieceShadow>(),
                         progressParts = createTouchShapeWith<TouchHoldPiece>(),
-                    }
+                    ]
                 },
-            };
+            ];
         }
 
         protected override void LoadComplete()
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
-                Children = new Drawable[]{
+                Children = [
                     new T
                     {
                         Anchor = Anchor.TopCentre,
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                         Anchor = Anchor.CentreLeft,
                         Rotation = 270,
                     },
-                }
+                ]
             };
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCentrePiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCentrePiece.cs
@@ -46,7 +46,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
         {
             base.LoadComplete();
 
-
             paletteBindable.BindValueChanged(p =>
             {
                 for (int i = 0; i < progressParts.Count; ++i)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCircularProgress.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCircularProgress.cs
@@ -20,7 +20,7 @@ public partial class TouchHoldCircularProgress : CircularProgress
         set
         {
             originalColour = value;
-            flashingColour = value.LightenHSL(0.3f);
+            flashingColour = value.LightenHSL(0.4f);
         }
     }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCircularProgress.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCircularProgress.cs
@@ -25,12 +25,13 @@ public partial class TouchHoldCircularProgress : CircularProgress
     }
 
     [Resolved]
-    private Bindable<bool> isHitting { get; set; } = new();
+    private Bindable<bool>? isHitting { get; set; }
+
     protected override void Update()
     {
         base.Update();
 
-        if (isHitting.Value)
+        if (isHitting?.Value ?? false)
         {
             const double flashing_time = 80;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCircularProgress.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCircularProgress.cs
@@ -1,0 +1,49 @@
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Sentakki.Extensions;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds;
+
+public partial class TouchHoldCircularProgress : CircularProgress
+{
+    private Color4 originalColour;
+    private Color4 flashingColour;
+
+    public Color4 AccentColour
+    {
+        get => originalColour;
+        set
+        {
+            originalColour = value;
+            flashingColour = value.LightenHSL(0.3f);
+        }
+    }
+
+    [Resolved]
+    private Bindable<bool> isHitting { get; set; } = new();
+    protected override void Update()
+    {
+        base.Update();
+
+        if (isHitting.Value)
+        {
+            const double flashing_time = 80;
+
+            double flashProg = (Time.Current % (flashing_time * 2)) / (flashing_time * 2);
+
+            if (flashProg <= 0.5)
+                Colour = Interpolation.ValueAt(flashProg, originalColour, flashingColour, 0, 0.5, Easing.OutSine);
+            else
+                Colour = Interpolation.ValueAt(flashProg, flashingColour, originalColour, 0.5, 0, Easing.InSine);
+        }
+        else
+        {
+            Colour = originalColour;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCompletedCentrePiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCompletedCentrePiece.cs
@@ -4,7 +4,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
-using osu.Framework.Graphics.UserInterface;
 using osuTK;
 using osuTK.Graphics;
 
@@ -12,7 +11,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
 {
     public partial class TouchHoldCompletedCentre : CompositeDrawable
     {
-        private CircularProgress[] progressParts;
+        private TouchHoldCircularProgress[] progressParts;
 
         [Resolved]
         private Bindable<IReadOnlyList<Color4>> paletteBindable { get; set; } = null!;
@@ -32,8 +31,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                 Colour = Color4.Black,
                 Radius = 10f,
             };
-            InternalChildren = new Drawable[]
-            {
+            InternalChildren =
+            [
                 new Container
                 {
                     Origin = Anchor.Centre,
@@ -43,45 +42,44 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                     Rotation = -45f,
                     Children = progressParts =
                     [
-                        new CircularProgress
+                        new TouchHoldCircularProgress
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             InnerRadius = 1,
-                            Size = Vector2.One,
                             RelativeSizeAxes = Axes.Both,
-                            Progress = 1,
+                            Progress = 0.25,
                         },
-                        new CircularProgress
+                        new TouchHoldCircularProgress
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             InnerRadius = 1,
-                            Size = Vector2.One,
                             RelativeSizeAxes = Axes.Both,
-                            Progress = 0.75 ,
+                            Progress = 0.25,
+                            Rotation = 90
                         },
-                        new CircularProgress
+                        new TouchHoldCircularProgress
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             InnerRadius = 1,
-                            Size = Vector2.One,
                             RelativeSizeAxes = Axes.Both,
-                            Progress = 0.5 ,
+                            Progress = 0.25,
+                            Rotation = 180
                         },
-                        new CircularProgress
+                        new TouchHoldCircularProgress
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             InnerRadius = 1,
-                            Size = Vector2.One,
                             RelativeSizeAxes = Axes.Both,
-                            Progress = 0.25 ,
+                            Progress = 0.25,
+                            Rotation = 270
                         },
                     ]
                 },
-            };
+            ];
         }
 
         protected override void LoadComplete()
@@ -91,7 +89,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
             paletteBindable.BindValueChanged(p =>
             {
                 for (int i = 0; i < progressParts.Length; ++i)
-                    progressParts[i].Colour = p.NewValue[^(i + 1)];
+                    progressParts[i].AccentColour = paletteBindable.Value[i];
             }, true);
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCompletedCentrePiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCompletedCentrePiece.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
         private TouchHoldCircularProgress[] progressParts;
 
         [Resolved]
-        private Bindable<IReadOnlyList<Color4>> paletteBindable { get; set; } = null!;
+        private Bindable<IReadOnlyList<Color4>>? paletteBindable { get; set; } = null!;
 
         public TouchHoldCompletedCentre()
         {
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
         {
             base.LoadComplete();
 
-            paletteBindable.BindValueChanged(p =>
+            paletteBindable?.BindValueChanged(p =>
             {
                 for (int i = 0; i < progressParts.Length; ++i)
                     progressParts[i].AccentColour = paletteBindable.Value[i];

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldProgressPiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldProgressPiece.cs
@@ -4,7 +4,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.UserInterface;
 using osuTK;
 using osuTK.Graphics;
 
@@ -14,7 +13,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
     {
         public BindableDouble ProgressBindable = new BindableDouble();
 
-        private CircularProgress[] progressParts;
+        private TouchHoldCircularProgress[] progressParts;
 
         [Resolved]
         private Bindable<IReadOnlyList<Color4>> paletteBindable { get; set; } = null!;
@@ -40,7 +39,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                     Size = new Vector2(2),
                     Rotation = -45f,
                     Children = progressParts = [
-                        new CircularProgress
+                        new TouchHoldCircularProgress
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
@@ -49,7 +48,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                             RelativeSizeAxes = Axes.Both,
                             Progress = 0,
                         },
-                        new CircularProgress
+                        new TouchHoldCircularProgress
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
@@ -57,8 +56,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                             Size = Vector2.One,
                             RelativeSizeAxes = Axes.Both,
                             Progress = 0,
+                            Rotation = 90,
                         },
-                        new CircularProgress
+                        new TouchHoldCircularProgress
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
@@ -66,8 +66,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                             Size = Vector2.One,
                             RelativeSizeAxes = Axes.Both,
                             Progress = 0,
+                            Rotation = 180,
                         },
-                        new CircularProgress
+                        new TouchHoldCircularProgress
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
@@ -75,6 +76,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
                             Size = Vector2.One,
                             RelativeSizeAxes = Axes.Both,
                             Progress = 0,
+                            Rotation = 270,
                         }
                     ]
                 }
@@ -88,13 +90,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
             ProgressBindable.BindValueChanged(p =>
             {
                 for (int i = 0; i < progressParts.Length; ++i)
-                    progressParts[^(i + 1)].Progress = Math.Min(p.NewValue, 0.25 * (i + 1));
+                    progressParts[i].Progress = Math.Clamp(p.NewValue - i * 0.25, 0, 0.25);
             }, true);
 
             paletteBindable.BindValueChanged(p =>
             {
                 for (int i = 0; i < progressParts.Length; ++i)
-                    progressParts[i].Colour = p.NewValue[^(i + 1)];
+                    progressParts[i].AccentColour = p.NewValue[i];
             }, true);
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldProgressPiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldProgressPiece.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
             ProgressBindable?.BindValueChanged(p =>
             {
                 for (int i = 0; i < progressParts.Length; ++i)
-                    progressParts[i].Progress = Math.Clamp(p.NewValue - i * 0.25, 0, 0.25);
+                    progressParts[i].Progress = Math.Clamp(p.NewValue - (i * 0.25), 0, 0.25);
             }, true);
 
             paletteBindable?.BindValueChanged(p =>

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldProgressPiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldProgressPiece.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
         private TouchHoldCircularProgress[] progressParts;
 
         [Resolved]
-        private Bindable<IReadOnlyList<Color4>> paletteBindable { get; set; } = null!;
+        private Bindable<IReadOnlyList<Color4>>? paletteBindable { get; set; } = null!;
 
         public TouchHoldProgressPiece()
         {
@@ -87,13 +87,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
         {
             base.LoadComplete();
 
-            ProgressBindable.BindValueChanged(p =>
+            ProgressBindable?.BindValueChanged(p =>
             {
                 for (int i = 0; i < progressParts.Length; ++i)
                     progressParts[i].Progress = Math.Clamp(p.NewValue - i * 0.25, 0, 0.25);
             }, true);
 
-            paletteBindable.BindValueChanged(p =>
+            paletteBindable?.BindValueChanged(p =>
             {
                 for (int i = 0; i < progressParts.Length; ++i)
                     progressParts[i].AccentColour = p.NewValue[i];

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Touches/TouchBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Touches/TouchBody.cs
@@ -21,19 +21,19 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Touches
             Origin = Anchor.Centre;
             Alpha = 0;
 
-            InternalChildren = new Drawable[]
-            {
+            InternalChildren =
+            [
                 PieceContainer = new Container
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
-                    {
+                    Children =
+                    [
                         createTouchShape<TouchPieceShadow>(),
                         createTouchShape<TouchPiece>(),
                         new DotPiece()
-                    }
+                    ]
                 },
                 BorderContainer = new Container
                 {
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Touches
                         RelativeSizeAxes = Axes.Both
                     }
                 },
-            };
+            ];
         }
 
         private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
@@ -66,13 +66,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Touches
         }
 
         // Creates the touch shape using the provided drawable as each of the 4 quarters
-        private Drawable createTouchShape<T>(bool shadow = false) where T : Drawable, new()
+        private Drawable createTouchShape<T>() where T : Drawable, new()
             => new Container
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
-                Children = new Drawable[]{
+                Children = [
                     new T()
                     {
                         Anchor = Anchor.TopCentre,
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Touches
                         Anchor = Anchor.CentreRight,
                         Rotation = 90
                     },
-                }
+                ]
             };
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiSlidePath.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiSlidePath.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
         public readonly SliderPath[] SlideSegments;
 
-        public readonly float FanStartProgress = 1;
+        public readonly float FanStartProgress = float.MaxValue;
 
         public bool EndsWithSlideFan { get; private set; }
         public bool StartsWithSlideFan { get; private set; }

--- a/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
@@ -130,9 +130,9 @@ namespace osu.Game.Rulesets.Sentakki
 
         public static Color4 LightenHSL(this Color4 colour, float ratio)
         {
-            float r = colour.R + (1 - colour.R) * ratio;
-            float g = colour.G + (1 - colour.G) * ratio;
-            float b = colour.B + (1 - colour.B) * ratio;
+            float r = colour.R + ((1 - colour.R) * ratio);
+            float g = colour.G + ((1 - colour.G) * ratio);
+            float b = colour.B + ((1 - colour.B) * ratio);
 
             return new Color4(r, g, b, colour.A);
         }

--- a/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
@@ -127,5 +127,14 @@ namespace osu.Game.Rulesets.Sentakki
                     return result.GetDescription();
             }
         }
+
+        public static Color4 LightenHSL(this Color4 colour, float ratio)
+        {
+            float r = colour.R + (1 - colour.R) * ratio;
+            float g = colour.G + (1 - colour.G) * ratio;
+            float b = colour.B + (1 - colour.B) * ratio;
+
+            return new Color4(r, g, b, colour.A);
+        }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
@@ -1,7 +1,5 @@
 using System;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Transforms;
@@ -16,8 +14,6 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
     {
         public override bool RemoveWhenNotAlive => true;
 
-        private readonly HitExplosionContainer visual;
-
         private const float default_explosion_size = 75;
         private const float touch_hold_explosion_size = 100;
 
@@ -27,21 +23,29 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             Origin = Anchor.Centre;
             Size = new Vector2(default_explosion_size);
             Colour = Color4.White;
+            BorderColour = Color4.White;
             Alpha = 0;
-            InternalChildren =
-            [
-                visual = new HitExplosionContainer()
-            ];
-
-            borderRatio.BindValueChanged(setBorderThiccness, true);
+            Masking = true;
+            CornerExponent = 2;
+            InternalChild = new Box
+            {
+                Alpha = 0,
+                RelativeSizeAxes = Axes.Both,
+                AlwaysPresent = true,
+            };
         }
 
-        private void setBorderThiccness(ValueChangedEvent<float> v)
+        private bool circular = true;
+
+        protected override void Update()
         {
-            visual.BorderThickness = Size.X / 2 * v.NewValue;
-        }
+            base.Update();
 
-        private readonly BindableFloat borderRatio = new BindableFloat(1);
+            if (circular) // We mimic whatever CircularContainer does
+                CornerRadius = Math.Min(DrawSize.X, DrawSize.Y) * 0.5f;
+            else
+                CornerRadius = 20;
+        }
 
         public HitExplosion Apply(DrawableSentakkiHitObject drawableSentakkiHitObject)
         {
@@ -52,13 +56,13 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                 case SentakkiLanedHitObject lanedObject:
                     Position = SentakkiExtensions.GetPositionAlongLane(SentakkiPlayfield.INTERSECTDISTANCE, lanedObject.Lane);
                     Size = new Vector2(default_explosion_size);
-                    visual.Circular = true;
+                    circular = true;
                     break;
 
                 case Touch touchObject:
                     Position = touchObject.Position;
                     Size = new Vector2(default_explosion_size);
-                    visual.Circular = false;
+                    circular = false;
                     Rotation = 0;
                     break;
 
@@ -66,7 +70,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
                 default:
                     Position = Vector2.Zero;
                     Size = new Vector2(touch_hold_explosion_size);
-                    visual.Circular = false;
+                    circular = false;
                     Rotation = 45;
                     break;
             }
@@ -85,47 +89,18 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             Explode().Expire(true);
         }
 
-        public TransformSequence<HitExplosion> Explode(double explode_duration = 80)
+        public TransformSequence<HitExplosion> Explode()
         {
+            const double explode_duration = 80;
             var sequence = this.FadeTo(0.8f)
-                               .TransformBindableTo(borderRatio, 1)
+                               .TransformTo(nameof(BorderThickness), Size.X * 0.5f)
                                .ScaleTo(1)
                                .Then()
-                               .TransformBindableTo(borderRatio, 0f, duration: explode_duration)
+                               .TransformTo(nameof(BorderThickness), 0f, duration: explode_duration)
                                .ScaleTo(2f, explode_duration)
                                .FadeOut(explode_duration);
 
             return sequence;
-        }
-
-        private partial class HitExplosionContainer : Container
-        {
-            public bool Circular { get; set; } = true;
-
-            public HitExplosionContainer()
-            {
-                Masking = true;
-                CornerExponent = 2;
-                Anchor = Anchor.Centre;
-                Origin = Anchor.Centre;
-                RelativeSizeAxes = Axes.Both;
-                BorderColour = Color4.White;
-                Child = new Box
-                {
-                    Alpha = 0,
-                    RelativeSizeAxes = Axes.Both,
-                    AlwaysPresent = true,
-                };
-            }
-
-            protected override void Update()
-            {
-                base.Update();
-                if (Circular)
-                    CornerRadius = Math.Min(DrawSize.X, DrawSize.Y) * 0.5f;
-                else
-                    CornerRadius = 20;
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/HitExplosion.cs
@@ -1,5 +1,4 @@
 using System;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -8,7 +7,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Transforms;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
-using osu.Game.Rulesets.UI;
 using osuTK;
 using osuTK.Graphics;
 
@@ -23,9 +21,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
         private const float default_explosion_size = 75;
         private const float touch_hold_explosion_size = 100;
 
-        public HitExplosion() : this(false) { }
-
-        public HitExplosion(bool forTouch = false)
+        public HitExplosion()
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
@@ -34,9 +30,7 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             Alpha = 0;
             InternalChildren =
             [
-                visual = new HitExplosionContainer(){
-                    Circular = !forTouch
-                },
+                visual = new HitExplosionContainer()
             ];
 
             borderRatio.BindValueChanged(setBorderThiccness, true);
@@ -104,22 +98,9 @@ namespace osu.Game.Rulesets.Sentakki.UI.Components
             return sequence;
         }
 
-        [Resolved(canBeNull: true)]
-        private SentakkiPlayfield? playfield { get; set; }
-
-        public void ManualExplode(double progress)
-        {
-            if (!playfield?.DisplayJudgements.Value ?? false)
-                return;
-
-            Alpha = (float)(0.8f * (1 - progress));
-            borderRatio.Value = (float)(1 * (1 - progress));
-            Scale = new Vector2((float)(1 + progress));
-        }
-
         private partial class HitExplosionContainer : Container
         {
-            public bool Circular { get; set; }
+            public bool Circular { get; set; } = true;
 
             public HitExplosionContainer()
             {

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -167,7 +167,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
             if (!result.IsHit) return;
 
-
             if (judgedObject.HitObject.Kiai)
                 ring.KiaiBeat();
 

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -167,11 +167,27 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
             if (!result.IsHit) return;
 
-            // We don't need an explosion for the slide body
-            if (judgedObject is DrawableSlideBody) return;
 
             if (judgedObject.HitObject.Kiai)
                 ring.KiaiBeat();
+
+            // Slide bodies can have multiple stars that may not be aligned to the laned end due to the player being able to complete it way ahead of time
+            // We should provide an explosion for each visible star, positioned to where the star was at the time of judgement
+            if (judgedObject is DrawableSlideBody sb)
+            {
+                bool allStarsVisible = sb.StarProgress < sb.HitObject.SlideBodyInfo.SlidePath.FanStartProgress;
+
+                for (int i = allStarsVisible ? 2 : 0; i < 3; ++i)
+                {
+                    var star = sb.SlideStars[i];
+                    var extraExplosion = explosionPool.Get().Apply(sentakkiHitObject);
+
+                    extraExplosion.Position = sb.ToSpaceOfOtherDrawable(star.Position, this) - OriginPosition;
+
+                    explosionLayer.Add(extraExplosion);
+                }
+                return;
+            }
 
             var explosion = explosionPool.Get().Apply(sentakkiHitObject);
             explosionLayer.Add(explosion);

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -167,26 +167,12 @@ namespace osu.Game.Rulesets.Sentakki.UI
 
             if (!result.IsHit) return;
 
+            // Slide bodies don't need explosions, they just don't work.
+            if (judgedObject is DrawableSlideBody)
+                return;
+
             if (judgedObject.HitObject.Kiai)
                 ring.KiaiBeat();
-
-            // Slide bodies can have multiple stars that may not be aligned to the laned end due to the player being able to complete it way ahead of time
-            // We should provide an explosion for each visible star, positioned to where the star was at the time of judgement
-            if (judgedObject is DrawableSlideBody sb)
-            {
-                bool allStarsVisible = sb.StarProgress < sb.HitObject.SlideBodyInfo.SlidePath.FanStartProgress;
-
-                for (int i = allStarsVisible ? 2 : 0; i < 3; ++i)
-                {
-                    var star = sb.SlideStars[i];
-                    var extraExplosion = explosionPool.Get().Apply(sentakkiHitObject);
-
-                    extraExplosion.Position = sb.ToSpaceOfOtherDrawable(star.Position, this) - OriginPosition;
-
-                    explosionLayer.Add(extraExplosion);
-                }
-                return;
-            }
 
             var explosion = explosionPool.Get().Apply(sentakkiHitObject);
             explosionLayer.Add(explosion);


### PR DESCRIPTION
When hitting the hold notes, the note now continuously flashes to indicate they are being held.

Also improved the transform code across all the HitObjects to (hopefully) increase their reliability in replay/editor scenarios.

|Hold|TouchHold|
|---|---|
|<video src="https://github.com/user-attachments/assets/be9f3635-cb12-456e-ab7a-63e567b05cef"/>|<video src="https://github.com/user-attachments/assets/e2a4d35f-6a71-4060-b5a3-ab146de6226e"/>|

