### PR TITLE
Clean up/Simplify note visual shaders

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneSlideFan.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Objects/TestSceneSlideFan.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Sentakki.UI;
 using osu.Game.Rulesets.Sentakki.UI.Components;
 using osu.Game.Tests.Visual;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.Tests.Objects
 {
@@ -51,10 +52,6 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
             });
 
             Add(chevronPool = new DrawablePool<SlideChevron>(62));
-
-            AddStep("Miss Single", () => testSingle(2000));
-            AddStep("Hit Single", () => testSingle(2000, true));
-            AddUntilStep("Wait for object despawn", () => !Children.Any(h => (h is DrawableSentakkiHitObject hitObject) && hitObject.AllJudged == false));
         }
 
         [TestCaseSource(nameof(ObjectFlagsSource))]
@@ -69,19 +66,30 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Objects
         {
             var slide = new Slide
             {
-                //Break = true,
+                Break = headBreak,
+                Ex = headEX,
                 SlideInfoList = new List<SlideBodyInfo>
                 {
                     new SlideBodyInfo
                     {
                         SlidePathParts = new[] { new SlideBodyPart(SlidePaths.PathShapes.Fan, 4, false) },
                         Duration = duration,
+                        Break = bodyBreak,
+                        Ex = bodyEx
                     },
                 },
                 StartTime = Time.Current + 1000,
             };
 
             slide.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+            if (headBreak)
+                slide.SlideTap.NoteColour = Color4.OrangeRed;
+            if (bodyBreak)
+            {
+                foreach (var body in slide.SlideBodies)
+                    body.NoteColour = Color4.OrangeRed;
+            }
 
             DrawableSlide dSlide;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/LaneNoteVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/LaneNoteVisual.cs
@@ -21,7 +21,7 @@ public enum NoteShape
 public partial class LaneNoteVisual : Sprite, ITexturedShaderDrawable
 {
     public NoteShape Shape { get; init; } = NoteShape.Ring;
-    private float thickness = 0.25f;
+    private float thickness = 18.75f;
     public float Thickness
     {
         get => thickness;
@@ -34,7 +34,7 @@ public partial class LaneNoteVisual : Sprite, ITexturedShaderDrawable
         }
     }
 
-    private float shadowRadius = 15f / 105f;
+    private float shadowRadius = 15;
     public float ShadowRadius
     {
         get => shadowRadius;
@@ -92,6 +92,18 @@ public partial class LaneNoteVisual : Sprite, ITexturedShaderDrawable
         // Bind exnote
         exBindable.BindTo(((DrawableSentakkiHitObject)hitObject).ExBindable);
         exBindable.BindValueChanged(b => Glow = b.NewValue, true);
+
+        Blending = new BlendingParameters
+        {
+            Source = BlendingType.One,
+            Destination = BlendingType.OneMinusSrcAlpha,
+
+            SourceAlpha = BlendingType.One,
+            DestinationAlpha = BlendingType.OneMinusSrcAlpha,
+
+            RGBEquation = BlendingEquation.Add,
+            AlphaEquation = BlendingEquation.Add
+        };
     }
 
     private partial class LaneNoteVisualDrawNode : SpriteDrawNode
@@ -127,7 +139,7 @@ public partial class LaneNoteVisual : Sprite, ITexturedShaderDrawable
 
             shapeParameters.Data = shapeParameters.Data with
             {
-                Thickness = thickness,
+                BorderThickness = thickness,
                 Size = size,
                 ShadowRadius = shadowRadius,
                 Glow = glow,
@@ -145,7 +157,7 @@ public partial class LaneNoteVisual : Sprite, ITexturedShaderDrawable
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
         private record struct ShapeParameters
         {
-            public UniformFloat Thickness;
+            public UniformFloat BorderThickness;
             public UniformPadding4 _;
             public UniformVector2 Size;
             public UniformFloat ShadowRadius;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/DrawableChevron.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/DrawableChevron.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides;
 
 public partial class DrawableChevron : Sprite, ITexturedShaderDrawable
 {
-    private float thickness = 15f;
+    private float thickness = 13f;
     public float Thickness
     {
         get => thickness;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/DrawableChevron.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/DrawableChevron.cs
@@ -11,8 +11,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides;
 
 public partial class DrawableChevron : Sprite, ITexturedShaderDrawable
 {
-    public NoteShape Shape { get; init; } = NoteShape.Ring;
-    private float thickness = 7f;
+    private float thickness = 15f;
     public float Thickness
     {
         get => thickness;
@@ -20,6 +19,7 @@ public partial class DrawableChevron : Sprite, ITexturedShaderDrawable
         {
             if (thickness == value)
                 return;
+
             thickness = value;
             Invalidate(Invalidation.DrawNode);
         }
@@ -74,6 +74,18 @@ public partial class DrawableChevron : Sprite, ITexturedShaderDrawable
     {
         TextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, "chevron");
         Texture = renderer.WhitePixel;
+
+        Blending = new BlendingParameters
+        {
+            Source = BlendingType.One,
+            Destination = BlendingType.OneMinusSrcAlpha,
+
+            SourceAlpha = BlendingType.One,
+            DestinationAlpha = BlendingType.OneMinusSrcAlpha,
+
+            RGBEquation = BlendingEquation.Add,
+            AlphaEquation = BlendingEquation.Add
+        };
     }
 
     private partial class ChevronDrawNode : SpriteDrawNode

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideChevron.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideChevron.cs
@@ -49,8 +49,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
-                ShadowRadius = 15,
-                Thickness = 6.5f
+                ShadowRadius = 7.5f,
+                Thickness = 15f
             });
         }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideVisual.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides
                     chevron.Rotation = angle;
                     chevron.Depth = chevrons.Count;
 
-                    chevron.Thickness = 14f;
+                    chevron.Thickness = 13f;
                     chevron.Height = 30;
                     chevron.FanChevron = false;
                     chevron.Width = 50;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideVisual.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideVisual.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides
                     chevron.Rotation = angle;
                     chevron.Depth = chevrons.Count;
 
-                    chevron.Thickness = 6.5f;
+                    chevron.Thickness = 14f;
                     chevron.Height = 30;
                     chevron.FanChevron = false;
                     chevron.Width = 50;
@@ -209,7 +209,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides
 
                 chevron.Width = w;
                 chevron.Height = h;
-                chevron.Thickness = t;
+                chevron.Thickness = t * 2;
                 chevron.FanChevron = true;
 
                 if (((DrawableSentakkiHitObject?)drawableHitObject)?.ExBindable.Value ?? false)

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCircularProgress.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldCircularProgress.cs
@@ -1,10 +1,8 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Utils;
-using osu.Game.Rulesets.Sentakki.Extensions;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldTrianglePiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TouchHolds/TouchHoldTrianglePiece.cs
@@ -16,8 +16,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds
             {
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre,
-                Size = new Vector2(73, 45f),
-                Thickness = 8f,
+                Size = new Vector2(75, 45f),
+                Thickness = 15f,
                 ShadowRadius = 0f,
                 FillTriangle = true,
             });

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Touches/DrawableTouchTriangle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Touches/DrawableTouchTriangle.cs
@@ -24,7 +24,6 @@ public partial class DrawableTouchTriangle : Sprite, ITexturedShaderDrawable
             thickness = value;
             Invalidate(Invalidation.DrawNode);
         }
-
     }
 
     private float shadowRadius = 15f;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Touches/DrawableTouchTriangle.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Touches/DrawableTouchTriangle.cs
@@ -13,8 +13,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Touches;
 
 public partial class DrawableTouchTriangle : Sprite, ITexturedShaderDrawable
 {
-    public NoteShape Shape { get; init; } = NoteShape.Ring;
-    private float thickness = 7f;
+    private float thickness = 15f;
     public float Thickness
     {
         get => thickness;
@@ -25,11 +24,10 @@ public partial class DrawableTouchTriangle : Sprite, ITexturedShaderDrawable
             thickness = value;
             Invalidate(Invalidation.DrawNode);
         }
+
     }
 
-    // Special behavior, any non-zero value will hide the main body
-    // This is because touch notes shadow should exist *under* all triangles, not just a single one
-    private float shadowRadius = 15;
+    private float shadowRadius = 15f;
     public float ShadowRadius
     {
         get => shadowRadius;
@@ -95,6 +93,18 @@ public partial class DrawableTouchTriangle : Sprite, ITexturedShaderDrawable
 
         if (hitObject is null)
             return;
+
+        Blending = new BlendingParameters
+        {
+            Source = BlendingType.One,
+            Destination = BlendingType.OneMinusSrcAlpha,
+
+            SourceAlpha = BlendingType.One,
+            DestinationAlpha = BlendingType.OneMinusSrcAlpha,
+
+            RGBEquation = BlendingEquation.Add,
+            AlphaEquation = BlendingEquation.Add
+        };
 
         // Bind exnote
         exBindable.BindTo(((DrawableSentakkiHitObject)hitObject).ExBindable);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Touches/TouchPiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Touches/TouchPiece.cs
@@ -15,8 +15,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Touches
             {
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre,
-                Size = new Vector2(73, 45f),
-                Thickness = 8f,
+                Size = new Vector2(75, 45f),
+                Thickness = 15f,
                 ShadowRadius = 0f,
             });
         }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Touches/TouchPieceShadow.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Touches/TouchPieceShadow.cs
@@ -15,11 +15,11 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Touches
             {
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre,
-                Size = new Vector2(103, 75f),
-                Thickness = 8f,
-                ShadowRadius = 15,
+                Size = new Vector2(105, 75f),
+                Thickness = 15f,
+                ShadowRadius = 15f,
                 ShadowOnly = true,
-                Y = -15
+                Y = -15f
             });
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_SDFUtils.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_SDFUtils.fs
@@ -10,10 +10,9 @@ layout(location = 0) out vec4 o_Colour;
 
 vec4 strokeSDF(in float dist, in float strokeRadius) {
     float base = smoothstep(strokeRadius - 1.0, strokeRadius, abs(dist));
-
     float inner = smoothstep(strokeRadius - 3.0, strokeRadius - 2.0, abs(dist));
+    
     float innerRing = 1.0 - inner;
-
     float basePlate = (1.0 - base) * (1.0 - innerRing);
 
     return basePlate * vec4(vec3(0.5), 1.0) + innerRing * vec4(vec3(1.0), 1.0);
@@ -31,7 +30,7 @@ vec4 fillSDF(in float dist, in float strokeRadius) {
 
 vec4 sdfShadow(float dist, float strokeRadius, float shadowThickness, bool glow) {
     vec3 shadowColor = glow ? vec3(0.3) : vec3(0);
-    float shadowAlpha = glow ? 0 : 0.5;
+    float shadowAlpha = glow ? 0 : 0.3;
 
     float glow_ = pow(smoothstep(shadowThickness - 1.0 + strokeRadius, strokeRadius - 1.0, dist), 1.0);
     float glowCutOut = smoothstep(strokeRadius - 1.0, strokeRadius, dist);

--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_SDFUtils.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_SDFUtils.fs
@@ -32,7 +32,7 @@ vec4 sdfShadow(float dist, float strokeRadius, float shadowThickness, bool glow)
     vec3 shadowColor = glow ? vec3(0.3) : vec3(0);
     float shadowAlpha = glow ? 0 : 0.3;
 
-    float glow_ = pow(smoothstep(shadowThickness - 1.0 + strokeRadius, strokeRadius - 1.0, dist), 1.0);
+    float glow_ = pow(smoothstep(shadowThickness + strokeRadius, strokeRadius - 1.0, dist), 1.0);
     float glowCutOut = smoothstep(strokeRadius - 1.0, strokeRadius, dist);
 
     glow_ *= glowCutOut;

--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_SDFUtils.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_SDFUtils.fs
@@ -11,7 +11,7 @@ layout(location = 0) out vec4 o_Colour;
 vec4 strokeSDF(in float dist, in float strokeRadius) {
     float base = smoothstep(strokeRadius - 1.0, strokeRadius, abs(dist));
     float inner = smoothstep(strokeRadius - 3.0, strokeRadius - 2.0, abs(dist));
-    
+
     float innerRing = 1.0 - inner;
     float basePlate = (1.0 - base) * (1.0 - innerRing);
 
@@ -41,6 +41,10 @@ vec4 sdfShadow(float dist, float strokeRadius, float shadowThickness, bool glow)
 
 float circleSDF(vec2 p, vec2 centre, float radius) {
     return length(p - centre) - radius;
+}
+
+vec4 toPremultipliedAlpha(in vec4 straightColour) {
+    return straightColour * vec4(vec3(v_Colour.w), 1.0);
 }
 
 #endif

--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_chevron.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_chevron.fs
@@ -100,6 +100,6 @@ void main(void) {
     vec4 shape = fillSDF(sdf, strokeRadius);
     vec4 edgeEffect = sdfShadow(sdf, strokeRadius, shadowRadius, glow);
 
-    o_Colour = (shape + edgeEffect) * v_Colour;
+    o_Colour = (shape + edgeEffect) * toPremultipliedAlpha(v_Colour);
 }
 #endif

--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_chevron.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_chevron.fs
@@ -12,45 +12,44 @@ layout(std140, set = 0, binding = 0) uniform m_shapeParameters
     bool fanChevron;
 };
 
-
-float sdPolygon( in vec2 p, in vec2 origin, in vec2[6] v )
+float sdPolygon(in vec2 p, in vec2 origin, in vec2[6] v)
 {
-    vec2 P = p-origin;
+    vec2 P = p - origin;
 
     const int num = v.length();
-    float d = dot(P-v[0],P-v[0]);
+    float d = dot(P - v[0], P - v[0]);
     float s = 1.0;
-    for( int i=0, j=num-1; i<num; j=i, i++ )
+    for (int i = 0, j = num - 1; i < num; j = i, i++)
     {
         // distance
         vec2 e = v[j] - v[i];
-        vec2 w =    P - v[i];
-        vec2 b = w - e*clamp( dot(w,e)/dot(e,e), 0.0, 1.0 );
-        d = min( d, dot(b,b) );
+        vec2 w = P - v[i];
+        vec2 b = w - e * clamp(dot(w, e) / dot(e, e), 0.0, 1.0);
+        d = min(d, dot(b, b));
 
         // winding number from http://geomalgorithms.com/a03-_inclusion.html
-        bvec3 cond = bvec3( P.y>=v[i].y, 
-                            P.y <v[j].y, 
-                            e.x*w.y>e.y*w.x );
-        if( all(cond) || all(not(cond)) ) s=-s;  
+        bvec3 cond = bvec3(P.y >= v[i].y,
+                P.y < v[j].y,
+                e.x * w.y > e.y * w.x);
+        if (all(cond) || all(not(cond))) s = -s;
     }
-    
-    return s*sqrt(d);
+
+    return s * sqrt(d);
 }
 
-float chev(in vec2 p, in vec2 centre, in vec2 hexSize, in float thickness){    
-    float h = hexSize.y * 0.5;
-    float w = hexSize.x * 0.5;
+float chev(in vec2 p, in vec2 centre, in vec2 chevSize, in float thickness) {
+    float h = chevSize.y * 0.5;
+    float w = chevSize.x * 0.5;
 
     vec2 v0 = vec2(0, -h);
-	vec2 v1 = vec2(w, h - thickness);
-	vec2 v2 = vec2(w,  h );
-	vec2 v3 = vec2(0.0, -h + thickness);
-	vec2 v4 = vec2(-w, h);
-	vec2 v5 = vec2(-w, h - thickness);
+    vec2 v1 = vec2(w, h - thickness);
+    vec2 v2 = vec2(w, h);
+    vec2 v3 = vec2(0.0, -h + thickness);
+    vec2 v4 = vec2(-w, h);
+    vec2 v5 = vec2(-w, h - thickness);
 
     // add more points
-    vec2[] polygon = vec2[](v0,v1,v2, v3, v4, v5);
+    vec2[] polygon = vec2[](v0, v1, v2, v3, v4, v5);
 
     float dist = sdPolygon(p, centre, polygon);
 
@@ -60,49 +59,47 @@ float chev(in vec2 p, in vec2 centre, in vec2 hexSize, in float thickness){
 #define PI 3.1415926538
 const float deg2rad_factor = (PI / 180.0);
 
-float fanChev(in vec2 p, in vec2 centre, in vec2 hexSize, in float thickness){    
-    float h = hexSize.y * 0.5;
-    float w = hexSize.x * 0.5;
+float fanChev(in vec2 p, in vec2 centre, in vec2 chevSize, in float thickness) {
+    float h = chevSize.y * 0.5;
+    float w = chevSize.x * 0.5;
 
     vec2 v0 = vec2(0, -h);
-	vec2 v1 = vec2(w, h - thickness);
+    vec2 v1 = vec2(w, h - thickness);
 
     // We want to make the chevron edges angled inwards a bit, so they line up better when in a fan formation
     float rad1 = (180 + 22.5) * deg2rad_factor;
     float rad2 = (180 - 22.5) * deg2rad_factor;
 
-	vec2 v2 = vec2(sin(rad1) * thickness, -cos(rad1) * thickness) + v1;
-	vec2 v3 = vec2(0.0, -h + thickness);
+    vec2 v2 = vec2(sin(rad1) * thickness, -cos(rad1) * thickness) + v1;
+    vec2 v3 = vec2(0.0, -h + thickness);
 
-	vec2 v5 = vec2(-w, h - thickness);
+    vec2 v5 = vec2(-w, h - thickness);
     vec2 v4 = vec2(sin(rad2) * thickness, -cos(rad2) * thickness) + v5;
 
     // add more points
-    vec2[] polygon = vec2[](v0,v1,v2, v3, v4, v5);
+    vec2[] polygon = vec2[](v0, v1, v2, v3, v4, v5);
 
     float dist = sdPolygon(p, centre, polygon);
 
     return dist;
 }
 
-
 void main(void) {
     vec2 resolution = v_TexRect.zw - v_TexRect.xy;
-    vec2 pixelPos = (v_TexCoord - v_TexRect.xy) / resolution;
+    vec2 pixelPos = (v_TexCoord - v_TexRect.xy) / resolution * size;
+    vec2 origin = 0.5 * size;
 
-    vec2 p = pixelPos * size;
-    vec2 c = 0.5 * size;
+    float strokeRadius = thickness * 0.5;
 
-    float shadeRadius = shadowRadius;
-    float borderThickness = thickness;
-    float paddingAmount = - borderThickness - shadeRadius;
+    float sdf = 0;
+    if (fanChevron)
+        sdf = fanChev(pixelPos, origin, size - vec2(shadowRadius + strokeRadius) * 2, strokeRadius);
+    else
+        sdf = chev(pixelPos, origin, size - vec2(shadowRadius + strokeRadius) * 2, strokeRadius);
 
-    float ringSDF = 0;
-    if(fanChevron)
-        ringSDF = fanChev(p, c,size - vec2(shadeRadius + borderThickness) * 2, borderThickness);
-    else ringSDF = chev(p, c,size - vec2(shadeRadius + borderThickness) * 2, borderThickness);
+    vec4 shape = fillSDF(sdf, strokeRadius);
+    vec4 edgeEffect = sdfShadow(sdf, strokeRadius, shadowRadius, glow);
 
-    vec4 r = sdfFill(ringSDF, borderThickness, shadeRadius, glow);
-    o_Colour = r;
+    o_Colour = (shape + edgeEffect) * v_Colour;
 }
 #endif

--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_hexNote.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_hexNote.fs
@@ -74,7 +74,7 @@ void main(void) {
 
     vec4 dots = max(dotShapeDown - dotShapeUp, vec4(0, 0, 0, 0)) + dotShapeUp;
 
-    o_Colour = (shape + dots + edgeEffect) * v_Colour;
+    o_Colour = (shape + dots + edgeEffect) * toPremultipliedAlpha(v_Colour);
 }
 
 #endif

--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_hexNote.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_hexNote.fs
@@ -5,7 +5,7 @@
 
 layout(std140, set = 0, binding = 0) uniform m_shapeParameters
 {
-    float thickness;
+    float borderThickness;
     vec2 size;
     float shadowRadius;
     bool glow;
@@ -13,8 +13,7 @@ layout(std140, set = 0, binding = 0) uniform m_shapeParameters
 
 // SDF that makes a rounded hexagon
 // Adapted from the Star shader provided at https://iquilezles.org/articles/distfunctions2d/
-float roundedHexSDF(in vec2 p, in vec2 origin, in float h, in float r)
-{
+float roundedHexSDF(in vec2 p, in vec2 origin, in float h, in float r) {
     vec2 P = p - origin;
     const float n = 6.0; // 6 sided star
     const float w = 1.0; // With no angle
@@ -22,60 +21,60 @@ float roundedHexSDF(in vec2 p, in vec2 origin, in float h, in float r)
     // these 5 lines can be precomputed for a given shape
     //float m = n*(1.0-w) + w*2.0;
     const float m = n + w * (2.0 - n);
-    
+
     const float an = 3.1415927 / n;
     const float en = 3.1415927 / m;
-    const vec2  ecs = vec2(cos(en),sin(en)); // ecs=vec2(0,1) and simplify, for regular polygon,
+    const vec2 ecs = vec2(cos(en), sin(en)); // ecs=vec2(0,1) and simplify, for regular polygon,
 
-    vec2 racs = r * vec2(cos(an),sin(an));
+    vec2 racs = r * vec2(cos(an), sin(an));
 
     float halfHeight = h * 0.5;
     float absY = abs(P.y);
 
-    if(absY <= halfHeight){
+    if (absY <= halfHeight)
         return abs(P.x) - racs.x;
-    }
 
     P = vec2(abs(P.x), (absY - halfHeight));
 
     // reduce to first sector
-    float bn = mod(atan(P.x,P.y), 2.0 * an) - an;
+    float bn = mod(atan(P.x, P.y), 2.0 * an) - an;
     P = length(P) * vec2(cos(bn), abs(sin(bn)));
 
     // line sdf
     P -= racs;
-    P += ecs * clamp(-dot(P,ecs), 0.0, racs.y / ecs.y);
+    P += ecs * clamp(-dot(P, ecs), 0.0, racs.y / ecs.y);
     return length(P) * sign(P.x);
 }
 
 void main(void) {
     vec2 resolution = v_TexRect.zw - v_TexRect.xy;
-    vec2 pixelPos = (v_TexCoord - v_TexRect.xy) / resolution;
+    vec2 origin = size * 0.5;
+    vec2 pixelPos = ((v_TexCoord - v_TexRect.xy) / resolution) * size;
 
-    vec2 p = pixelPos * size;
-    vec2 c = 0.5 * size;
+    float radius = size.x / 2.0;
 
-    float shadeRadius = size.x * shadowRadius;
-    float noteW = size.x - shadeRadius * 2;
-    float borderThickness = thickness * 0.5 * noteW;
-    float paddingAmount = - borderThickness - shadeRadius;
+    // Since our edge effect is centred along the sdf path
+    //// each side of the sdf will have the same thickness
+    float strokeRadius = borderThickness * 0.5;
 
-    float radius = size.x * 0.5 + paddingAmount;
+    float sdfRadius = radius - strokeRadius - shadowRadius;
+    float sdfHeight = size.y - (shadowRadius + sdfRadius) * 2.0 - borderThickness;
 
-    float h = size.y - size.x;
+    float sdf = roundedHexSDF(pixelPos, origin, sdfHeight, sdfRadius);
 
-    float hex = roundedHexSDF(p, c, h, radius);
-    float dotDown = circleSDF(p, c + vec2(0, h * 0.5), borderThickness/4 - 1.5);
-    float dotUp =  circleSDF(p, c -vec2(0, h * 0.5), borderThickness/4 - 1.5);
+    vec4 shape = strokeSDF(sdf, strokeRadius);
 
-    vec4 dotDownShape = sdfToShape(dotDown, borderThickness, 0, false);
-    vec4 dotUpShape = sdfToShape(dotUp, borderThickness, 0, false);
+    vec4 edgeEffect = sdfShadow(sdf, strokeRadius, shadowRadius, glow);
 
-    vec4 r2 = max(dotDownShape - dotUpShape, vec4(0,0,0,0)) + dotUpShape;
+    // We add 1 here to better match o!f's built in edge smoothing
+    float dotStrokeRadius = (strokeRadius + 1.0) / 2.0;
 
-    vec4 r = sdfToShape(hex, borderThickness, shadeRadius, glow) + r2;
+    vec4 dotShapeUp = fillSDF(circleSDF(pixelPos, origin + vec2(0, sdfHeight * 0.5), dotStrokeRadius), dotStrokeRadius);
+    vec4 dotShapeDown = fillSDF(circleSDF(pixelPos, origin - vec2(0, sdfHeight * 0.5), dotStrokeRadius), dotStrokeRadius);
 
-    o_Colour = r;
+    vec4 dots = max(dotShapeDown - dotShapeUp, vec4(0, 0, 0, 0)) + dotShapeUp;
+
+    o_Colour = (shape + dots + edgeEffect) * v_Colour;
 }
 
 #endif

--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_ringNote.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_ringNote.fs
@@ -5,7 +5,7 @@
 
 layout(std140, set = 0, binding = 0) uniform m_shapeParameters
 {
-    float thickness;
+    float borderThickness;
     vec2 size;
     float shadowRadius;
     bool glow;
@@ -13,23 +13,29 @@ layout(std140, set = 0, binding = 0) uniform m_shapeParameters
 
 void main(void) {
     vec2 resolution = v_TexRect.zw - v_TexRect.xy;
-    vec2 pixelPos = (v_TexCoord - v_TexRect.xy) / resolution;
+    vec2 origin = size * 0.5;
+    vec2 pixelPos = ((v_TexCoord - v_TexRect.xy) / resolution) * size;
 
-    vec2 p = pixelPos * size;
-    vec2 c = 0.5 * size;
+    float radius = min(size.x, size.y) / 2.0;
 
-    float shadeRadius = size.x * shadowRadius;
-    float noteW = size.x - shadeRadius * 2;
-    float borderThickness = thickness * 0.5 * noteW;
-    float paddingAmount = - borderThickness - shadeRadius;
+    // Since our edge effect is centred along the sdf path
+    //// each side of the sdf will have the same thickness
+    float strokeRadius = borderThickness * 0.5;
 
-    float radius = size.x * 0.5 + paddingAmount;
+    float sdfRadius = radius - strokeRadius - shadowRadius;
 
-    float dotSDF = circleSDF(p,c, borderThickness / 4  - 1.5);
-    float ringSDF = circleSDF(p, c, radius);
+    float sdf = circleSDF(pixelPos, origin, sdfRadius);
 
-    vec4 r = sdfToShape(ringSDF, borderThickness, shadeRadius, glow) + sdfToShape(dotSDF, borderThickness, 0, false);
-    o_Colour = r;
+    vec4 shape = strokeSDF(sdf, strokeRadius);
+
+    vec4 edgeEffect = sdfShadow(sdf, strokeRadius, shadowRadius, glow);
+
+    // We add 1 here to better match o!f's built in edge smoothing
+    float dotStrokeRadius = (strokeRadius + 1.0) / 2.0;
+
+    vec4 dotShape = fillSDF(circleSDF(pixelPos, origin, dotStrokeRadius), dotStrokeRadius);
+
+    o_Colour = (dotShape + shape + edgeEffect) * v_Colour;
 }
 
 #endif

--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_ringNote.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_ringNote.fs
@@ -35,7 +35,7 @@ void main(void) {
 
     vec4 dotShape = fillSDF(circleSDF(pixelPos, origin, dotStrokeRadius), dotStrokeRadius);
 
-    o_Colour = (dotShape + shape + edgeEffect) * v_Colour;
+    o_Colour = (dotShape + shape + edgeEffect) * toPremultipliedAlpha(v_Colour);
 }
 
 #endif

--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_starNote.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_starNote.fs
@@ -14,30 +14,29 @@ layout(std140, set = 0, binding = 0) uniform m_shapeParameters
 // signed distance to a n-star polygon, with external angle w
 float sdStar(in vec2 p, in vec2 origin, in float r, in float n, in float w)
 {
-    vec2 P = p-origin;
+    vec2 P = p - origin;
     P.y = -P.y;
     // these 5 lines can be precomputed for a given shape
     //float m = n*(1.0-w) + w*2.0;
-    float m = n + w*(2.0-n);
-    
-    float an = 3.1415927/n;
-    float en = 3.1415927/m;
-    vec2  racs = r*vec2(cos(an),sin(an));
-    vec2   ecs =   vec2(cos(en),sin(en)); // ecs=vec2(0,1) and simplify, for regular polygon,
+    float m = n + w * (2.0 - n);
+
+    float an = 3.1415927 / n;
+    float en = 3.1415927 / m;
+    vec2 racs = r * vec2(cos(an), sin(an));
+    vec2 ecs = vec2(cos(en), sin(en)); // ecs=vec2(0,1) and simplify, for regular polygon,
 
     // symmetry (optional)
     P.x = abs(P.x);
-    
+
     // reduce to first sector
-    float bn = mod(atan(P.x,P.y),2.0*an) - an;
-    P = length(P)*vec2(cos(bn),abs(sin(bn)));
+    float bn = mod(atan(P.x, P.y), 2.0 * an) - an;
+    P = length(P) * vec2(cos(bn), abs(sin(bn)));
 
     // line sdf
     P -= racs;
-    P += ecs*clamp( -dot(P,ecs), 0.0, racs.y/ecs.y);
-    return length(P)*sign(P.x);
+    P += ecs * clamp(-dot(P, ecs), 0.0, racs.y / ecs.y);
+    return length(P) * sign(P.x);
 }
-
 
 void main(void) {
     vec2 resolution = v_TexRect.zw - v_TexRect.xy;
@@ -60,7 +59,7 @@ void main(void) {
     vec4 shape = strokeSDF(sdf, strokeRadius);
     vec4 edgeEffect = sdfShadow(sdf, strokeRadius, shadowRadius, glow);
 
-    o_Colour = (shape + edgeEffect) * v_Colour;
+    o_Colour = (shape + edgeEffect) * toPremultipliedAlpha(v_Colour);
 }
 
 #endif

--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_starNote.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_starNote.fs
@@ -5,7 +5,7 @@
 
 layout(std140, set = 0, binding = 0) uniform m_shapeParameters
 {
-    float thickness;
+    float borderThickness;
     vec2 size;
     float shadowRadius;
     bool glow;
@@ -41,25 +41,26 @@ float sdStar(in vec2 p, in vec2 origin, in float r, in float n, in float w)
 
 void main(void) {
     vec2 resolution = v_TexRect.zw - v_TexRect.xy;
-    vec2 pixelPos = (v_TexCoord - v_TexRect.xy) / resolution;
+    vec2 origin = size * 0.5;
+    vec2 pixelPos = ((v_TexCoord - v_TexRect.xy) / resolution) * size;
 
-    vec2 p = pixelPos * size;
-    vec2 c = 0.5 * size;
+    float radius = min(size.x, size.y) / 2.0;
 
-    float shadeRadius = size.x * shadowRadius;
-    float noteW = size.x - shadeRadius * 2;
-    float borderThickness = thickness * 0.5 * noteW;
-    float paddingAmount = - borderThickness - shadeRadius;
+    // Fixed modifier to make it look right when put with other notes with the same thickness
+    float adjustedBorderThickness = borderThickness * 0.75;
 
-    float radius = size.x * 0.5 + paddingAmount;
+    // Since our edge effect is centred along the sdf path
+    //// each side of the sdf will have the same thickness
+    float strokeRadius = adjustedBorderThickness * 0.5;
 
-    float h = size.y - size.x;
+    float sdfRadius = radius - strokeRadius - shadowRadius;
 
-    float star = sdStar(p, c, radius, 5, 0.6);
+    float sdf = sdStar(pixelPos, origin, sdfRadius, 5.0, 0.6);
 
-    vec4 r = sdfToShape(star, borderThickness * 0.75, shadeRadius, glow);
+    vec4 shape = strokeSDF(sdf, strokeRadius);
+    vec4 edgeEffect = sdfShadow(sdf, strokeRadius, shadowRadius, glow);
 
-    o_Colour = r;
+    o_Colour = (shape + edgeEffect) * v_Colour;
 }
 
 #endif

--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_touchTriangle.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_touchTriangle.fs
@@ -60,6 +60,6 @@ void main(void) {
             result += strokeSDF(sdf, strokeRadius);
     }
 
-    o_Colour = result * v_Colour;
+    o_Colour = result * toPremultipliedAlpha(v_Colour);
 }
 #endif

--- a/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_touchTriangle.fs
+++ b/osu.Game.Rulesets.Sentakki/Resources/Shaders/sh_touchTriangle.fs
@@ -5,7 +5,7 @@
 
 layout(std140, set = 0, binding = 0) uniform m_shapeParameters
 {
-    float thickness;
+    float borderThickness;
     vec2 size;
     float shadowRadius;
     bool glow;
@@ -13,22 +13,21 @@ layout(std140, set = 0, binding = 0) uniform m_shapeParameters
     bool shadowOnly;
 };
 
-float sdTriangle( in vec2 p, in vec2 p0, in vec2 p1, in vec2 p2 )
+float sdTriangle(in vec2 p, in vec2 p0, in vec2 p1, in vec2 p2)
 {
-    vec2 e0 = p1-p0, e1 = p2-p1, e2 = p0-p2;
-    vec2 v0 = p -p0, v1 = p -p1, v2 = p -p2;
-    vec2 pq0 = v0 - e0*clamp( dot(v0,e0)/dot(e0,e0), 0.0, 1.0 );
-    vec2 pq1 = v1 - e1*clamp( dot(v1,e1)/dot(e1,e1), 0.0, 1.0 );
-    vec2 pq2 = v2 - e2*clamp( dot(v2,e2)/dot(e2,e2), 0.0, 1.0 );
-    float s = sign( e0.x*e2.y - e0.y*e2.x );
-    vec2 d = min(min(vec2(dot(pq0,pq0), s*(v0.x*e0.y-v0.y*e0.x)),
-                     vec2(dot(pq1,pq1), s*(v1.x*e1.y-v1.y*e1.x))),
-                     vec2(dot(pq2,pq2), s*(v2.x*e2.y-v2.y*e2.x)));
-    return -sqrt(d.x)*sign(d.y);
+    vec2 e0 = p1 - p0, e1 = p2 - p1, e2 = p0 - p2;
+    vec2 v0 = p - p0, v1 = p - p1, v2 = p - p2;
+    vec2 pq0 = v0 - e0 * clamp(dot(v0, e0) / dot(e0, e0), 0.0, 1.0);
+    vec2 pq1 = v1 - e1 * clamp(dot(v1, e1) / dot(e1, e1), 0.0, 1.0);
+    vec2 pq2 = v2 - e2 * clamp(dot(v2, e2) / dot(e2, e2), 0.0, 1.0);
+    float s = sign(e0.x * e2.y - e0.y * e2.x);
+    vec2 d = min(min(vec2(dot(pq0, pq0), s * (v0.x * e0.y - v0.y * e0.x)),
+                vec2(dot(pq1, pq1), s * (v1.x * e1.y - v1.y * e1.x))),
+            vec2(dot(pq2, pq2), s * (v2.x * e2.y - v2.y * e2.x)));
+    return -sqrt(d.x) * sign(d.y);
 }
 
-float triangle(in vec2 p, in vec2 centre, in vec2 size){    
-
+float triangle(in vec2 p, in vec2 centre, in vec2 size) {
     p -= centre;
 
     float w = size.x * 0.5;
@@ -36,45 +35,31 @@ float triangle(in vec2 p, in vec2 centre, in vec2 size){
     vec2 p0 = vec2(-w, -h);
     vec2 p1 = vec2(0.0, h);
     vec2 p2 = vec2(w, -h);
-    float dist = sdTriangle(p, p0,p1,p2);
+    float dist = sdTriangle(p, p0, p1, p2);
 
     return dist;
 }
 
-vec4 sdfShadow(in float dist, in float borderThickness, in float shadowThickness){
-    vec3 shadowColor =  glow ? vec3(1) : vec3(0);
-    float shadowAlpha = glow ? 0.75: 0.6;
-
-    float shadowDist = dist - borderThickness;
-
-    float shadow =  pow((1 - clamp(((1 / shadowThickness) * shadowDist), 0.0 , 1.0)) * shadowAlpha, 2.0);
-    float exclusion = smoothstep(borderThickness, borderThickness - 1.0, dist); // Inner cutout for shadow
-
-    vec4 shadowPart = vec4(shadowColor,shadow) * (1 - exclusion) * v_Colour;
-    return shadowPart;
-}
-
-
 void main(void) {
     vec2 resolution = v_TexRect.zw - v_TexRect.xy;
-    vec2 pixelPos = (v_TexCoord - v_TexRect.xy) / resolution;
+    vec2 origin = size * 0.5;
+    vec2 pixelPos = ((v_TexCoord - v_TexRect.xy) / resolution) * size;
 
-    vec2 p = pixelPos * size;
-    vec2 c = 0.5 * size;
+    float strokeRadius = borderThickness * 0.5;
 
-    float shadeRadius = shadowRadius;
-    float borderThickness = thickness;
-    float paddingAmount = - borderThickness - shadeRadius;
+    vec2 sdfSize = size - borderThickness - shadowRadius * 2.0;
 
-    vec2 newSize=  size + paddingAmount * 2;
+    float sdf = triangle(pixelPos, origin, sdfSize);
 
-    float ringSDF = triangle(p, c, newSize);
+    vec4 result = sdfShadow(sdf, strokeRadius, shadowRadius, glow);
 
-    if(shadowOnly)
-        o_Colour = sdfShadow(ringSDF, borderThickness, shadeRadius);
-    else if(fillTriangle) 
-        o_Colour = sdfFill(ringSDF, borderThickness, shadeRadius, glow);
-    else
-        o_Colour = sdfToShape(ringSDF, borderThickness, shadeRadius, glow);
+    if (!shadowOnly) {
+        if (fillTriangle)
+            result += fillSDF(sdf, strokeRadius);
+        else
+            result += strokeSDF(sdf, strokeRadius);
+    }
+
+    o_Colour = result * v_Colour;
 }
 #endif


### PR DESCRIPTION
I never liked the state I left it in. I barely can recall what each line does, the same parameter is used in different ways (thickness sometimes being absolute, sometimes being a ratio)

* Shader code for each note type are now more similar in usages
* BorderThickness and ShadowRadius are now in absolute values rather than relative in all casaes
* SDF functions simplified, using fewer operations to achieve the same look
* SDF Glow/Shadow is now separate from the sdfStroke/Fill methods

As a bonus, I'm trying out the use of pre-multiplied alpha. Initial glances look promising due to the glow being non-occluding.