### PR TITLE
Relax slide part validity check

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneAllSlides.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/Slides/TestSceneAllSlides.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
             });
             Add(slide = new SlideVisual());
 
-            AddSliderStep("Path ID", 0, SlidePaths.VALIDPATHS.Count - 1, 0, p =>
+            AddSliderStep("Path ID", 0, SlidePaths.VALID_CONVERT_PATHS.Count - 1, 0, p =>
             {
                 id = p;
                 RefreshSlide();
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects.Slides
             });
         }
 
-        protected SentakkiSlidePath CreatePattern() => SlidePaths.CreateSlidePath(SlidePaths.VALIDPATHS[id].SlidePart);
+        protected SentakkiSlidePath CreatePattern() => SlidePaths.CreateSlidePath(SlidePaths.VALID_CONVERT_PATHS[id].SlidePart);
 
         protected override void LoadComplete()
         {

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/Converter/SentakkiBeatmapConverter.Slider.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/Converter/SentakkiBeatmapConverter.Slider.cs
@@ -93,7 +93,7 @@ public partial class SentakkiBeatmapConverter
         double duration = ((IHasDuration)original).Duration;
         double adjustedDuration = duration * velocity;
 
-        var candidates = SlidePaths.VALIDPATHS.AsEnumerable();
+        var candidates = SlidePaths.VALID_CONVERT_PATHS.AsEnumerable();
         if (!ConversionFlags.HasFlag(ConversionFlags.fanSlides) || !allowFans)
             candidates = candidates.Where(p => p.SlidePart.Shape != SlidePaths.PathShapes.Fan);
 

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverterOld.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapConverterOld.cs
@@ -325,7 +325,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
             double duration = ((IHasDuration)original).Duration;
             double adjustedDuration = duration * velocity;
 
-            var candidates = SlidePaths.VALIDPATHS;
+            var candidates = SlidePaths.VALID_CONVERT_PATHS;
             if (!ConversionFlags.HasFlag(ConversionFlags.fanSlides))
                 candidates = candidates.Where(p => p.SlidePart.Shape != SlidePaths.PathShapes.Fan).ToList();
 
@@ -333,7 +333,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                                            .Select(t => t.SlidePart)
                                            .ToList();
 
-            return !candidateParts.Any() ? null : candidateParts[patternGenerator.RNG.Next(candidateParts.Count)];
+            return candidateParts.Count != 0 ? null : candidateParts[patternGenerator.RNG.Next(candidateParts.Count)];
         }
 
         private IEnumerable<Tap> createTapsFromNodes(HitObject original, IList<IList<HitSampleInfo>> nodeSamples)


### PR DESCRIPTION
Allows straight/circular +-1 end offset slides to be legal for editor use. These slides aren't allowed in conversion still.