### PR TITLE
Adjust touch hold twinning rules

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapProcessor.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                 var hitObject = hitObjects[i];
                 if (canBeColored(hitObject)) yield return hitObject;
 
-                foreach (var nested in getColorableHitObject(hitObject.NestedHitObjects).AsEnumerable())
+                foreach (var nested in getColorableHitObject(hitObject.NestedHitObjects))
                     yield return nested;
             }
         }

--- a/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Sentakki/Beatmaps/SentakkiBeatmapProcessor.cs
@@ -45,7 +45,13 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
                 {
                     if (hitObject is TouchHold th)
                     {
-                        th.ColourPalette = th.Break ? TouchHold.BreakPalette : TouchHold.DefaultPalette;
+                        th.ColourPalette = TouchHold.DefaultPalette;
+
+                        if (th.Break)
+                            th.ColourPalette = TouchHold.BreakPalette;
+                        else if (isTwin)
+                            th.ColourPalette = TouchHold.TwinPalette;
+
                         continue;
                     }
 
@@ -95,7 +101,6 @@ namespace osu.Game.Rulesets.Sentakki.Beatmaps
         private static bool countsForTwin(HitObject hitObject) => hitObject switch
         {
             Hold.HoldHead => false,
-            TouchHold => false,
             Slide => false,
             _ => true
         };

--- a/osu.Game.Rulesets.Sentakki/Objects/TouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/TouchHold.cs
@@ -80,6 +80,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
     {
         public static readonly IReadOnlyList<Color4> DefaultPalette;
         public static readonly IReadOnlyList<Color4> BreakPalette;
+        public static readonly IReadOnlyList<Color4> TwinPalette;
 
         static TouchHold()
         {
@@ -93,9 +94,16 @@ namespace osu.Game.Rulesets.Sentakki.Objects
 
             BreakPalette = [
                 Color4.OrangeRed,
-                Colour4.FromHex("#802200"),
+                Colour4.FromHex("#802300"),
                 Color4.OrangeRed,
-                Colour4.FromHex("#802200"),
+                Colour4.FromHex("#802300"),
+            ];
+
+            TwinPalette = [
+                Color4.Gold,
+                Colour4.FromHex("#806c00"),
+                Color4.Gold,
+                Colour4.FromHex("#806c00"),
             ];
         }
     }


### PR DESCRIPTION
Closes #696

TouchHolds now contribute to twin note consideration. And unlike maimaiDX, are also coloured appropriately, this is an intentional decision in order to increase consistency in twin note application.



![image](https://github.com/user-attachments/assets/6ac59a74-869e-4216-9efa-8f28d9f7e145)
![image](https://github.com/user-attachments/assets/f98145a8-1db4-4b11-94b1-5a5f1b76e9e5)
