### PR TITLE
Adjust touch input handling

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -279,7 +279,7 @@ public partial class DrawableHold : DrawableSentakkiLanedHitObject, IKeyBindingH
 
             foreach (var pressedAction in SentakkiActionInputManager.PressedActions)
             {
-                if (pressedAction == SentakkiAction.Key1 + HitObject.Lane)
+                if (IsValidLaneAction(pressedAction))
                     ++count;
             }
 
@@ -292,7 +292,7 @@ public partial class DrawableHold : DrawableSentakkiLanedHitObject, IKeyBindingH
         if (AllJudged)
             return false;
 
-        if (e.Action != SentakkiAction.Key1 + HitObject.Lane)
+        if (!IsValidLaneAction(e.Action))
             return false;
 
         // Passthrough excess inputs to later hitobjects in the same lane
@@ -315,7 +315,7 @@ public partial class DrawableHold : DrawableSentakkiLanedHitObject, IKeyBindingH
         if (AllJudged) return;
         if (!isHolding) return;
 
-        if (e.Action != SentakkiAction.Key1 + HitObject.Lane)
+        if (!IsValidLaneAction(e.Action))
             return;
 
         // We only release the hold once ALL inputs are released

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableHold.cs
@@ -268,8 +268,8 @@ public partial class DrawableHold : DrawableSentakkiLanedHitObject, IKeyBindingH
         headContainer.Clear(false);
     }
 
-    private SentakkiInputManager? sentakkiActionInputManager;
-    internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= (SentakkiInputManager)GetContainingInputManager();
+    [Resolved]
+    private SentakkiInputManager sentakkiInputManager { get; set; } = null!;
 
     private int pressedCount
     {
@@ -277,7 +277,7 @@ public partial class DrawableHold : DrawableSentakkiLanedHitObject, IKeyBindingH
         {
             int count = 0;
 
-            foreach (var pressedAction in SentakkiActionInputManager.PressedActions)
+            foreach (var pressedAction in sentakkiInputManager.PressedActions)
             {
                 if (IsValidLaneAction(pressedAction))
                     ++count;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiLanedHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiLanedHitObject.cs
@@ -28,12 +28,11 @@ public partial class DrawableSentakkiLanedHitObject : DrawableSentakkiHitObject
     {
         int laneNumber = HitObject.Lane;
 
-        Console.WriteLine(action);
-
         return
             action == (SentakkiAction.B1Lane1 + laneNumber)
             || action == (SentakkiAction.B2Lane1 + laneNumber)
             || action == (SentakkiAction.SensorLane1 + laneNumber)
+            || action == (SentakkiAction.SensorLane1Alt + laneNumber)
             || action == (SentakkiAction.Key1 + laneNumber);
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiLanedHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiLanedHitObject.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using osu.Framework.Allocation;
+﻿using osu.Framework.Allocation;
 using osu.Game.Rulesets.Sentakki.Extensions;
 using osu.Game.Rulesets.Sentakki.UI;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiLanedHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSentakkiLanedHitObject.cs
@@ -1,4 +1,5 @@
-﻿using osu.Framework.Allocation;
+﻿using System;
+using osu.Framework.Allocation;
 using osu.Game.Rulesets.Sentakki.Extensions;
 using osu.Game.Rulesets.Sentakki.UI;
 
@@ -21,5 +22,18 @@ public partial class DrawableSentakkiLanedHitObject : DrawableSentakkiHitObject
     {
         if (DrawableSentakkiRuleset is not null)
             AnimationDuration.BindTo(DrawableSentakkiRuleset?.AdjustedAnimDuration);
+    }
+
+    protected bool IsValidLaneAction(SentakkiAction action)
+    {
+        int laneNumber = HitObject.Lane;
+
+        Console.WriteLine(action);
+
+        return
+            action == (SentakkiAction.B1Lane1 + laneNumber)
+            || action == (SentakkiAction.B2Lane1 + laneNumber)
+            || action == (SentakkiAction.SensorLane1 + laneNumber)
+            || action == (SentakkiAction.Key1 + laneNumber);
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideCheckpointNode.cs
@@ -1,3 +1,4 @@
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Game.Rulesets.Scoring;
@@ -17,9 +18,6 @@ public partial class DrawableSlideCheckpointNode : DrawableSentakkiHitObject
 
     public override bool HandlePositionalInput => true;
     public override bool DisplayResult => false;
-
-    private SentakkiInputManager? sentakkiActionInputManager;
-    internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= (SentakkiInputManager)GetContainingInputManager();
 
     public const float DETECTION_RADIUS = 100;
 
@@ -75,14 +73,17 @@ public partial class DrawableSlideCheckpointNode : DrawableSentakkiHitObject
         ApplyResult(Result.Judgement.MaxResult);
     }
 
+    [Resolved]
+    private SentakkiInputManager sentakkiInputManager { get; set; } = null!;
+
     private int countActiveTouchPoints()
     {
-        var touchInput = SentakkiActionInputManager.CurrentState.Touch;
+        var touchInput = sentakkiInputManager.CurrentState.Touch;
         int count = 0;
 
-        if (ReceivePositionalInputAt(SentakkiActionInputManager.CurrentState.Mouse.Position))
+        if (ReceivePositionalInputAt(sentakkiInputManager.CurrentState.Mouse.Position))
         {
-            foreach (var item in SentakkiActionInputManager.PressedActions)
+            foreach (var item in sentakkiInputManager.PressedActions)
             {
                 if (item < SentakkiAction.Key1)
                     ++count;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTap.cs
@@ -121,7 +121,7 @@ public partial class DrawableTap : DrawableSentakkiLanedHitObject, IKeyBindingHa
 
     public bool OnPressed(KeyBindingPressEvent<SentakkiAction> e)
     {
-        if (e.Action != SentakkiAction.Key1 + HitObject.Lane)
+        if (!IsValidLaneAction(e.Action))
             return false;
 
         return UpdateResult(true);

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouch.cs
@@ -16,9 +16,6 @@ public partial class DrawableTouch : DrawableSentakkiHitObject
 
     public TouchBody TouchBody = null!;
 
-    private SentakkiInputManager? sentakkiActionInputManager;
-    internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= (SentakkiInputManager)GetContainingInputManager();
-
     public DrawableTouch()
         : this(null)
     {
@@ -63,14 +60,17 @@ public partial class DrawableTouch : DrawableSentakkiHitObject
         pressedCount = updatedPressedCounts;
     }
 
+    [Resolved]
+    private SentakkiInputManager sentakkiInputManager { get; set; } = null!;
+
     private int countActiveTouchPoints()
     {
-        var touchInput = SentakkiActionInputManager.CurrentState.Touch;
+        var touchInput = sentakkiInputManager.CurrentState.Touch;
         int count = 0;
 
-        if (ReceivePositionalInputAt(SentakkiActionInputManager.CurrentState.Mouse.Position))
+        if (ReceivePositionalInputAt(sentakkiInputManager.CurrentState.Mouse.Position))
         {
-            foreach (var item in SentakkiActionInputManager.PressedActions)
+            foreach (var item in sentakkiInputManager.PressedActions)
             {
                 if (item < SentakkiAction.Key1)
                     ++count;

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableTouchHold.cs
@@ -25,9 +25,6 @@ public partial class DrawableTouchHold : DrawableSentakkiHitObject
 
     public override bool HandlePositionalInput => true;
 
-    private SentakkiInputManager? sentakkiActionInputManager;
-    internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= (SentakkiInputManager)GetContainingInputManager();
-
     public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => TouchHoldBody.ReceivePositionalInputAt(screenSpacePos);
 
     public TouchHoldBody TouchHoldBody = null!;
@@ -222,14 +219,17 @@ public partial class DrawableTouchHold : DrawableSentakkiHitObject
         Expire();
     }
 
+    [Resolved]
+    private SentakkiInputManager sentakkiInputManager { get; set; } = null!;
+
     private int countActiveTouchPoints()
     {
-        var touchInput = SentakkiActionInputManager.CurrentState.Touch;
+        var touchInput = sentakkiInputManager.CurrentState.Touch;
         int count = 0;
 
-        if (ReceivePositionalInputAt(SentakkiActionInputManager.CurrentState.Mouse.Position))
+        if (ReceivePositionalInputAt(sentakkiInputManager.CurrentState.Mouse.Position))
         {
-            foreach (var item in SentakkiActionInputManager.PressedActions)
+            foreach (var item in sentakkiInputManager.PressedActions)
             {
                 if (item < SentakkiAction.Key1)
                     ++count;

--- a/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
@@ -43,7 +43,7 @@ public partial class SentakkiInputManager : RulesetInputManager<SentakkiAction>
     public void TriggerReleased(SentakkiAction action) => KeyBindingContainer.TriggerReleased(action);
 
     public SentakkiInputManager(RulesetInfo ruleset)
-        : base(ruleset, 0, SimultaneousBindingMode.All)
+        : base(ruleset, 0, SimultaneousBindingMode.Unique)
     {
     }
 }
@@ -56,6 +56,7 @@ public enum SentakkiAction
     [LocalisableDescription(typeof(SentakkiActionStrings), nameof(SentakkiActionStrings.Button2))]
     Button2,
 
+    // These represent potential ring buttons
     [LocalisableDescription(typeof(SentakkiActionStrings), nameof(SentakkiActionStrings.Key1))]
     Key1,
 
@@ -79,4 +80,33 @@ public enum SentakkiAction
 
     [LocalisableDescription(typeof(SentakkiActionStrings), nameof(SentakkiActionStrings.Key8))]
     Key8,
+
+    // These are meant for touch screen usage
+    SensorLane1,
+    SensorLane2,
+    SensorLane3,
+    SensorLane4,
+    SensorLane5,
+    SensorLane6,
+    SensorLane7,
+    SensorLane8,
+
+    // These are auxiliary actions for mouse + Keyboard users
+    B1Lane1,
+    B1Lane2,
+    B1Lane3,
+    B1Lane4,
+    B1Lane5,
+    B1Lane6,
+    B1Lane7,
+    B1Lane8,
+
+    B2Lane1,
+    B2Lane2,
+    B2Lane3,
+    B2Lane4,
+    B2Lane5,
+    B2Lane6,
+    B2Lane7,
+    B2Lane8,
 }

--- a/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
@@ -1,3 +1,4 @@
+using osu.Framework.Allocation;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Lists;
@@ -7,6 +8,7 @@ using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Sentakki;
 
+[Cached]
 public partial class SentakkiInputManager : RulesetInputManager<SentakkiAction>
 {
     protected override bool MapMouseToLatestTouch => false;

--- a/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiInputManager.cs
@@ -91,6 +91,15 @@ public enum SentakkiAction
     SensorLane7,
     SensorLane8,
 
+    SensorLane1Alt,
+    SensorLane2Alt,
+    SensorLane3Alt,
+    SensorLane4Alt,
+    SensorLane5Alt,
+    SensorLane6Alt,
+    SensorLane7Alt,
+    SensorLane8Alt,
+
     // These are auxiliary actions for mouse + Keyboard users
     B1Lane1,
     B1Lane2,

--- a/osu.Game.Rulesets.Sentakki/UI/Lane.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Lane.cs
@@ -1,12 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
-using osu.Game.Overlays;
-using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.Extensions;
@@ -66,8 +63,8 @@ public partial class Lane : Playfield
     private const float receptor_angle_range = 45;
     private const float receptor_angle_range_mid = receptor_angle_range / 2;
 
-    private SentakkiInputManager? sentakkiActionInputManager;
-    internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= (SentakkiInputManager)GetContainingInputManager();
+    [Resolved]
+    private SentakkiInputManager sentakkiInputManager { get; set; } = null!;
 
     public override bool HandlePositionalInput => true;
 
@@ -117,7 +114,7 @@ public partial class Lane : Playfield
 
     private void updateTouchInputState()
     {
-        var touchInput = SentakkiActionInputManager.CurrentState.Touch;
+        var touchInput = sentakkiInputManager.CurrentState.Touch;
 
         for (TouchSource t = TouchSource.Touch1; t <= TouchSource.Touch10; ++t)
         {
@@ -152,7 +149,7 @@ public partial class Lane : Playfield
         SentakkiAction baseAction = SentakkiAction.SensorLane1 + (int)(touchCount * 8);
         ++touchCount;
 
-        SentakkiActionInputManager.TriggerPressed(baseAction + LaneNumber);
+        sentakkiInputManager.TriggerPressed(baseAction + LaneNumber);
     }
 
     private void triggerTouchRelease()
@@ -182,7 +179,7 @@ public partial class Lane : Playfield
         --touchCount;
         SentakkiAction baseAction = SentakkiAction.SensorLane1 + (int)(touchCount * 8);
 
-        SentakkiActionInputManager.TriggerReleased(baseAction + LaneNumber);
+        sentakkiInputManager.TriggerReleased(baseAction + LaneNumber);
     }
 
     private readonly Dictionary<SentakkiAction, bool> buttonInputState = [];
@@ -192,7 +189,7 @@ public partial class Lane : Playfield
         for (SentakkiAction a = SentakkiAction.Button1; a <= SentakkiAction.Button2; ++a)
         {
             bool wasDetected = buttonInputState.GetValueOrDefault(a);
-            bool isDetected = IsHovered && SentakkiActionInputManager.PressedActions.Contains(a);
+            bool isDetected = IsHovered && sentakkiInputManager.PressedActions.Contains(a);
 
             buttonInputState[a] = isDetected;
 
@@ -201,11 +198,11 @@ public partial class Lane : Playfield
             switch (isDetected)
             {
                 case false when wasDetected:
-                    SentakkiActionInputManager.TriggerReleased(action);
+                    sentakkiInputManager.TriggerReleased(action);
                     break;
 
                 case true when !wasDetected:
-                    SentakkiActionInputManager.TriggerPressed(action);
+                    sentakkiInputManager.TriggerPressed(action);
                     break;
             }
         }

--- a/osu.Game.Rulesets.Sentakki/UI/Lane.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Lane.cs
@@ -62,9 +62,6 @@ public partial class Lane : Playfield
     private const float receptor_angle_range = 45;
     private const float receptor_angle_range_mid = receptor_angle_range / 2;
 
-    private const float receptor_angle_range_inner = receptor_angle_range * 1.4f;
-    private const float receptor_angle_range_inner_mid = receptor_angle_range_inner / 2;
-
     private SentakkiInputManager? sentakkiActionInputManager;
     internal SentakkiInputManager SentakkiActionInputManager => sentakkiActionInputManager ??= (SentakkiInputManager)GetContainingInputManager();
 
@@ -77,11 +74,9 @@ public partial class Lane : Playfield
         float distance = Vector2.DistanceSquared(Vector2.Zero, localPos);
         if (distance is < 200 * 200 or > 600 * 600) return false;
 
-        float targetAngleRangeMid = distance > 400 ? receptor_angle_range_mid : receptor_angle_range_inner_mid;
-
         float angleDelta = MathExtensions.AngleDelta(0, Vector2.Zero.AngleTo(localPos));
 
-        return !(Math.Abs(angleDelta) > targetAngleRangeMid);
+        return !(Math.Abs(angleDelta) > receptor_angle_range_mid);
     }
 
     private void updateInputState()


### PR DESCRIPTION
## Background
During COE2025, sentakki got an arcade set-up with a significantly larger touch panel than the typically phone/tablet. During gameplay, players tended to hit the notes with hands, rather than their fingers. This means that multiple simultaneous touch inputs can occur for the same gameplay intent. The existing touch input handling breaks down in this scenario, causing each touch input to be handled separately, and multiple hitobjects may be triggered by the same intent.

The "quick fix" deployed during the event made lanes block all subsequent touch inputs if the first input was still detected. Unblocking only after all inputs are gone (similar to mania's lanes). This made some maps impossible to play, due to the use of concurrent hitobjects (like a tap concurrent with a hold).

## Changes
This PR adjusts the touch input handling to accommodate both mobile and arcade sized set-ups (and keyboard + mouse/pen-tablet). 

* Direct touches to a lane receptor will temporarily block further direct touches, which expires after either:
  * Expires after: 
    * 10ms has passed
      * This blocks further inputs for the same intent, time threshold chosen
    * The blocking touch has been lifted.


* Lane receptors no longer have an overlapping area (D1-D8 in simai notation)
  * These shrink the effective input area for each lane, and reduces the likelihood that a lane is inadvertantly hit when the player targets an adjacent lane.

* Dedicated `SentakkiAction`s have been introduced for both touch input, and kb+mouse inputs; `SimultaneousBindingMode.Unique` is now used 
  * This allows for clear distinction between the different input styles, and allows for the handling to not conflict with each other.
  * Two actions per lane for touch inputs
  * Two actions per lane for mouse button (B1, B2)
  * Also serves as an alternative resolution to https://github.com/ppy/osu/pull/32131, matching peppy's proposal


* Lane receptor event changes 
  * I suck at explaining the process in english so refer to the flowchart
```mermaid
---
config:
  theme: redux
---
flowchart TD
    A["No pressed actions"] --> TD1(["TouchDown"])
    TD1 --> P("OnActionPressed") & B["One pressed actions"]
    B --> TD2(["TouchDown"]) & TU1(["TouchUp"])
    TD2 --> P & C["Multiple pressed actions"]
    C --> TD3(["TouchDown"]) & TU2(["TouchUp"])
    TD3 --> C
    TU2 --> B & R("OnActionReleased")
    TU1 --> D{"remaining touch inputs = 0"}
    D --> Dt(("true")) & Df(("false"))
    Dt --> A & R
    Df --> B

```

## Practical testing
I've been dogfooding this for quite some time on my relatively tiny tablet, and I can say with confidence that I can't notice any deficiencies with this. This is corroborated with dev-builds not receiving any complaints.

Still pending testing from @JonLit for the arcade set-up. Based on my rudimentary testing on tablet (tapping the same note with multiple fingers), it seems to hold up. 