### PR TITLE
Improve lifetime management of DHOs

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -200,6 +200,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             {
                 case ArmedState.Hit:
                     NoteBody.FadeOut();
+                    this.FadeOut();
                     break;
                 case ArmedState.Miss:
                     NoteBody.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -198,6 +198,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             switch (state)
             {
+                case ArmedState.Hit:
+                    NoteBody.FadeOut();
+                    break;
                 case ArmedState.Miss:
                     NoteBody.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
                             .FadeColour(Color4.Red, time_fade_miss, Easing.OutQuint)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -194,22 +194,17 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             base.UpdateHitStateTransforms(state);
-            double time_fade_miss = 400 * (DrawableSentakkiRuleset?.GameplaySpeed ?? 1);
+            double time_fade_miss = 400;
 
             switch (state)
             {
-                case ArmedState.Hit:
-                    Expire();
-                    break;
-
                 case ArmedState.Miss:
                     NoteBody.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
                             .FadeColour(Color4.Red, time_fade_miss, Easing.OutQuint)
                             .MoveToOffset(new Vector2(0, -100), time_fade_miss, Easing.OutCubic)
                             .FadeOut(time_fade_miss);
 
-                    using (BeginDelayedSequence(time_fade_miss))
-                        this.FadeOut();
+                    this.Delay(time_fade_miss).FadeOut();
                     break;
             }
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             // In non-frame-stable contexts, the DHO may be skipped over, so it is never hit/missed and therefore the ArmedState is Idle despite CurrentTime being past the miss window.
             // This manual expiry aims to mitigate the problem.
             // Possibly similar case: https://github.com/ppy/osu/blob/143593b3b90977d0a91da833eccc3efd39c39254/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs#L208
-            this.Delay(HitObject.MaximumJudgementOffset).FadeOut().Expire();
+            this.Delay(HitObject.MaximumJudgementOffset + 50).FadeOut().Expire();
         }
 
         protected new void ApplyResult(HitResult hitResult)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiHitObject.cs
@@ -1,5 +1,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -104,6 +105,22 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             // The transform is reset as soon as this function begins
             // This includes the usual LoadComplete() call, or rewind resets
             transformResetQueued = false;
+        }
+
+        protected override void UpdateHitStateTransforms(ArmedState state)
+        {
+            base.UpdateHitStateTransforms(state);
+
+            if (state is not ArmedState.Idle)
+                return;
+
+            // This is a very aggressive lifetime optimisation to ensure that lifetimes are sane even in editor contexts (or any non-frame stable contexts)
+            // The beginning of DHO.UpdateState() sets LifetimeEnd to double.MaxValue, regardless of the LifetimeEnd set in the LifetimeEntry
+            // After UpdateHitStateTransforms(), the LifetimeEnd only gets set iff the current ArmedState is not Idle.
+            // In non-frame-stable contexts, the DHO may be skipped over, so it is never hit/missed and therefore the ArmedState is Idle despite CurrentTime being past the miss window.
+            // This manual expiry aims to mitigate the problem.
+            // Possibly similar case: https://github.com/ppy/osu/blob/143593b3b90977d0a91da833eccc3efd39c39254/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs#L208
+            this.Delay(HitObject.MaximumJudgementOffset).FadeOut().Expire();
         }
 
         protected new void ApplyResult(HitResult hitResult)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlide.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlide.cs
@@ -54,7 +54,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
-            // We also make sure all transforms have finished to avoid jank
             bool allClear = true;
 
             for (int i = 0; i < NestedHitObjects.Count; i++)
@@ -66,6 +65,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                 allClear = allClear && nested.Result.IsHit;
             }
 
+            // In order to ensure all animations do not get interrupted, we update the hit state transforms to accommodate the worst result
             ApplyResult(allClear ? Result.Judgement.MaxResult : Result.Judgement.MinResult);
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlide.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlide.cs
@@ -55,14 +55,18 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             // We also make sure all transforms have finished to avoid jank
+            bool allClear = true;
+
             for (int i = 0; i < NestedHitObjects.Count; i++)
             {
                 var nested = NestedHitObjects[i];
-                if (!nested.Result.HasResult || Time.Current < nested.LatestTransformEndTime)
+                if (!nested.Result.HasResult)
                     return;
+
+                allClear = allClear && nested.Result.IsHit;
             }
 
-            ApplyResult(Result.Judgement.MaxResult);
+            ApplyResult(allClear ? Result.Judgement.MaxResult : Result.Judgement.MinResult);
         }
 
         protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)
@@ -111,6 +115,20 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             }
 
             base.AddNestedHitObject(hitObject);
+        }
+
+        protected override void UpdateHitStateTransforms(ArmedState state)
+        {
+            base.UpdateHitStateTransforms(state);
+            switch (state)
+            {
+                case ArmedState.Hit:
+                    this.Delay(200).FadeOut().Expire();
+                    break;
+                case ArmedState.Miss:
+                    this.Delay(400).FadeOut().Expire();
+                    break;
+            }
         }
 
         protected override void ClearNestedHitObjects()

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideBody.cs
@@ -263,7 +263,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     foreach (var star in SlideStars)
                         star.FadeOut(time_fade_hit);
 
-                    this.Delay(time_fade_hit).Expire();
+                    this.Delay(time_fade_hit).FadeOut();
 
                     break;
 
@@ -274,7 +274,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                         star.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
                             .MoveToOffset(SentakkiExtensions.GetCircularPosition(100, star.Rotation), time_fade_miss, Easing.OutCubic);
 
-                    this.FadeColour(Color4.Red, time_fade_miss, Easing.OutQuint).FadeOut(time_fade_miss).Expire();
+                    this.FadeColour(Color4.Red, time_fade_miss, Easing.OutQuint).FadeOut(time_fade_miss);
                     break;
             }
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
@@ -10,6 +10,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
     public partial class DrawableSlideCheckpoint : DrawableSentakkiHitObject
     {
+        // Slides parts can be hit as long as the body is visible, regardless of it's intended time
+        // By setting the animation duration to an absurdly high value, the lifetimes of touch regions are bounded by the parent DrawableSlide.
+        protected override double InitialLifetimeOffset => double.MaxValue;
+
         public new SlideCheckpoint HitObject => (SlideCheckpoint)base.HitObject;
 
         public override bool DisplayResult => false;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpoint.cs
@@ -12,10 +12,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
     {
         public new SlideCheckpoint HitObject => (SlideCheckpoint)base.HitObject;
 
-        // We need this to be alive as soon as the parent slide note is alive
-        // This is to ensure reverts are still possible during edge case situation (eg. 0 duration slide)
-        protected override bool ShouldBeAlive => Time.Current < LifetimeEnd;
-
         public override bool DisplayResult => false;
 
         private new DrawableSlideBody ParentHitObject => (DrawableSlideBody)base.ParentHitObject;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
@@ -12,10 +12,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         private DrawableSlideCheckpoint checkpoint => (DrawableSlideCheckpoint)ParentHitObject;
 
-        // We need this to be alive as soon as the parent slide note is alive
-        // This is to ensure reverts are still possible during edge case situation (eg. 0 duration slide)
-        protected override bool ShouldBeAlive => true;
-
         public override bool HandlePositionalInput => true;
         public override bool DisplayResult => false;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
@@ -7,6 +7,10 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 {
     public partial class DrawableSlideCheckpointNode : DrawableSentakkiHitObject
     {
+        // Slides parts can be hit as long as the body is visible, regardless of it's intended time
+        // By setting the animation duration to an absurdly high value, the lifetimes of touch regions are bounded by the parent DrawableSlide.
+        protected override double InitialLifetimeOffset => double.MaxValue;
+
         public new SlideCheckpoint.CheckpointNode HitObject => (SlideCheckpoint.CheckpointNode)base.HitObject;
 
         private DrawableSlideCheckpoint checkpoint => (DrawableSlideCheckpoint)ParentHitObject;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Game.Rulesets.Scoring;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -103,7 +103,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             {
                 case ArmedState.Hit:
                     TapVisual.FadeOut();
-                    Expire();
                     break;
 
                 case ArmedState.Miss:
@@ -112,7 +111,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                              .MoveToOffset(new Vector2(0, -100), time_fade_miss, Easing.OutCubic)
                              .FadeOut(time_fade_miss);
 
-                    this.ScaleTo(1f, time_fade_miss).Expire();
+                    this.Delay(time_fade_miss).FadeOut();
 
                     break;
             }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -103,6 +103,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             {
                 case ArmedState.Hit:
                     TapVisual.FadeOut();
+                    this.FadeOut();
                     break;
 
                 case ArmedState.Miss:

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -141,10 +141,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             switch (state)
             {
-                case ArmedState.Hit:
-                    Expire();
-                    break;
-
                 case ArmedState.Miss:
                     this.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
                         .FadeColour(Color4.Red, time_fade_miss, Easing.OutQuint)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -143,6 +143,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             {
                 case ArmedState.Hit:
                     TouchBody.FadeOut();
+                    this.FadeOut();
                     break;
 
                 case ArmedState.Miss:

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -141,10 +141,16 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             switch (state)
             {
+                case ArmedState.Hit:
+                    TouchBody.FadeOut();
+                    break;
+
                 case ArmedState.Miss:
-                    this.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
+                    TouchBody.ScaleTo(0.5f, time_fade_miss, Easing.InCubic)
                         .FadeColour(Color4.Red, time_fade_miss, Easing.OutQuint)
                         .FadeOut(time_fade_miss);
+
+                    this.Delay(time_fade_miss).FadeOut();
                     break;
             }
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -62,7 +62,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             Colour = Color4.SlateGray;
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
-            Alpha = 0;
             AddRangeInternal(
             [
                 TouchHoldBody = new TouchHoldBody(),
@@ -108,7 +107,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             double animTime = AnimationDuration.Value * 0.8;
             double fadeTime = AnimationDuration.Value * 0.2;
 
-            this.FadeInFromZero(fadeTime).ScaleTo(1);
+            TouchHoldBody.FadeInFromZero(fadeTime).ScaleTo(1);
 
             using (BeginDelayedSequence(fadeTime))
                 TouchHoldBody.ResizeTo(80, animTime, Easing.InCirc);
@@ -203,8 +202,13 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             switch (state)
             {
+                case ArmedState.Hit:
+                    TouchHoldBody.FadeOut();
+                    break;
+
                 case ArmedState.Miss:
-                    this.ScaleTo(.0f, time_fade_miss).FadeOut(time_fade_miss).Expire();
+                    TouchHoldBody.ScaleTo(.0f, time_fade_miss).FadeOut(time_fade_miss).Expire();
+                    this.Delay(time_fade_miss).FadeOut();
                     break;
             }
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -203,10 +203,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
             switch (state)
             {
-                case ArmedState.Hit:
-                    Expire();
-                    break;
-
                 case ArmedState.Miss:
                     this.ScaleTo(.0f, time_fade_miss).FadeOut(time_fade_miss).Expire();
                     break;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -204,10 +204,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             {
                 case ArmedState.Hit:
                     TouchHoldBody.FadeOut();
+                    this.FadeOut();
                     break;
 
                 case ArmedState.Miss:
-                    TouchHoldBody.ScaleTo(.0f, time_fade_miss).FadeOut(time_fade_miss).Expire();
+                    TouchHoldBody.ScaleTo(.0f, time_fade_miss).FadeOut(time_fade_miss);
                     this.Delay(time_fade_miss).FadeOut();
                     break;
             }

--- a/osu.Game.Rulesets.Sentakki/Objects/ScorePaddingObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/ScorePaddingObject.cs
@@ -8,6 +8,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects
     // Used to increase the weighting of an object
     public class ScorePaddingObject : HitObject
     {
+        public override double MaximumJudgementOffset => ParentMaximumJudgementOffset;
+        public double ParentMaximumJudgementOffset { get; set; }
+
         public override Judgement CreateJudgement() => new SentakkiJudgement();
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             base.CreateNestedHitObjects(cancellationToken);
 
             for (int i = 1; i < ScoreWeighting; ++i)
-                AddNested(new ScorePaddingObject { StartTime = this.GetEndTime() });
+                AddNested(new ScorePaddingObject { StartTime = this.GetEndTime(), ParentMaximumJudgementOffset = MaximumJudgementOffset });
         }
 
         public HitSampleInfo[] CreateBreakSample()

--- a/osu.Game.Rulesets.Sentakki/Objects/Slide.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Slide.cs
@@ -10,6 +10,18 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 {
     public class Slide : SentakkiLanedHitObject, IHasDuration
     {
+        public override double MaximumJudgementOffset
+        {
+            get
+            {
+                double offset = 0.0;
+                foreach (var nested in NestedHitObjects)
+                    offset = Math.Max(offset, nested.MaximumJudgementOffset);
+
+                return offset;
+            }
+        }
+
         public enum TapTypeEnum
         {
             Star,

--- a/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlideBody.cs
@@ -73,7 +73,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                     {
                         Progress = (float)progress,
                         StartTime = StartTime + ShootDelay + ((Duration - ShootDelay) * progress),
-                        NodePositions = new List<Vector2> { SlideBodyInfo.SlidePath.PositionAt(progress) }
+                        NodePositions = new List<Vector2> { SlideBodyInfo.SlidePath.PositionAt(progress) },
+                        SlideDuration = Duration
                     };
 
                     AddNested(checkpoint);
@@ -99,6 +100,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
                     Progress = progress,
                     StartTime = StartTime + ShootDelay + ((Duration - ShootDelay) * progress),
                     NodesToPass = 2,
+                    SlideDuration = Duration
                 };
 
                 for (int j = -1; j < 2; ++j)

--- a/osu.Game.Rulesets.Sentakki/Objects/SlideCheckpoint.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SlideCheckpoint.cs
@@ -8,6 +8,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 {
     public class SlideCheckpoint : SentakkiHitObject
     {
+        public double SlideDuration { get; set; }
+        public override double MaximumJudgementOffset => SlideDuration;
+
         // Used to update slides visuals
         public float Progress { get; set; }
 
@@ -19,7 +22,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
         {
             foreach (var nodePosition in NodePositions)
-                AddNested(new CheckpointNode(nodePosition) { StartTime = StartTime });
+                AddNested(new CheckpointNode(nodePosition) { StartTime = StartTime, SlideDuration = SlideDuration });
         }
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
@@ -27,6 +30,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
         public class CheckpointNode : SentakkiHitObject
         {
+            public double SlideDuration { get; set; }
+            public override double MaximumJudgementOffset => SlideDuration;
+
             public CheckpointNode(Vector2 position)
             {
                 Position = position;

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiHitObjectLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiHitObjectLifetimeEntry.cs
@@ -15,6 +15,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
             : base(hitObject)
         {
             drawableRuleset = senRuleset;
+
             bindAnimationDuration();
             AnimationDurationBindable.BindValueChanged(x => LifetimeStart = HitObject.StartTime - InitialLifetimeOffset, true);
 
@@ -26,6 +27,13 @@ namespace osu.Game.Rulesets.Sentakki.UI
         {
             switch (HitObject)
             {
+                // Slides parts can be hit as long as the body is visible, regardless of it's intended time
+                // By setting the animation duration to an absurdly high value, the lifetimes of touch regions are bounded by the parent DrawableSlide.
+                case SlideCheckpoint:
+                case SlideCheckpoint.CheckpointNode:
+                    AnimationDurationBindable.Value = double.MaxValue;
+                    break;
+
                 case SentakkiLanedHitObject:
                     AnimationDurationBindable.BindTo(drawableRuleset.AdjustedAnimDuration);
                     break;

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiHitObjectLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiHitObjectLifetimeEntry.cs
@@ -1,9 +1,6 @@
-using System;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.Objects;
-using osu.Game.Rulesets.Sentakki.Scoring;
 
 namespace osu.Game.Rulesets.Sentakki.UI
 {

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiHitObjectLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiHitObjectLifetimeEntry.cs
@@ -1,6 +1,9 @@
+using System;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Scoring;
 
 namespace osu.Game.Rulesets.Sentakki.UI
 {
@@ -17,6 +20,9 @@ namespace osu.Game.Rulesets.Sentakki.UI
             drawableRuleset = senRuleset;
             bindAnimationDuration();
             AnimationDurationBindable.BindValueChanged(x => LifetimeStart = HitObject.StartTime - InitialLifetimeOffset, true);
+
+            // Prevent past objects in idles states from remaining alive as their end times are skipped in non-frame-stable contexts.
+            LifetimeEnd = HitObject.GetEndTime() + HitObject.MaximumJudgementOffset;
         }
 
         private void bindAnimationDuration()


### PR DESCRIPTION
This is an effort to make DHO's play nicer with non-frameStable contexts like the editor, at the same time removing some of the more hacky aspects of HitStateTransforms (specifically the WTF in `DrawableSlide.CheckForResult`)