### PR TITLE
Miss unheld hold notes more aggressively when they finish

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -110,8 +110,14 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     ApplyResult(HitResult.Perfect);
                 else if (timeOffset > HitObject.HitWindows.WindowFor(HitResult.Perfect) && isHolding)
                     ApplyResult(applyDeductionTo(HitResult.Great));
-                else if (!HitObject.HitWindows.CanBeHit(timeOffset: timeOffset))
+                else if (timeOffset >= 0 && !isHolding)
+                {
+                    // In this particular case it is very possible that the Head is also not judged.
+                    if (!Head.AllJudged)
+                        Head.MissForcefully();
+
                     ApplyResult(Result.Judgement.MinResult);
+                }
 
                 return;
             }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -110,14 +110,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     ApplyResult(HitResult.Perfect);
                 else if (timeOffset > HitObject.HitWindows.WindowFor(HitResult.Perfect) && isHolding)
                     ApplyResult(applyDeductionTo(HitResult.Great));
-                else if (timeOffset >= 0 && !isHolding)
-                {
-                    // In this particular case it is very possible that the Head is also not judged.
-                    if (!Head.AllJudged)
-                        Head.MissForcefully();
-
+                else if (Head.AllJudged && timeOffset >= 0 && !isHolding)
                     ApplyResult(Result.Judgement.MinResult);
-                }
 
                 return;
             }


### PR DESCRIPTION
Instead of waiting for the late miss window, which could never be reached even when holding the note, we miss unheld notes immediately when `TimeOffset >= 0 and the head is judged`.

This would also ensure that players don't accidentally "hit" hold notes that is way past the intended hit period.