### PR TITLE
Adjust judgement colours to better match osu

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/Statistics/TestSceneJudgementChart.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/Statistics/TestSceneJudgementChart.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Statistics;
@@ -14,48 +16,51 @@ namespace osu.Game.Rulesets.Sentakki.Tests.Statistics
     {
         protected override Ruleset CreateRuleset() => new SentakkiRuleset();
 
+        [Cached]
+        private OsuColour colours = new OsuColour();
+
         private List<HitEvent> testevents = new List<HitEvent>
         {
             // Tap
-            new HitEvent(0,1, HitResult.Great, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Great, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Great, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Great, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Great, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Great, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Good, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Good, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Good, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Good, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Good, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Ok, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Ok, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Ok, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Miss, new Tap(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Miss, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Great, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Great, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Great, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Great, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Great, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Great, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Good, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Good, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Good, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Good, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Good, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Ok, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Ok, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Ok, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Miss, new Tap(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Miss, new Tap(), new Tap(), null),
             // Holds
-            new HitEvent(0,1, HitResult.Great, new Hold(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Great, new Hold(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Great, new Hold(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Great, new Hold(), new Tap(), null),
             // Touch
-            new HitEvent(0,1, HitResult.Good, new Touch(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Good, new Touch(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Good, new Touch(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Good, new Touch(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Ok, new Touch(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Ok, new Touch(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Ok, new Touch(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Miss, new Touch(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Miss, new Touch(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Great, new Touch(), new Tap(), null),
-            new HitEvent(0,1, HitResult.Great, new Touch(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Good, new Touch(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Good, new Touch(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Good, new Touch(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Good, new Touch(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Ok, new Touch(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Ok, new Touch(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Ok, new Touch(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Miss, new Touch(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Miss, new Touch(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Great, new Touch(), new Tap(), null),
+            new HitEvent(0, 1, HitResult.Great, new Touch(), new Tap(), null),
             // Breaks
-            new HitEvent(0,1, HitResult.Great, new Tap { Break = true }, new Tap(), null),
-            new HitEvent(0,1, HitResult.Good, new Tap { Break = true }, new Tap(), null),
-            new HitEvent(0,1, HitResult.Good, new Tap { Break = true }, new Tap(), null),
-            new HitEvent(0,1, HitResult.Good, new Tap { Break = true }, new Tap(), null),
-            new HitEvent(0,1, HitResult.Good, new Tap { Break = true }, new Tap(), null),
-            new HitEvent(0,1, HitResult.Good, new Tap { Break = true }, new Tap(), null),
-            new HitEvent(0,1, HitResult.Ok, new Tap { Break = true }, new Tap(), null),
+            new HitEvent(0, 1, HitResult.Great, new Tap { Break = true }, new Tap(), null),
+            new HitEvent(0, 1, HitResult.Good, new Tap { Break = true }, new Tap(), null),
+            new HitEvent(0, 1, HitResult.Good, new Tap { Break = true }, new Tap(), null),
+            new HitEvent(0, 1, HitResult.Good, new Tap { Break = true }, new Tap(), null),
+            new HitEvent(0, 1, HitResult.Good, new Tap { Break = true }, new Tap(), null),
+            new HitEvent(0, 1, HitResult.Good, new Tap { Break = true }, new Tap(), null),
+            new HitEvent(0, 1, HitResult.Ok, new Tap { Break = true }, new Tap(), null),
         };
 
         public TestSceneJudgementChart()

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiJudgement.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiJudgement.cs
@@ -27,6 +27,9 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
 
         private readonly BindableBool detailedJudgements = new BindableBool();
 
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
         [BackgroundDependencyLoader]
         private void load(SentakkiRulesetConfigManager sentakkiConfigs)
         {
@@ -40,8 +43,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Scale = new Vector2(0.9f),
-                    Children = new Drawable[]
-                    {
+                    Children =
+                    [
                         timingPiece = new OsuSpriteText
                         {
                             Y = -15,
@@ -51,42 +54,43 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
                             ShadowColour = Color4.Black
                         },
                         judgementPiece = new SentakkiJudgementPiece(HitResult.Great)
-                    }
+                    ]
                 }
             );
         }
 
         public DrawableSentakkiJudgement Apply(JudgementResult result, DrawableHitObject hitObject)
         {
-            if (result.Type == HitResult.Perfect && detailedJudgements.Value)
-                judgementPiece.JudgementText.Text = HitResult.Great.GetDisplayNameForSentakkiResult().ToUpperInvariant();
-            else
-                judgementPiece.JudgementText.Text = result.Type.GetDisplayNameForSentakkiResult().ToUpperInvariant();
-
-            judgementPiece.JudgementText.Colour = result.Type.GetColorForSentakkiResult();
-
             if (result.HitObject.HitWindows is SentakkiEmptyHitWindows || result.Type == HitResult.Miss || !detailedJudgements.Value)
-            {
                 timingPiece.Alpha = 0;
+            else
+                timingPiece.Alpha = 1;
+
+            judgementPiece.JudgementText.Colour = colours.ForSentakkiResult(result.Type);
+
+            if (result.Type == HitResult.Perfect)
+            {
+                timingPiece.Text = "CRITICAL";
+                timingPiece.Colour = colours.ForSentakkiResult(result.Type);
+                judgementPiece.JudgementText.Text =
+                    (detailedJudgements.Value ? HitResult.Great : result.Type).GetDisplayNameForSentakkiResult().ToUpperInvariant();
             }
             else
             {
-                timingPiece.Alpha = 1;
+                judgementPiece.JudgementText.Text =
+                    result.Type.GetDisplayNameForSentakkiResult().ToUpperInvariant();
 
-                if (result.Type == HitResult.Perfect)
+                switch (result.TimeOffset)
                 {
-                    timingPiece.Text = "CRITICAL";
-                    timingPiece.Colour = result.Type.GetColorForSentakkiResult();
-                }
-                else if (result.TimeOffset > 0)
-                {
-                    timingPiece.Text = "LATE";
-                    timingPiece.Colour = Color4.OrangeRed;
-                }
-                else if (result.TimeOffset < 0)
-                {
-                    timingPiece.Text = "EARLY";
-                    timingPiece.Colour = Color4.GreenYellow;
+                    case > 0:
+                        timingPiece.Text = "LATE";
+                        timingPiece.Colour = Color4.OrangeRed;
+                        break;
+
+                    case < 0:
+                        timingPiece.Text = "EARLY";
+                        timingPiece.Colour = Color4.GreenYellow;
+                        break;
                 }
             }
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiJudgement.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiJudgement.cs
@@ -1,6 +1,8 @@
 ﻿using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Sprites;
@@ -71,7 +73,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects.Drawables
             if (result.Type == HitResult.Perfect)
             {
                 timingPiece.Text = "CRITICAL";
-                timingPiece.Colour = colours.ForSentakkiResult(result.Type);
+                timingPiece.Colour = ColourInfo.GradientVertical(Color4Extensions.FromHex("#00FFAA"), Color4Extensions.FromHex("7CF6FF"));
                 judgementPiece.JudgementText.Text =
                     (detailedJudgements.Value ? HitResult.Great : result.Type).GetDisplayNameForSentakkiResult().ToUpperInvariant();
             }

--- a/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiExtensions.cs
@@ -1,6 +1,8 @@
 using System;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics.Colour;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
 using osuTK.Graphics;
@@ -87,23 +89,15 @@ namespace osu.Game.Rulesets.Sentakki
         public static float Mod(this float a, float b)
             => (a %= b) < 0 ? a + b : a;
 
-        public static Color4 GetColorForSentakkiResult(this HitResult result)
+        public static ColourInfo ForSentakkiResult(this OsuColour osuColour, HitResult result)
         {
             switch (result)
             {
                 case HitResult.Perfect:
-                    return Color4.Orange.Lighten(0.3f);
-                case HitResult.Great:
-                    return Color4.Orange;
-
-                case HitResult.Good:
-                    return Color4.DeepPink;
-
-                case HitResult.Ok:
-                    return Color4.Green;
+                    return ColourInfo.GradientVertical(Color4Extensions.FromHex("#7CF6FF"), Color4Extensions.FromHex("#FF9AD7"));
 
                 default:
-                    return Color4.LightGray;
+                    return osuColour.ForHitResult(result);
             }
         }
 


### PR DESCRIPTION
Makes the colours of judgements match other rulesets, rather than matching maimai.

The only remaining deviation is in the colour used for `Critical`s, which is a gradient that can be found in [Flyte's upcoming result screen designs](https://www.figma.com/design/a85wCm9QKEsCPo0C4lt9x9/Client-Result-Screen?node-id=5433-6113&t=f9SpsH1t4Rw9DRfI-0), chosen to better differentiate them from regular `Perfect` judgements.

<img width="1736" height="555" alt="image" src="https://github.com/user-attachments/assets/18fbd5bf-d79f-4903-ac6f-1f0e354ef1b9" />
