### PR TITLE
Put touch notes above touchHolds

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -86,6 +86,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 }
             });
             AddNested(LanedPlayfield);
+            AddNested(touchPlayfield);
             NewResult += onNewResult;
         }
 

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiPlayfield.cs
@@ -40,6 +40,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
         public const float NOTESTARTDISTANCE = 66f;
 
         public readonly LanedPlayfield LanedPlayfield;
+        private readonly TouchPlayfield touchPlayfield;
 
         internal readonly Container AccentContainer;
 
@@ -77,7 +78,8 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 },
                 explosionLayer = new Container<HitExplosion> { RelativeSizeAxes = Axes.Both },
                 LanedPlayfield = new LanedPlayfield(),
-                HitObjectContainer, // This only contains Touch related notes, which needs to be above others types
+                HitObjectContainer, // This only contains TouchHolds
+                touchPlayfield = new TouchPlayfield(), // This only contains Touch notes, which needs to be above all other note types
                 judgementLayer = new Container<DrawableSentakkiJudgement>
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -102,8 +104,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
         private void load(SkinManager skinManager, IBeatmap beatmap, BeatmapDifficultyCache difficultyCache)
         {
             RegisterPool<TouchHold, DrawableTouchHold>(2);
-            RegisterPool<Touch, DrawableTouch>(16);
-            RegisterPool<ScorePaddingObject, DrawableScorePaddingObject>(20);
+            RegisterPool<ScorePaddingObject, DrawableScorePaddingObject>(8);
 
             // handle colouring of playfield elements
             beatmapDifficulty = difficultyCache.GetBindableDifficulty(beatmap.BeatmapInfo);
@@ -132,6 +133,10 @@ namespace osu.Game.Rulesets.Sentakki.UI
                     LanedPlayfield.Add(h);
                     break;
 
+                case Touch:
+                    touchPlayfield.Add(h);
+                    break;
+
                 default:
                     base.Add(h);
                     break;
@@ -144,6 +149,9 @@ namespace osu.Game.Rulesets.Sentakki.UI
             {
                 case SentakkiLanedHitObject:
                     return LanedPlayfield.Remove(h);
+
+                case Touch:
+                    return touchPlayfield.Remove(h);
 
                 default:
                     return base.Remove(h);

--- a/osu.Game.Rulesets.Sentakki/UI/TouchPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/TouchPlayfield.cs
@@ -1,0 +1,24 @@
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables;
+using osu.Game.Rulesets.UI;
+
+namespace osu.Game.Rulesets.Sentakki.UI
+{
+    public partial class TouchPlayfield : Playfield
+    {
+        public TouchPlayfield()
+        {
+            RelativeSizeAxes = Axes.Both;
+            Anchor = Origin = Anchor.Centre;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            RegisterPool<Touch, DrawableTouch>(8);
+            RegisterPool<ScorePaddingObject, DrawableScorePaddingObject>(32);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/UI/TouchPlayfield.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/TouchPlayfield.cs
@@ -1,5 +1,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
 using osu.Game.Rulesets.UI;
@@ -13,6 +14,11 @@ namespace osu.Game.Rulesets.Sentakki.UI
             RelativeSizeAxes = Axes.Both;
             Anchor = Origin = Anchor.Centre;
         }
+
+        [Resolved]
+        private DrawableSentakkiRuleset drawableSentakkiRuleset { get; set; } = null!;
+
+        protected override HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject) => new SentakkiHitObjectLifetimeEntry(hitObject, drawableSentakkiRuleset);
 
         [BackgroundDependencyLoader]
         private void load()


### PR DESCRIPTION
In https://github.com/LumpBloom7/sentakki/pull/672/commits/f4ace7b66510bcf9255547e59693bd143bd2f006, the Touch playfield was removed as part of a simplification of input handling. However, the Touch playfield did serve the additional purpose of ensuring Touch notes are drawn above TouchHolds. 

This change brings the playfield back.