### PR TITLE
Add expected keywords to sentakki settings

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
@@ -30,7 +30,8 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 new SettingsCheckbox
                 {
                     LabelText = SentakkiSettingsSubsectionStrings.ShowKiaiEffects,
-                    Current = config.GetBindable<bool>(SentakkiRulesetSettings.KiaiEffects)
+                    Current = config.GetBindable<bool>(SentakkiRulesetSettings.KiaiEffects),
+                    Keywords = ["visualiser"]
                 },
                 new SettingsCheckbox
                 {
@@ -45,12 +46,14 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 new SettingsCheckbox
                 {
                     LabelText = SentakkiSettingsSubsectionStrings.ShowDetailedJudgements,
-                    Current = config.GetBindable<bool>(SentakkiRulesetSettings.DetailedJudgements)
+                    Current = config.GetBindable<bool>(SentakkiRulesetSettings.DetailedJudgements),
+                    Keywords = ["early", "late", "indicators"]
                 },
                 new SettingsEnumDropdown<ColorOption>
                 {
                     LabelText = SentakkiSettingsSubsectionStrings.RingColor,
-                    Current = config.GetBindable<ColorOption>(SentakkiRulesetSettings.RingColor)
+                    Current = config.GetBindable<ColorOption>(SentakkiRulesetSettings.RingColor),
+                    Keywords = ["color"]
                 },
                 new SettingsSlider<float, NoteTimeSlider>
                 {


### PR DESCRIPTION
Fixes #682 

Includes things like "color" as an alternative search term for colour, "early"/"late" for detailed judgements, etc.