### PR TITLE
Disable blueprint interactivity when multi-selecting

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Holds/HoldSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Holds/HoldSelectionBlueprint.cs
@@ -107,6 +107,10 @@ public partial class HoldSelectionBlueprint : SentakkiSelectionBlueprint<Hold, D
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
         {
+            // HACK: We really only want to allow interactivity iff this is the only hitobject selected
+            if (blueprintContainer.SelectionHandler.SelectedItems.Count != 1)
+                return false;
+
             if (snapGrid.State.Value is Visibility.Hidden)
                 return false;
 

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSegmentHighlight.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSegmentHighlight.cs
@@ -51,6 +51,10 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
 
     public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
     {
+        // HACK: We really only want to allow interactivity iff this is the only hitobject selected
+        if (beatmap.SelectedHitObjects.Count != 1)
+            return false;
+
         if (IsDragged)
             return true;
 


### PR DESCRIPTION
When multiple blueprints are selected, the slide and hold blueprints should not allow interactivity. 

[A similar thing was done for std slider blueprints](https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs#L191-L210), but unlike them, we keep the drawable, but ignore positional inputs.